### PR TITLE
fix(GlobalSaaSHub): publish Descript approved affiliate link

### DIFF
--- a/projects/GlobalSaaSHub/scripts/tests/test_descript_affiliate.py
+++ b/projects/GlobalSaaSHub/scripts/tests/test_descript_affiliate.py
@@ -1,0 +1,16 @@
+import unittest
+from pathlib import Path
+
+PROJECT = Path(__file__).resolve().parents[2]
+TRACKING_URL = "https://get.descript.com/ole5fu20j5sq"
+
+
+class DescriptAffiliateTests(unittest.TestCase):
+    def test_directory_cta_override_uses_verified_tracking_url(self):
+        url_js = (PROJECT / "src" / "utils" / "url.js").read_text(encoding="utf-8")
+        self.assertIn('descript: "https://get.descript.com/ole5fu20j5sq"', url_js)
+        self.assertIn("VERIFIED_AFFILIATE_OVERRIDES", url_js)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/GlobalSaaSHub/src/utils/url.js
+++ b/projects/GlobalSaaSHub/src/utils/url.js
@@ -4,6 +4,7 @@
  */
 const VERIFIED_AFFILIATE_OVERRIDES = {
   castmagic: "https://castmagic.io?fpr=sangkwon-an54",
+  descript: "https://get.descript.com/ole5fu20j5sq",
   vidiq: "https://vidiq.com/coshuma",
 };
 


### PR DESCRIPTION
Descript has officially approved the COSHUMA partner account and issued the personal referral URL `https://get.descript.com/ole5fu20j5sq` by email on 2026-08-26. This PR adds that verified referral URL to the existing evidence-backed affiliate override path and adds a focused regression test. No generic homepage URL is treated as affiliate tracking.