### PR TITLE
fix(GlobalSaaSHub): align crawler fallback corpus count

### DIFF
--- a/projects/GlobalSaaSHub/index.html
+++ b/projects/GlobalSaaSHub/index.html
@@ -63,10 +63,10 @@
   <body style="background-color: #090a0f; color: #ffffff; margin: 0; padding: 0;">
     <div id="root">
       {/* Static Fallback Content for AI Crawlers & Bots (ChatGPT Bot, Googlebot, Perplexity) */}
-      <div style="padding: 40px; max-w: 800px; margin: 0 auto; text-align: center;">
+      <div style="padding: 40px; max-width: 800px; margin: 0 auto; text-align: center;">
         <h1 style="font-size: 28px; font-weight: 800; color: #a855f7;">GlobalSaaSHub - Premier AI & B2B SaaS Directory</h1>
         <p style="font-size: 14px; color: #94a3b8; line-height: 1.6;">
-          Discover top-tier AI software, productivity tools, workflow automation, and developer APIs to scale your business. Browse 150 curated SaaS profiles with clearly sourced pricing where available and side-by-side comparisons of up to 3 direct competitors.
+          Discover top-tier AI software, productivity tools, workflow automation, and developer APIs to scale your business. Browse 151 curated SaaS profiles with clearly sourced pricing where available and side-by-side comparisons of up to 3 direct competitors.
         </p>
 
       </div>

--- a/projects/GlobalSaaSHub/index.html
+++ b/projects/GlobalSaaSHub/index.html
@@ -63,7 +63,7 @@
   <body style="background-color: #090a0f; color: #ffffff; margin: 0; padding: 0;">
     <div id="root">
       {/* Static Fallback Content for AI Crawlers & Bots (ChatGPT Bot, Googlebot, Perplexity) */}
-      <div style="padding: 40px; max-width: 800px; margin: 0 auto; text-align: center;">
+      <div style="padding: 40px; max-w: 800px; margin: 0 auto; text-align: center;">
         <h1 style="font-size: 28px; font-weight: 800; color: #a855f7;">GlobalSaaSHub - Premier AI & B2B SaaS Directory</h1>
         <p style="font-size: 14px; color: #94a3b8; line-height: 1.6;">
           Discover top-tier AI software, productivity tools, workflow automation, and developer APIs to scale your business. Browse 151 curated SaaS profiles with clearly sourced pricing where available and side-by-side comparisons of up to 3 direct competitors.


### PR DESCRIPTION
## Summary
- align the static crawler/bot fallback copy with the current verified GlobalSaaSHub corpus
- change the fallback count from 150 to 151 curated SaaS profiles

## Evidence
- merged PR #9 regression verification passed `151/151 tools, 151 pages`
- the current `projects/GlobalSaaSHub/index.html` fallback still advertised 150 profiles

## Scope / Safety
- static crawler-facing copy only
- no catalog data changes
- no payment, Worker, secret, account, or affiliate-link changes
- zero-cost change