### PR TITLE
fix(GlobalSaaSHub): add Fireflies static affiliate CTA

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/fireflies-ai.html
+++ b/projects/GlobalSaaSHub/public/tool/fireflies-ai.html
@@ -125,7 +125,10 @@
             <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
           </div>
-          <a data-cta="official" href="https://fireflies.ai/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Fireflies.ai Site</span><span>→</span></a>
+          <div class="flex flex-col sm:flex-row gap-3">
+            <a data-cta="affiliate" href="https://fireflies.ai/?fpr=sangkwon53" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center border border-purple-500 hover:bg-purple-500 transition-all flex items-center justify-center gap-2"><span>Visit Fireflies.ai via Verified Affiliate Link</span><span>→</span></a>
+            <a data-cta="official" href="https://fireflies.ai/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Fireflies.ai Site</span><span>→</span></a>
+          </div>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->


### PR DESCRIPTION
Publishes the already verified Fireflies.ai referral URL on the crawler-visible static detail page while retaining the official-site fallback.

Verified referral URL: `https://fireflies.ai/?fpr=sangkwon53`

Changes are limited to the Fireflies static page and mark the referral link with `rel="sponsored noopener noreferrer"`.