### PR TITLE
fix(GlobalSaaSHub): publish approved affiliate CTAs and Fliki page

### DIFF
--- a/projects/GlobalSaaSHub/public/sitemap.xml
+++ b/projects/GlobalSaaSHub/public/sitemap.xml
@@ -61,6 +61,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://coshuma.com/tool/fliki.html</loc>
+    <lastmod>2026-07-27</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://coshuma.com/tool/inkfluence-ai.html</loc>
     <lastmod>2026-07-27</lastmod>
     <changefreq>weekly</changefreq>

--- a/projects/GlobalSaaSHub/public/tool/fliki.html
+++ b/projects/GlobalSaaSHub/public/tool/fliki.html
@@ -3,25 +3,25 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Systeme.io Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Systeme.io is an all-in-one marketing platform designed for entrepreneurs and small businesses, offering tools for sales funnels, email marketing, web... Discover features, pricing (See official pricing), and official links for Systeme.io on GlobalSaaSHub." />
-    <link rel="canonical" href="https://coshuma.com/tool/systeme-io.html" />
+    <title>Fliki Pricing, Features & Review (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Create studio-quality videos from scripts, ideas, and long-form content with lifelike voices.... Discover features, pricing (See official pricing), and official links for Fliki on GlobalSaaSHub." />
+    <link rel="canonical" href="https://coshuma.com/tool/fliki.html" />
     
     <!-- Open Graph SEO Tags -->
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://coshuma.com/tool/systeme-io.html" />
-    <meta property="og:title" content="Systeme.io Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Systeme.io is an all-in-one marketing platform designed for entrepreneurs and small businesses, offering tools for sales funnels, email marketing, web... Check rating, pricing, and features." />
+    <meta property="og:url" content="https://coshuma.com/tool/fliki.html" />
+    <meta property="og:title" content="Fliki Review & Pricing (2026) | GlobalSaaSHub" />
+    <meta property="og:description" content="Create studio-quality videos from scripts, ideas, and long-form content with lifelike voices.... Check rating, pricing, and features." />
 
     <!-- JSON-LD Structured Data for Google Indexing -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
-      "name": "Systeme.io",
+      "name": "Fliki",
       "operatingSystem": "Web",
-      "applicationCategory": "Sales & CRM",
-      "description": "Systeme.io is an all-in-one marketing platform designed for entrepreneurs and small businesses, offering tools for sales funnels, email marketing, websites, and online courses. Simplify your online business with its comprehensive and user-friendly features."
+      "applicationCategory": "Video & Shorts Gen",
+      "description": "Create studio-quality videos from scripts, ideas, and long-form content with lifelike voices."
     }
     </script>
 
@@ -55,12 +55,12 @@
         
         <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=systeme.io&sz=128" alt="Systeme.io logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=fliki.ai&sz=128" alt="Fliki logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
             <div>
               <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Sales & CRM</span>
+                <span>Video & Shorts Gen</span>
               </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Systeme.io</h1>
+              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Fliki</h1>
             </div>
           </div>
 
@@ -72,17 +72,17 @@
         <!-- Description -->
         <div class="space-y-3">
           <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">Systeme.io is an all-in-one marketing platform designed for entrepreneurs and small businesses, offering tools for sales funnels, email marketing, websites, and online courses. Simplify your online business with its comprehensive and user-friendly features.</p>
+          <p class="text-slate-300 text-base leading-relaxed">Create studio-quality videos from scripts, ideas, and long-form content with lifelike voices.</p>
         </div>
 
         <!-- Key Features -->
         <div class="space-y-4">
           <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Sales Funnel Builder</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Email Marketing Automation</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Website & Blog Creation</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Online Course Hosting</div>
+            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Text-to-video creation</div>
+<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI voiceovers</div>
+<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI avatars</div>
+<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Video translation and dubbing</div>
           </div>
         </div>
 
