### PR TITLE
fix(GlobalSaaSHub): publish Castmagic approved affiliate link

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/castmagic.html
+++ b/projects/GlobalSaaSHub/public/tool/castmagic.html
@@ -126,6 +126,7 @@
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See website for details</div>
           </div>
           <a data-cta="official" href="https://www.castmagic.io/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Castmagic Site</span><span>→</span></a>
+<a data-cta="affiliate" href="https://castmagic.io?fpr=sangkwon-an54" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Castmagic via Verified Affiliate Link</span><span>→</span></a>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->

--- a/projects/GlobalSaaSHub/scripts/tests/test_castmagic_affiliate.py
+++ b/projects/GlobalSaaSHub/scripts/tests/test_castmagic_affiliate.py
@@ -1,0 +1,23 @@
+import unittest
+from pathlib import Path
+
+PROJECT = Path(__file__).resolve().parents[2]
+TRACKING_URL = "https://castmagic.io?fpr=sangkwon-an54"
+
+
+class CastmagicAffiliateTests(unittest.TestCase):
+    def test_static_detail_page_uses_verified_tracking_url(self):
+        html = (PROJECT / "public" / "tool" / "castmagic.html").read_text(encoding="utf-8")
+        self.assertIn(f'href="{TRACKING_URL}"', html)
+        self.assertIn('data-cta="affiliate"', html)
+        self.assertIn('rel="sponsored noopener noreferrer"', html)
+        self.assertIn("Visit Castmagic via Verified Affiliate Link", html)
+
+    def test_directory_cta_override_uses_verified_tracking_url(self):
+        url_js = (PROJECT / "src" / "utils" / "url.js").read_text(encoding="utf-8")
+        self.assertIn('castmagic: "https://castmagic.io?fpr=sangkwon-an54"', url_js)
+        self.assertIn("VERIFIED_AFFILIATE_OVERRIDES", url_js)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/GlobalSaaSHub/src/utils/url.js
+++ b/projects/GlobalSaaSHub/src/utils/url.js
@@ -1,13 +1,26 @@
 /**
+ * Verified affiliate links that have been confirmed outside the catalog data pipeline
+ * but are not yet migrated into tools.json. Keep this list small and evidence-backed.
+ */
+const VERIFIED_AFFILIATE_OVERRIDES = {
+  castmagic: "https://castmagic.io?fpr=sangkwon-an54",
+};
+
+/**
  * Validates and extracts a clean HTTP/HTTPS external URL from a tool object.
- * Uses affiliate_url only after explicit verification, then falls back to official_url.
+ * Uses an explicit verified override first, then affiliate_url only after explicit
+ * verification, and finally falls back to official_url.
  * Returns null if no valid URL is found (rejects null, undefined, none, #, empty strings).
  */
 export const getValidExternalUrl = (tool) => {
   if (!tool) return null;
-  const candidates = tool.affiliate_verified === true
-    ? [tool.affiliate_url, tool.official_url]
-    : [tool.official_url];
+
+  const verifiedOverride = VERIFIED_AFFILIATE_OVERRIDES[tool.id];
+  const candidates = verifiedOverride
+    ? [verifiedOverride, tool.official_url]
+    : tool.affiliate_verified === true
+      ? [tool.affiliate_url, tool.official_url]
+      : [tool.official_url];
 
   for (const value of candidates) {
     if (typeof value !== "string") continue;


### PR DESCRIPTION
## Summary
- route the GlobalSaaSHub directory CTA for Castmagic through the verified referral URL
- add a sponsored affiliate CTA to the static Castmagic detail page
- add a focused regression test for the verified Castmagic tracking URL

## Evidence
Castmagic sent the approved unique referral URL to `support@coshuma.com` in its affiliate welcome email: `https://castmagic.io?fpr=sangkwon-an54`.

## Safety
- no production deployment performed
- no payments or account changes
- official Castmagic URL remains present on the detail page
- affiliate CTA is marked `rel="sponsored noopener noreferrer"`

## Follow-up
The catalog data (`tools.json`) still has Castmagic `affiliate_url: null`; this PR uses a small evidence-backed runtime override so the live directory can monetize the approved link without rewriting the large catalog file. A later data-pipeline migration can remove the override once the catalog record is updated.