### PR TITLE
fix(GlobalSaaSHub): publish Fireflies approved affiliate link

### DIFF
--- a/projects/GlobalSaaSHub/scripts/tests/test_fireflies_affiliate.py
+++ b/projects/GlobalSaaSHub/scripts/tests/test_fireflies_affiliate.py
@@ -1,0 +1,16 @@
+import unittest
+from pathlib import Path
+
+PROJECT = Path(__file__).resolve().parents[2]
+TRACKING_URL = "https://fireflies.ai/?fpr=sangkwon53"
+
+
+class FirefliesAffiliateTests(unittest.TestCase):
+    def test_directory_cta_override_uses_verified_tracking_url(self):
+        url_js = (PROJECT / "src" / "utils" / "url.js").read_text(encoding="utf-8")
+        self.assertIn('fireflies-ai: "https://fireflies.ai/?fpr=sangkwon53"', url_js)
+        self.assertIn("VERIFIED_AFFILIATE_OVERRIDES", url_js)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/GlobalSaaSHub/src/utils/url.js
+++ b/projects/GlobalSaaSHub/src/utils/url.js
@@ -5,6 +5,7 @@
 const VERIFIED_AFFILIATE_OVERRIDES = {
   castmagic: "https://castmagic.io?fpr=sangkwon-an54",
   descript: "https://get.descript.com/ole5fu20j5sq",
+  fireflies-ai: "https://fireflies.ai/?fpr=sangkwon53",
   vidiq: "https://vidiq.com/coshuma",
 };
 


### PR DESCRIPTION
Fireflies.ai was auto-approved in its FirstPromoter dashboard and issued the verified tracking URL `https://fireflies.ai/?fpr=sangkwon53`.

This PR:
- adds the verified Fireflies override for directory CTAs
- adds a focused regression test for the verified tracking URL

No pricing, payment, account, or unrelated catalog data is changed.