@@ -109,13 +109,13 @@
         <!-- Alternatives & Direct Competitors Section -->
         <div class="space-y-4 pt-4 border-t border-[#222538]">
           <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Systeme.io</span>
+            <span>Top Alternatives to Fliki</span>
             <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
           </h2>
           <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/privy.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=privy.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Privy</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/reply-io.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=reply.io&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Reply.io</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/omnisend.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=omnisend.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Omnisend</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
+            <a href="/tool/tubebuddy.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=tubebuddy.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">TubeBuddy</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
+<a href="/tool/outlierkit.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=outlierkit.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">OutlierKit</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
+<a href="/tool/pictory.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=pictory.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Pictory</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
           </div>
         </div>
 
@@ -125,15 +125,15 @@
             <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
           </div>
-          <a data-cta="official" href="https://systeme.io/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Systeme.io Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://systeme.io/?sa=sa0279779913657b281b5d2c1fed58680413f14dca" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Systeme.io via Verified Affiliate Link</span><span>→</span></a>
+          <a data-cta="official" href="https://fliki.ai/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Fliki Site</span><span>→</span></a>
+<a data-cta="affiliate" href="https://fliki.ai?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Fliki via Verified Affiliate Link</span><span>→</span></a>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->
         <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
           <div class="flex items-center justify-between">
             <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Systeme.io?</span>
+              <span>🏆 Are you the founder of Fliki?</span>
             </div>
             <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
           </div>
@@ -145,12 +145,12 @@
           </div>
           <div class="flex flex-col sm:flex-row items-center gap-3">
             <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Systeme.io Profile ($49/yr)
+              ⚡ Claim Fliki Profile ($49/yr)
             </a>
           </div>
           <div class="relative pt-2">
             <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/systeme-io.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Systeme.io Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
+            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/fliki.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Fliki Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
           </div>
         </div>
 

--- a/projects/GlobalSaaSHub/public/tool/taskade.html
+++ b/projects/GlobalSaaSHub/public/tool/taskade.html
@@ -126,6 +126,7 @@
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">Free plan available; Pro starting at $8/user/month (billed annually)</div>
           </div>
           <a data-cta="official" href="https://www.taskade.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Taskade Site</span><span>→</span></a>
+<a data-cta="affiliate" href="https://www.taskade.com/?via=7zzjo7" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Taskade via Verified Affiliate Link</span><span>→</span></a>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->

--- a/projects/GlobalSaaSHub/scripts/generate_seo_pages.py
+++ b/projects/GlobalSaaSHub/scripts/generate_seo_pages.py
@@ -320,7 +320,7 @@ for tool in tools_data:
     else:
         cta_parts.append('<div class="px-6 py-3.5 rounded-xl font-bold text-xs bg-slate-800 text-slate-500 border border-slate-700/50 text-center">Official Link Unavailable</div>')
     if affiliate_url:
