### PR TITLE
fix(GlobalSaaSHub): publish Pictory approved affiliate link

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/pictory.html
+++ b/projects/GlobalSaaSHub/public/tool/pictory.html
@@ -126,6 +126,7 @@
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
           </div>
           <a data-cta="official" href="https://pictory.ai/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Pictory Site</span><span>→</span></a>
+<a data-cta="affiliate" href="https://pictory.ai?fpr=sangkwon-an23" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Pictory via Verified Affiliate Link</span><span>→</span></a>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->

--- a/projects/GlobalSaaSHub/scripts/tests/test_pictory_affiliate.py
+++ b/projects/GlobalSaaSHub/scripts/tests/test_pictory_affiliate.py
@@ -1,0 +1,22 @@
+import unittest
+from pathlib import Path
+
+PROJECT = Path(__file__).resolve().parents[2]
+TRACKING_URL = "https://pictory.ai?fpr=sangkwon-an23"
+
+
+class PictoryAffiliateTests(unittest.TestCase):
+    def test_directory_cta_override_uses_verified_tracking_url(self):
+        url_js = (PROJECT / "src" / "utils" / "url.js").read_text(encoding="utf-8")
+        self.assertIn('pictory: "https://pictory.ai?fpr=sangkwon-an23"', url_js)
+        self.assertIn("VERIFIED_AFFILIATE_OVERRIDES", url_js)
+
+    def test_static_page_publishes_verified_tracking_cta(self):
+        page = (PROJECT / "public" / "tool" / "pictory.html").read_text(encoding="utf-8")
+        self.assertIn(TRACKING_URL, page)
+        self.assertIn('data-cta="affiliate"', page)
+        self.assertIn('rel="sponsored noopener noreferrer"', page)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/GlobalSaaSHub/src/utils/url.js
+++ b/projects/GlobalSaaSHub/src/utils/url.js
@@ -6,6 +6,7 @@ const VERIFIED_AFFILIATE_OVERRIDES = {
   castmagic: "https://castmagic.io?fpr=sangkwon-an54",
   descript: "https://get.descript.com/ole5fu20j5sq",
   fireflies-ai: "https://fireflies.ai/?fpr=sangkwon53",
+  pictory: "https://pictory.ai?fpr=sangkwon-an23",
   vidiq: "https://vidiq.com/coshuma",
 };
 


### PR DESCRIPTION
Pictory 승인 메일에서 확인된 고유 referral URL `https://pictory.ai?fpr=sangkwon-an23`를 COSHUMA에 반영합니다.

변경:
- 디렉터리 CTA용 verified affiliate override 추가
- `/tool/pictory.html` 정적 상세페이지에 sponsored affiliate CTA 추가
- 회귀 테스트 추가

근거: Pictory Affiliate Partner Program 승인 메일(2026-08-27), 40% first transaction commission, PayPal payout, 90일 내 최소 1 paid sale 유지 조건.