### PR TITLE
fix(GlobalSaaSHub): add Descript static affiliate CTA

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/descript.html
+++ b/projects/GlobalSaaSHub/public/tool/descript.html
@@ -126,6 +126,7 @@
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
           </div>
           <a data-cta="official" href="https://www.descript.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Descript Site</span><span>→</span></a>
+<a data-cta="affiliate" href="https://get.descript.com/ole5fu20j5sq" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Descript via Verified Affiliate Link</span><span>→</span></a>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->


### PR DESCRIPTION
Publishes the already-approved Descript referral URL on the static Descript detail page. This complements PR #16, which added only the verified directory override. Scope is intentionally limited to one generated static HTML line: retain the official CTA and add a sponsored verified-affiliate CTA for https://get.descript.com/ole5fu20j5sq.