### PR TITLE
fix(GlobalSaaSHub): add crawler-visible internal links

### DIFF
--- a/projects/GlobalSaaSHub/index.html
+++ b/projects/GlobalSaaSHub/index.html
@@ -63,11 +63,21 @@
   <body style="background-color: #090a0f; color: #ffffff; margin: 0; padding: 0;">
     <div id="root">
       {/* Static Fallback Content for AI Crawlers & Bots (ChatGPT Bot, Googlebot, Perplexity) */}
-      <div style="padding: 40px; max-w: 800px; margin: 0 auto; text-align: center;">
+      <div style="padding: 40px; max-width: 800px; margin: 0 auto; text-align: center;">
         <h1 style="font-size: 28px; font-weight: 800; color: #a855f7;">GlobalSaaSHub - Premier AI & B2B SaaS Directory</h1>
         <p style="font-size: 14px; color: #94a3b8; line-height: 1.6;">
           Discover top-tier AI software, productivity tools, workflow automation, and developer APIs to scale your business. Browse 151 curated SaaS profiles with clearly sourced pricing where available and side-by-side comparisons of up to 3 direct competitors.
         </p>
+        <nav aria-label="Featured software guides" style="margin-top: 20px; font-size: 13px; line-height: 2;">
+          <a href="/tool/taskade.html">Taskade review</a> ·
+          <a href="/tool/systeme-io.html">Systeme.io review</a> ·
+          <a href="/tool/fliki.html">Fliki review</a> ·
+          <a href="/tool/castmagic.html">Castmagic review</a> ·
+          <a href="/tool/vidiq.html">vidIQ review</a><br />
+          <a href="/compare/vidiq-vs-tubebuddy.html">vidIQ vs TubeBuddy</a> ·
+          <a href="/compare/castmagic-vs-tubebuddy.html">Castmagic vs TubeBuddy</a> ·
+          <a href="/compare/systeme-io-vs-privy.html">Systeme.io vs Privy</a>
+        </nav>
 
       </div>
     </div>

--- a/projects/GlobalSaaSHub/index.html
+++ b/projects/GlobalSaaSHub/index.html
@@ -63,7 +63,7 @@
   <body style="background-color: #090a0f; color: #ffffff; margin: 0; padding: 0;">
     <div id="root">
       {/* Static Fallback Content for AI Crawlers & Bots (ChatGPT Bot, Googlebot, Perplexity) */}
-      <div style="padding: 40px; max-width: 800px; margin: 0 auto; text-align: center;">
+      <div style="padding: 40px; max-w: 800px; margin: 0 auto; text-align: center;">
         <h1 style="font-size: 28px; font-weight: 800; color: #a855f7;">GlobalSaaSHub - Premier AI & B2B SaaS Directory</h1>
         <p style="font-size: 14px; color: #94a3b8; line-height: 1.6;">
           Discover top-tier AI software, productivity tools, workflow automation, and developer APIs to scale your business. Browse 151 curated SaaS profiles with clearly sourced pricing where available and side-by-side comparisons of up to 3 direct competitors.


### PR DESCRIPTION
## Summary
- add crawler-visible internal links from the static homepage fallback to five verified affiliate tool pages
- add three high-intent comparison links using canonical `.html` URLs

## Evidence
- SEO P1 audit found the crawler fallback had descriptive copy but no useful internal anchors
- linked tool pages are existing canonical pages: Taskade, Systeme.io, Fliki, Castmagic, vidIQ
- linked comparison pages already exist in the generated sitemap

## Scope / Safety
- static fallback markup only
- no catalog, affiliate target, payment, account, secret, or deployment configuration changes
- zero-cost change