### PR TITLE
chore(GlobalSaaSHub): enable PayPal live production

### DIFF
--- a/projects/GlobalSaaSHub/worker/wrangler.toml
+++ b/projects/GlobalSaaSHub/worker/wrangler.toml
@@ -1,10 +1,17 @@
 name = "globalsaashub-payments"
 main = "src/index.js"
-compatibility_date = "2026-08-01"
+compatibility_date = "2026-08-09"
 workers_dev = true
+preview_urls = false
+
+[observability]
+enabled = true
+
+[observability.logs]
+enabled = true
 
 [vars]
-PAYPAL_ENVIRONMENT = "sandbox"
+PAYPAL_ENVIRONMENT = "live"
 ALLOWED_ORIGIN = "https://coshuma.com"
 
 # Create the D1 database before deployment, then add its non-secret database_id here.


### PR DESCRIPTION
## Summary
- switch the production payment Worker to PayPal Live
- preserve the existing production compatibility, preview URL, and observability settings

## Verification
- payment Worker unit tests (7 passing)
- Worker deployment dry run
- production `/health` returns `checkoutConfigured=true`
- frontend lint and payment security tests pass
- production checkout build succeeds

Actual PayPal order approval and capture were not performed.