### PR TITLE
feat(GlobalSaaSHub): connect PayPal sponsorship checkout

### DIFF
--- a/projects/GlobalSaaSHub/scripts/tests/test_payment_security.py
+++ b/projects/GlobalSaaSHub/scripts/tests/test_payment_security.py
@@ -33,7 +33,15 @@ def test_frontend_has_no_secret_and_is_disabled_by_default():
     assert "PAYPAL_CLIENT_SECRET" not in source
     assert "PAYPAL_WEBHOOK_ID" not in source
     assert "VITE_SPONSORSHIP_CHECKOUT_ENABLED === 'true'" in config
-    assert app.count("disabled") >= 2
+    checkout = (ROOT / "src" / "components" / "SponsorshipCheckout.jsx").read_text(encoding="utf-8")
+    sdk = (ROOT / "src" / "services" / "paypalSdk.js").read_text(encoding="utf-8")
+    assert "paymentConfig.checkoutEnabled &&" in app
+    assert "if (!paymentConfig.checkoutEnabled) return null" in checkout
+    assert "createSponsorshipOrder()" in checkout
+    assert "captureVerifiedSponsorshipOrder(orderID)" in checkout
+    assert "amount" not in checkout.lower()
+    assert "client-id" in sdk
+    assert "PAYPAL_CLIENT_SECRET" not in sdk
 
 
 def test_node_payment_regressions():

--- a/projects/GlobalSaaSHub/scripts/tests/test_public_security_hotfix.py
+++ b/projects/GlobalSaaSHub/scripts/tests/test_public_security_hotfix.py
@@ -24,8 +24,11 @@ def test_admin_and_checkout_code_are_not_in_public_source():
     assert "paypal.com/cgi-bin/webscr" not in public_source
     assert "cardCvc" not in public_source
     assert "contactEmail" not in public_source
-    assert "Sponsorship submissions temporarily unavailable" in app
-    assert app.count("disabled") >= 2
+    assert "paymentConfig.checkoutEnabled &&" in app
+    assert "<SponsorshipCheckout />" in app
+    assert "if (!paymentConfig.checkoutEnabled) return null" in (
+        SRC / "components" / "SponsorshipCheckout.jsx"
+    ).read_text(encoding="utf-8")
 
 
 def test_unused_payment_sdk_is_removed():

--- a/projects/GlobalSaaSHub/src/App.jsx
+++ b/projects/GlobalSaaSHub/src/App.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import toolsData from '../data/tools.json';
 import CompareModal from './components/CompareModal';
