### PR TITLE
fix(GlobalSaaSHub): publish vidIQ approved affiliate link

### DIFF
--- a/projects/GlobalSaaSHub/src/utils/url.js
+++ b/projects/GlobalSaaSHub/src/utils/url.js
@@ -4,6 +4,7 @@
  */
 const VERIFIED_AFFILIATE_OVERRIDES = {
   castmagic: "https://castmagic.io?fpr=sangkwon-an54",
+  vidiq: "https://vidiq.com/coshuma",
 };
 
 /**


### PR DESCRIPTION
## Summary
- use the official vidIQ affiliate URL `https://vidiq.com/coshuma` for directory CTAs
- evidence: official vidIQ welcome email confirms COSHUMA is active in the affiliate program, with recurring commission starting at 15% and increasing up to 25%

## Follow-up
- static detail-page CTA can be aligned to the same verified URL after this override is validated