-        cta_parts.append(f'<a data-cta="affiliate" href="{affiliate_url}" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit {tool_name} via Verified Affiliate Link</span><span>→</span></a>')
+        cta_parts.append(f'<a data-cta="affiliate" href="{affiliate_url}" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit {tool_name} via Verified Affiliate Link</span><span>→</span></a>')
     cta_button_html = "\n".join(cta_parts)
 
     file_content = html_template.format(

--- a/projects/GlobalSaaSHub/scripts/tests/test_content_audit.py
+++ b/projects/GlobalSaaSHub/scripts/tests/test_content_audit.py
@@ -4,6 +4,6 @@ P=Path(__file__).resolve().parents[1]/"content_audit.py"; S=importlib.util.spec_
 class Tests(unittest.TestCase):
  def test_domains(self): self.assertTrue(M.same_domain("https://example.com","https://app.example.com/x")); self.assertFalse(M.same_domain("https://example.com","https://example.com.evil.test"))
  def test_corpus(self):
-  r=M.audit(False,1); self.assertEqual((r["tool_count"],r["detail_pages_checked"],r["compare_pages_checked"],r["sitemap_tool_urls_checked"]),(150,150,231,150)); bad=sum(r["classification_counts"][s] for s in ("BROKEN","STALE","TYPO"))
+  r=M.audit(False,1); self.assertEqual((r["tool_count"],r["detail_pages_checked"],r["compare_pages_checked"],r["sitemap_tool_urls_checked"]),(151,151,231,151)); bad=sum(r["classification_counts"][s] for s in ("BROKEN","STALE","TYPO"))
   if bad: self.fail(json.dumps([(t["id"],t["issues"]) for t in r["tools"] if t["classification"] in {"BROKEN","STALE","TYPO"}],ensure_ascii=False,indent=2))
 if __name__=="__main__": unittest.main()

--- a/projects/GlobalSaaSHub/scripts/tests/test_link_integrity.py
+++ b/projects/GlobalSaaSHub/scripts/tests/test_link_integrity.py
@@ -93,15 +93,24 @@ def main():
         if "Visit Relevance AI" in relevance_html:
             fail(errors, "Relevance AI affiliate CTA must not be rendered")
 
-    taskade = next((tool for tool in tools if tool["id"] == "taskade"), None)
-    if not taskade or taskade.get("affiliate_url") is not None or taskade.get("affiliate_verified") is not False:
-        fail(errors, "Taskade must remain official-only until an approved tracking link is stored")
-    else:
-        taskade_html = (PUBLIC / "tool" / "taskade.html").read_text(encoding="utf-8")
-        if taskade.get("official_url") not in taskade_html or "Visit Official Taskade Site" not in taskade_html:
-            fail(errors, "Taskade official-only CTA is missing")
-        if "via Verified Affiliate Link" in taskade_html:
-            fail(errors, "Taskade affiliate CTA must not be rendered")
+    approved_tracking_urls = {
+        "taskade": "https://www.taskade.com/?via=7zzjo7",
+        "systeme-io": "https://systeme.io/?sa=sa0279779913657b281b5d2c1fed58680413f14dca",
+        "fliki": "https://fliki.ai?via=sangkwon",
+    }
+    for tool_id, tracking_url in approved_tracking_urls.items():
+        tool = next((item for item in tools if item["id"] == tool_id), None)
+        if not tool or tool.get("affiliate_url") != tracking_url or tool.get("affiliate_verified") is not True:
+            fail(errors, f"{tool_id} approved tracking data is missing or unverified")
+            continue
+        html = (PUBLIC / "tool" / f"{tool_id}.html").read_text(encoding="utf-8")
+        affiliate_cta = re.search(r'<a data-cta="affiliate"[^>]+>', html)
+        if not affiliate_cta or f'href="{tracking_url}"' not in affiliate_cta.group(0):
+            fail(errors, f"{tool_id} generated affiliate CTA does not use its approved tracking URL")
+        if not affiliate_cta or 'rel="sponsored noopener noreferrer"' not in affiliate_cta.group(0):
+            fail(errors, f"{tool_id} affiliate CTA is missing the sponsored safety relation")
+        if "via Verified Affiliate Link" not in html:
+            fail(errors, f"{tool_id} affiliate disclosure is missing")
     if errors:
         print(f"LINK INTEGRITY: FAIL ({len(errors)} errors)")
         for error in errors:


### PR DESCRIPTION
## Summary
- regenerate the missing Fliki static tool page and add it to the sitemap
- publish the approved Taskade, Systeme.io, and Fliki tracking URLs in generated affiliate CTAs
- preserve affiliate disclosure and add `rel="sponsored noopener noreferrer"`
- update link-integrity and corpus regression coverage

## Verification
- `npm run test:links` — PASS (151/151 tools, 151 pages)
- `npm run lint` — PASS
- `npm run build` — PASS
- `python -m unittest discover -s scripts/tests -p 'test_*.py'` — PASS (31 tests)

## Safety
- no production deployment
- sponsor CTA unchanged
- robots.txt unchanged; sitemap only adds the missing Fliki tool URL