+import SponsorshipCheckout from './components/SponsorshipCheckout';
+import { paymentConfig } from './config/payment.js';
 import { getValidExternalUrl } from './utils/url';
 import { 
   Search, 
@@ -185,14 +187,11 @@ export default function App() {
             </span>
           </div>
           <div className="flex items-center gap-4">
-            <button
-              type="button"
-              disabled
-              title="Sponsorship submissions temporarily unavailable while secure checkout is being configured"
-              className="text-xs sm:text-sm font-medium px-4 py-2 rounded-full border border-slate-700 bg-slate-800/60 text-slate-500 cursor-not-allowed"
-            >
-              Sponsorship submissions temporarily unavailable
-            </button>
+            {paymentConfig.checkoutEnabled && (
+              <a href="#submit" className="text-xs sm:text-sm font-medium px-4 py-2 rounded-full border border-purple-500/40 bg-purple-500/10 text-purple-200 hover:bg-purple-500/20 transition-colors">
+                Sponsor for $49
+              </a>
+            )}
           </div>
 
 
@@ -497,15 +496,7 @@ export default function App() {
             <p className="text-slate-400 mb-8 leading-relaxed">
               Are you a founder? Get listed in front of thousands of digital creators, automators, and developers. Custom sponsorship positions available.
             </p>
-            <div className="flex flex-wrap gap-4">
-              <button
-                type="button"
-                disabled
-                className="bg-slate-800 text-slate-500 font-bold py-3.5 px-6 rounded-xl inline-flex items-center gap-2 border border-slate-700 cursor-not-allowed"
-              >
-                <span>Sponsorship submissions temporarily unavailable while secure checkout is being configured</span>
-              </button>
-            </div>
+            {paymentConfig.checkoutEnabled && <SponsorshipCheckout />}
           </div>
         </section>
 

--- a/projects/GlobalSaaSHub/src/components/SponsorshipCheckout.jsx
+++ b/projects/GlobalSaaSHub/src/components/SponsorshipCheckout.jsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from 'react';
+import { paymentConfig } from '../config/payment.js';
+import { captureVerifiedSponsorshipOrder, createSponsorshipOrder } from '../services/paymentApi.js';
+import { loadPayPalSdk } from '../services/paypalSdk.js';
+
+export default function SponsorshipCheckout() {
+  const buttonContainer = useRef(null);
+  const [status, setStatus] = useState({ type: 'loading', message: 'Loading secure checkout...' });
+
+  useEffect(() => {
+    if (!paymentConfig.checkoutEnabled || !buttonContainer.current) return undefined;
+    let active = true;
+    let buttons;
+
+    loadPayPalSdk()
+      .then((paypal) => {
+        if (!active || !buttonContainer.current) return;
+        buttons = paypal.Buttons({
+          style: { layout: 'vertical', shape: 'pill', label: 'paypal' },
+          createOrder: async () => {
+            setStatus({ type: 'loading', message: 'Preparing your $49 sponsorship...' });
+            const order = await createSponsorshipOrder();
+            return order.orderId;
+          },
+          onApprove: async ({ orderID }) => {
+            setStatus({ type: 'loading', message: 'Verifying payment securely...' });
+            await captureVerifiedSponsorshipOrder(orderID);
+            setStatus({ type: 'success', message: "Payment confirmed. We'll follow up about your sponsorship." });
+          },
+          onCancel: () => setStatus({ type: 'neutral', message: 'Checkout cancelled. You have not been charged.' }),
+          onError: () => setStatus({ type: 'error', message: 'Checkout could not be completed. Please try again.' }),
+        });
+        if (!buttons.isEligible()) throw new Error('PayPal checkout is unavailable');
+        return buttons.render(buttonContainer.current).then(() => {
+          if (active) setStatus({ type: 'neutral', message: 'Secure $49 sponsorship payment via PayPal Sandbox.' });
+        });
+      })
+      .catch(() => {
+        if (active) setStatus({ type: 'error', message: 'Secure checkout is temporarily unavailable.' });
+      });
+
+    return () => {
+      active = false;
+      buttons?.close?.();
+    };
+  }, []);
+
+  if (!paymentConfig.checkoutEnabled) return null;
+
+  const statusColor = status.type === 'success'
+    ? 'text-emerald-300'
+    : status.type === 'error' ? 'text-rose-300' : 'text-slate-400';
+
+  return (
+    <div className="w-full max-w-sm" aria-live="polite">
+      <div ref={buttonContainer} className="min-h-12" />
+      <p className={`mt-3 text-xs ${statusColor}`}>{status.message}</p>
+    </div>
+  );
+}

--- a/projects/GlobalSaaSHub/src/services/paypalSdk.js
+++ b/projects/GlobalSaaSHub/src/services/paypalSdk.js
@@ -1,0 +1,33 @@
+import { paymentConfig } from '../config/payment.js';
+
+let sdkPromise;
+
+export function loadPayPalSdk() {
+  if (!paymentConfig.checkoutEnabled) {
+    return Promise.reject(new Error('Checkout is not enabled'));
+  }
+  if (window.paypal?.Buttons) return Promise.resolve(window.paypal);
+  if (sdkPromise) return sdkPromise;
+
+  sdkPromise = new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    const params = new URLSearchParams({
+      'client-id': paymentConfig.paypalClientId,
+      components: 'buttons',
+      currency: 'USD',
+      intent: 'capture',
+    });
+    script.src = `https://www.paypal.com/sdk/js?${params}`;
+    script.async = true;
+    script.onload = () => window.paypal?.Buttons
+      ? resolve(window.paypal)
+      : reject(new Error('PayPal checkout is unavailable'));
+    script.onerror = () => reject(new Error('PayPal checkout could not be loaded'));
+    document.head.appendChild(script);
+  }).catch((error) => {
+    sdkPromise = undefined;
+    throw error;
+  });
+
+  return sdkPromise;
+}


### PR DESCRIPTION
## Summary

- load the PayPal JS SDK only when the existing payment configuration is fully enabled
- connect the $49 sponsorship UI to the existing server-owned create-order and capture endpoints
- keep checkout fail-closed and hide all checkout controls when disabled
- show minimal loading, success, cancellation, and error states
- extend payment and public-security regression coverage

## Security

- no amount is submitted by the browser
- no PayPal client secret or webhook secret is bundled
- no production settings, deployment, or gh-pages changes
- no real payment or capture was executed during verification

## Verification

- `npm run lint`
- `npm run build`
- `python -m pytest scripts/tests -q` (141 passed)
- `python -m pytest scripts/tests/test_payment_security.py scripts/tests/test_public_security_hotfix.py -q` (6 passed)
- `npm test` in `worker` (7 passed)

## Remaining manual step

Run one browser-based PayPal Sandbox buyer flow after preview configuration is supplied, then verify the successful capture UI and signed webhook delivery. Do not use Production credentials.