### PR TITLE
fix(GlobalSaaSHub): remove Jotform dashboard redirect from revenue CTA

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/jotform.html
+++ b/projects/GlobalSaaSHub/public/tool/jotform.html
@@ -126,7 +126,6 @@
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
           </div>
           <a data-cta="official" href="https://www.jotform.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Jotform Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://link.jotform.com/yS9uTiLnz1?username=AnSangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Jotform via Verified Affiliate Link</span><span>→</span></a>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->

--- a/projects/GlobalSaaSHub/scripts/tests/test_jotform_affiliate.py
+++ b/projects/GlobalSaaSHub/scripts/tests/test_jotform_affiliate.py
@@ -2,23 +2,21 @@ import unittest
 from pathlib import Path
 
 PROJECT = Path(__file__).resolve().parents[2]
-TRACKING_URL = "https://link.jotform.com/yS9uTiLnz1?username=AnSangkwon"
+MISDIRECTING_URL = "https://link.jotform.com/yS9uTiLnz1?username=AnSangkwon"
 
 
 class JotformAffiliateTests(unittest.TestCase):
-    def test_directory_cta_override_uses_verified_tracking_url(self):
+    def test_directory_override_does_not_use_dashboard_redirect(self):
         url_js = (PROJECT / "src" / "utils" / "url.js").read_text(encoding="utf-8")
-        self.assertIn(
-            'jotform: "https://link.jotform.com/yS9uTiLnz1?username=AnSangkwon"',
-            url_js,
-        )
-        self.assertIn("VERIFIED_AFFILIATE_OVERRIDES", url_js)
+        self.assertNotIn(MISDIRECTING_URL, url_js)
+        self.assertNotIn('jotform: "https://link.jotform.com/yS9uTiLnz1?username=AnSangkwon"', url_js)
 
-    def test_static_page_publishes_verified_tracking_cta(self):
+    def test_static_page_does_not_publish_dashboard_redirect_as_affiliate_cta(self):
         page = (PROJECT / "public" / "tool" / "jotform.html").read_text(encoding="utf-8")
-        self.assertIn(TRACKING_URL, page)
-        self.assertIn('data-cta="affiliate"', page)
-        self.assertIn('rel="sponsored noopener noreferrer"', page)
+        self.assertNotIn(MISDIRECTING_URL, page)
+        self.assertNotIn('data-cta="affiliate"', page)
+        self.assertIn('data-cta="official"', page)
+        self.assertIn('href="https://www.jotform.com/"', page)
 
 
 if __name__ == "__main__":

--- a/projects/GlobalSaaSHub/src/utils/url.js
+++ b/projects/GlobalSaaSHub/src/utils/url.js
@@ -6,7 +6,6 @@ const VERIFIED_AFFILIATE_OVERRIDES = {
   castmagic: "https://castmagic.io?fpr=sangkwon-an54",
   descript: "https://get.descript.com/ole5fu20j5sq",
   fireflies-ai: "https://fireflies.ai/?fpr=sangkwon53",
-  jotform: "https://link.jotform.com/yS9uTiLnz1?username=AnSangkwon",
   pictory: "https://pictory.ai?fpr=sangkwon-an23",
   vidiq: "https://vidiq.com/coshuma",
 };


### PR DESCRIPTION
## Why
The Jotform URL published by PR #23 was re-verified after deployment. The live CTA resolves to Jotform's Partner Dashboard onboarding URL rather than a customer-facing Jotform destination, so it should not be presented as a verified revenue tracking CTA.

## Evidence
- Jotform's official affiliate welcome email says the Partner Dashboard is where the unique affiliate tracking link can be viewed.
- The same email labels `https://link.jotform.com/yS9uTiLnz1?username=AnSangkwon` as a Partner Dashboard access/share link.
- A live follow of the deployed CTA resolves to `https://www.jotform.com/partnership/dashboard/?...&username=AnSangkwon`, not a customer acquisition page.

## Changes
- remove the Jotform verified override from `src/utils/url.js`
- remove the static sponsored affiliate CTA from `public/tool/jotform.html`
- change the regression test to prevent this dashboard redirect from being published again
- keep the normal official Jotform link available

## Safety
No affiliate application, payment, CAPTCHA handling, OTP, or legal-consent action is performed. This is a corrective rollback of an incorrectly classified CTA while the actual unique referral link remains to be retrieved from the Partner Dashboard.