### PR TITLE
fix(GlobalSaaSHub): remove sandbox checkout copy

### DIFF
--- a/projects/GlobalSaaSHub/src/components/SponsorshipCheckout.jsx
+++ b/projects/GlobalSaaSHub/src/components/SponsorshipCheckout.jsx
@@ -32,7 +32,7 @@ export default function SponsorshipCheckout() {
         });
         if (!buttons.isEligible()) throw new Error('PayPal checkout is unavailable');
         return buttons.render(buttonContainer.current).then(() => {
-          if (active) setStatus({ type: 'neutral', message: 'Secure $49 sponsorship payment via PayPal Sandbox.' });
+          if (active) setStatus({ type: 'neutral', message: 'Secure $49 sponsorship payment via PayPal.' });
         });
       })
       .catch(() => {


### PR DESCRIPTION
## Summary
- replace the public PayPal Sandbox status copy with neutral production wording
- leave payment amount, flow, and security configuration unchanged

## Verification
- `npm run lint`
- `npm run build`
- `python -m pytest scripts/tests/test_payment_security.py scripts/tests/test_public_security_hotfix.py -q` (6 passed)