### PR TITLE
fix(GlobalSaaSHub): stop publishing stale sitemap lastmod dates

### DIFF
--- a/projects/GlobalSaaSHub/scripts/generate_seo_pages.py
+++ b/projects/GlobalSaaSHub/scripts/generate_seo_pages.py
@@ -242,7 +242,6 @@ html_template = """<!doctype html>
 sitemap_urls = [
     """  <url>
     <loc>https://coshuma.com/</loc>
-    <lastmod>2026-07-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>"""
@@ -354,7 +353,6 @@ for tool in tools_data:
     generated_count += 1
     sitemap_urls.append(f"""  <url>
     <loc>https://coshuma.com/tool/{slug}.html</loc>
-    <lastmod>2026-07-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>""")
@@ -587,7 +585,6 @@ for tool_a in tools_data:
         compare_generated_count += 1
         sitemap_urls.append(f"""  <url>
     <loc>https://coshuma.com/compare/{slug_a}-vs-{slug_b}.html</loc>
-    <lastmod>2026-07-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>""")


### PR DESCRIPTION
## Summary
- remove hard-coded `lastmod` values from generated sitemap entries
- prefer omitting `lastmod` when no reliable per-page modification date is available

## Evidence
- SEO P1 audit found deployed sitemap dates stuck on 2026-07-27 even for pages updated on 2026-08-26
- the generator hard-coded those dates for homepage, tool pages, and comparison pages

## Scope / Safety
- three XML lines removed from sitemap generation only
- no catalog, affiliate, payment, account, secret, or deployment configuration changes
- zero-cost change

## Verification
- commit diff verified: only the three hard-coded `<lastmod>` lines were removed
- Python string/template structure is unchanged