### PR TITLE
fix(GlobalSaaSHub): publish vidIQ static affiliate CTA

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/vidiq.html
+++ b/projects/GlobalSaaSHub/public/tool/vidiq.html
@@ -126,6 +126,7 @@
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">Free plan available</div>
           </div>
           <a data-cta="official" href="https://vidiq.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official VidIQ Site</span><span>→</span></a>
+<a data-cta="affiliate" href="https://vidiq.com/coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit vidIQ via Verified Affiliate Link</span><span>→</span></a>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->

--- a/projects/GlobalSaaSHub/scripts/tests/test_vidiq_affiliate.py
+++ b/projects/GlobalSaaSHub/scripts/tests/test_vidiq_affiliate.py
@@ -1,0 +1,23 @@
+import unittest
+from pathlib import Path
+
+PROJECT = Path(__file__).resolve().parents[2]
+TRACKING_URL = "https://vidiq.com/coshuma"
+
+
+class VidiqAffiliateTests(unittest.TestCase):
+    def test_static_detail_page_uses_verified_tracking_url(self):
+        html = (PROJECT / "public" / "tool" / "vidiq.html").read_text(encoding="utf-8")
+        self.assertIn(f'href="{TRACKING_URL}"', html)
+        self.assertIn('data-cta="affiliate"', html)
+        self.assertIn('rel="sponsored noopener noreferrer"', html)
+        self.assertIn("Visit vidIQ via Verified Affiliate Link", html)
+
+    def test_directory_cta_override_uses_verified_tracking_url(self):
+        url_js = (PROJECT / "src" / "utils" / "url.js").read_text(encoding="utf-8")
+        self.assertIn('vidiq: "https://vidiq.com/coshuma"', url_js)
+        self.assertIn("VERIFIED_AFFILIATE_OVERRIDES", url_js)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the verified vidIQ affiliate CTA to the static detail page
- keep the official link alongside the monetized CTA
- add a regression test covering both the static detail page and directory override

## Evidence
- approved tracking URL already verified in PR #11: `https://vidiq.com/coshuma`
- static CTA uses `rel="sponsored noopener noreferrer"`

## Scope
- no paid services
- no credential or secret changes
