### PR TITLE
chore(GlobalSaaSHub): clean up lint warnings

### DIFF
--- a/projects/GlobalSaaSHub/src/App.jsx
+++ b/projects/GlobalSaaSHub/src/App.jsx
@@ -7,21 +7,17 @@ import {
   Sparkles, 
   Cpu, 
   Layers, 
-  ExternalLink, 
   Star, 
-  DollarSign, 
   ArrowUpRight, 
   HelpCircle,
   TrendingUp,
   Award,
-  BarChart3,
   Heart,
   Scale,
   Video,
   Mic,
   Image as ImageIcon,
   Code,
-  FileText,
   Briefcase,
   Wand2,
   MessageSquare,
@@ -67,7 +63,7 @@ export default function App() {
   const [bookmarkedIds, setBookmarkedIds] = useState(() => {
     try {
       return JSON.parse(localStorage.getItem('coshuma_bookmarks') || '[]');
-    } catch (e) {
+    } catch {
       return [];
     }
   });

--- a/projects/GlobalSaaSHub/src/components/CompareModal.jsx
+++ b/projects/GlobalSaaSHub/src/components/CompareModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { X, ExternalLink, Plus, Check, ShieldCheck, Zap } from 'lucide-react';
+import { X, ExternalLink, Zap } from 'lucide-react';
 import { getValidExternalUrl } from '../utils/url';
 
 export default function CompareModal({ toolA, toolB, allTools, onClose }) {

--- a/projects/GlobalSaaSHub/src/utils/analytics.js
+++ b/projects/GlobalSaaSHub/src/utils/analytics.js
@@ -26,7 +26,7 @@ export function detectVisitorCountry() {
       return { country: 'Canada', flag: '🇨🇦', code: 'CA' };
     }
     return { country: 'United States', flag: '🇺🇸', code: 'US' };
-  } catch (e) {
+  } catch {
     return { country: 'United States', flag: '🇺🇸', code: 'US' };
   }
 }
@@ -129,7 +129,7 @@ export function getRealAnalyticsStats() {
       topClickedTools,
       rawEvents: events
     };
-  } catch (e) {
+  } catch {
     return { totalPageviews: 0, totalClicks: 0, ctr: '0.0%', countryBreakdown: [], topClickedTools: [], rawEvents: [] };
   }
 }


### PR DESCRIPTION
## Summary

- Remove unused imports from `projects/GlobalSaaSHub/src/App.jsx`
- Remove unused imports from `projects/GlobalSaaSHub/src/components/CompareModal.jsx`
- Remove unused catch parameters from `projects/GlobalSaaSHub/src/utils/analytics.js`
- No functional, payment, data, Worker/D1, or deployment configuration changes

## Validation

- Link integrity: PASS (`150/150 tools, 150 pages`)
- Lint: PASS
- Vite production build: PASS