### PR TITLE
fix(GlobalSaaSHub): publish Jotform affiliate tracking CTA

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/jotform.html
+++ b/projects/GlobalSaaSHub/public/tool/jotform.html
@@ -126,6 +126,7 @@
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
           </div>
           <a data-cta="official" href="https://www.jotform.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Jotform Site</span><span>→</span></a>
+<a data-cta="affiliate" href="https://link.jotform.com/yS9uTiLnz1?username=AnSangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Jotform via Verified Affiliate Link</span><span>→</span></a>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->
@@ -165,4 +166,3 @@
     </footer>
   </body>
 </html>
-

--- a/projects/GlobalSaaSHub/scripts/tests/test_jotform_affiliate.py
+++ b/projects/GlobalSaaSHub/scripts/tests/test_jotform_affiliate.py
@@ -1,0 +1,25 @@
+import unittest
+from pathlib import Path
+
+PROJECT = Path(__file__).resolve().parents[2]
+TRACKING_URL = "https://link.jotform.com/yS9uTiLnz1?username=AnSangkwon"
+
+
+class JotformAffiliateTests(unittest.TestCase):
+    def test_directory_cta_override_uses_verified_tracking_url(self):
+        url_js = (PROJECT / "src" / "utils" / "url.js").read_text(encoding="utf-8")
+        self.assertIn(
+            'jotform: "https://link.jotform.com/yS9uTiLnz1?username=AnSangkwon"',
+            url_js,
+        )
+        self.assertIn("VERIFIED_AFFILIATE_OVERRIDES", url_js)
+
+    def test_static_page_publishes_verified_tracking_cta(self):
+        page = (PROJECT / "public" / "tool" / "jotform.html").read_text(encoding="utf-8")
+        self.assertIn(TRACKING_URL, page)
+        self.assertIn('data-cta="affiliate"', page)
+        self.assertIn('rel="sponsored noopener noreferrer"', page)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/GlobalSaaSHub/src/utils/url.js
+++ b/projects/GlobalSaaSHub/src/utils/url.js
@@ -6,6 +6,7 @@ const VERIFIED_AFFILIATE_OVERRIDES = {
   castmagic: "https://castmagic.io?fpr=sangkwon-an54",
   descript: "https://get.descript.com/ole5fu20j5sq",
   fireflies-ai: "https://fireflies.ai/?fpr=sangkwon53",
+  jotform: "https://link.jotform.com/yS9uTiLnz1?username=AnSangkwon",
   pictory: "https://pictory.ai?fpr=sangkwon-an23",
   vidiq: "https://vidiq.com/coshuma",
 };


### PR DESCRIPTION
## Summary
- publish the Jotform affiliate tracking link issued through the approved Partner Program welcome email
- add the verified URL to the directory override path
- add a sponsored affiliate CTA to the static Jotform SEO page
- add regression coverage for both surfaces

## Evidence
Jotform's official welcome email confirms the account is accepted into the Affiliate Partner Program and that the Partner Dashboard exposes unique tracking links/custom links that track back to the affiliate. The published share link contains the account username parameter and comes directly from that welcome email.

## Safety
No account application, payment, CAPTCHA handling, OTP, or legal-consent action is performed by this PR.