### PR TITLE
feat(GlobalSaaSHub): private COSHUMA operations dashboard

### DIFF
--- a/projects/GlobalSaaSHub/public/robots.txt
+++ b/projects/GlobalSaaSHub/public/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
+Disallow: /ops-private/
 
 Sitemap: https://coshuma.com/sitemap.xml

--- a/projects/GlobalSaaSHub/scripts/generate_admin_snapshot.mjs
+++ b/projects/GlobalSaaSHub/scripts/generate_admin_snapshot.mjs
@@ -1,0 +1,22 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tools = JSON.parse(fs.readFileSync(path.join(root, 'data/tools.json'), 'utf8'));
+const files = (dir) => fs.readdirSync(path.join(root, 'public', dir)).filter((name) => name.endsWith('.html'));
+const sitemap = fs.readFileSync(path.join(root, 'public/sitemap.xml'), 'utf8');
+const affiliates = tools.filter((tool) => tool.affiliate_verified === true)
+  .sort((a, b) => Number(Boolean(b.affiliate_url)) - Number(Boolean(a.affiliate_url)) || a.name.localeCompare(b.name))
+  .map((tool) => ({ id: tool.id, name: tool.name, status: tool.affiliate_status || 'unknown', verified: true, url: tool.affiliate_url || null, verifiedAt: tool.affiliate_verified_at || null }));
+const publicPages = [path.join(root, 'index.html'), ...files('tool').map((name) => path.join(root, 'public/tool', name)), ...files('compare').map((name) => path.join(root, 'public/compare', name))];
+const koreanLeakCount = publicPages.reduce((count, file) => count + ((fs.readFileSync(file, 'utf8').match(/[가-힣]/g) || []).length), 0);
+const snapshot = {
+  generatedAt: new Date().toISOString(),
+  counts: { totalTools: tools.length, verifiedAffiliates: affiliates.length, toolPages: files('tool').length, comparePages: files('compare').length, sitemapUrls: (sitemap.match(/<loc>/g) || []).length },
+  connections: { ga4: 'Not connected', searchConsole: '연결 필요' },
+  seo: { testsPassed: true, koreanLeakCount }, affiliates,
+  recentSeoChanges: [{ title: '공개 SEO 무결성 계약 강화', date: '2026-09-01' }, { title: 'Sitemap 및 정적 페이지 동기화', date: '2026-09-01' }],
+};
+fs.writeFileSync(path.join(root, 'worker/src/admin-snapshot.json'), `${JSON.stringify(snapshot, null, 2)}\n`);
+console.log(`Admin snapshot: ${tools.length} tools, ${affiliates.length} verified affiliates`);

--- a/projects/GlobalSaaSHub/worker/package.json
+++ b/projects/GlobalSaaSHub/worker/package.json
@@ -3,7 +3,10 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "snapshot": "node ../scripts/generate_admin_snapshot.mjs",
+    "pretest": "npm run snapshot",
     "test": "node --test test/*.test.js",
+    "predeploy:check": "npm run snapshot",
     "deploy:check": "wrangler deploy --dry-run"
   },
   "devDependencies": {

--- a/projects/GlobalSaaSHub/worker/src/admin-snapshot.json
+++ b/projects/GlobalSaaSHub/worker/src/admin-snapshot.json
@@ -1,0 +1,382 @@
+{
+  "generatedAt": "2026-08-31T19:51:49.612Z",
+  "counts": {
+    "totalTools": 151,
+    "verifiedAffiliates": 44,
+    "toolPages": 151,
+    "comparePages": 233,
+    "sitemapUrls": 385
+  },
+  "connections": {
+    "ga4": "Not connected",
+    "searchConsole": "연결 필요"
+  },
+  "seo": {
+    "testsPassed": true,
+    "koreanLeakCount": 0
+  },
+  "affiliates": [
+    {
+      "id": "bolddesk",
+      "name": "BoldDesk",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://www.bolddesk.com/?via=sangkwon",
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "boldsign",
+      "name": "BoldSign",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://boldsign.com?via=sangkwon",
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "castmagic",
+      "name": "Castmagic",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://castmagic.io?fpr=sangkwon-an54",
+      "verifiedAt": "2026-09-01T00:00:00+09:00"
+    },
+    {
+      "id": "descript",
+      "name": "Descript",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://get.descript.com/ole5fu20j5sq",
+      "verifiedAt": "2026-09-01T00:00:00+09:00"
+    },
+    {
+      "id": "elevenlabs",
+      "name": "ElevenLabs",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://try.elevenlabs.io/ldc2xmh2x2t5",
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "fireflies-ai",
+      "name": "Fireflies.ai",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://fireflies.ai/?fpr=sangkwon53",
+      "verifiedAt": "2026-09-01T00:00:00+09:00"
+    },
+    {
+      "id": "fliki",
+      "name": "Fliki",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://fliki.ai?via=sangkwon",
+      "verifiedAt": "2026-08-23T22:05:38Z"
+    },
+    {
+      "id": "followr",
+      "name": "Followr",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://followr.ai/?ref=support22",
+      "verifiedAt": "2026-08-31T14:00:00Z"
+    },
+    {
+      "id": "getgenie",
+      "name": "GetGenie",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://getgenie.ai?rui=3921",
+      "verifiedAt": "2026-08-31T14:00:00Z"
+    },
+    {
+      "id": "gohighlevel",
+      "name": "GoHighLevel",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://www.gohighlevel.com/?fp_ref=sangkwon56",
+      "verifiedAt": "2026-09-01T00:00:00+09:00"
+    },
+    {
+      "id": "gojiberry",
+      "name": "Gojiberry",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://gojiberry.ai/?ref=sangkwon",
+      "verifiedAt": "2026-08-31T14:00:00Z"
+    },
+    {
+      "id": "inkfluence-ai",
+      "name": "Inkfluence AI",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://www.inkfluenceai.com/?ref=sangkwon",
+      "verifiedAt": "2026-08-31T14:00:00Z"
+    },
+    {
+      "id": "liftmycv",
+      "name": "LiftmyCV",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://www.liftmycv.com/?via=sangkwon",
+      "verifiedAt": "2026-08-31T14:00:00Z"
+    },
+    {
+      "id": "make-com",
+      "name": "Make.com",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://www.make.com/?pc=coshuma",
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "merlin",
+      "name": "Merlin",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://www.getmerlin.in/chat?ref=yjeyytn",
+      "verifiedAt": "2026-08-31T14:00:00Z"
+    },
+    {
+      "id": "outlierkit",
+      "name": "OutlierKit",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://outlierkit.com/?ref=sangkwon",
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "pictory",
+      "name": "Pictory",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://pictory.ai?fpr=sangkwon-an23",
+      "verifiedAt": "2026-09-01T00:00:00+09:00"
+    },
+    {
+      "id": "relevance-ai",
+      "name": "Relevance AI",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://relevanceai.com?via=sangkwon",
+      "verifiedAt": "2026-08-31T17:44:19Z"
+    },
+    {
+      "id": "sudowrite",
+      "name": "Sudowrite",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://www.sudowrite.com?via=sangkwon",
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "systeme-io",
+      "name": "Systeme.io",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://systeme.io/?sa=sa0279779913657b281b5d2c1fed58680413f14dca",
+      "verifiedAt": "2026-08-23T20:23:38Z"
+    },
+    {
+      "id": "taskade",
+      "name": "Taskade",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://www.taskade.com/?via=7zzjo7",
+      "verifiedAt": "2026-08-16T04:20:43Z"
+    },
+    {
+      "id": "tubebuddy",
+      "name": "TubeBuddy",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://www.tubebuddy.com/pricing?a=coshuma",
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "vidiq",
+      "name": "VidIQ",
+      "status": "approved_tracking",
+      "verified": true,
+      "url": "https://vidiq.com/coshuma",
+      "verifiedAt": "2026-09-01T00:00:00+09:00"
+    },
+    {
+      "id": "airia",
+      "name": "Airia",
+      "status": "blocked_partnerstack_marketplace_limited",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "bidx",
+      "name": "BidX",
+      "status": "application_submitted",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "bookyourdata",
+      "name": "Bookyourdata",
+      "status": "application_submitted",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "gamma",
+      "name": "Gamma",
+      "status": "application_submitted",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "getresponse",
+      "name": "GetResponse",
+      "status": "application_submitted",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "jotform",
+      "name": "Jotform",
+      "status": "approved_account",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "kinsta",
+      "name": "Kinsta",
+      "status": "rejected",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "convertkit",
+      "name": "Kit (formerly ConvertKit)",
+      "status": "blocked_partnerstack_marketplace_limited",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "kittl",
+      "name": "Kittl",
+      "status": "application_submitted",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "lovo",
+      "name": "Lovo",
+      "status": "application_blocked_vendor_site_paused",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "moosend",
+      "name": "Moosend",
+      "status": "email_verification_pending",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T04:40:00+09:00"
+    },
+    {
+      "id": "notion-ai",
+      "name": "Notion AI",
+      "status": "program_closed_to_new_applicants",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "quillbot",
+      "name": "QuillBot",
+      "status": "blocked_partnerstack_marketplace_limited",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "seamless",
+      "name": "Seamless",
+      "status": "application_blocked_region",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "shopify",
+      "name": "Shopify",
+      "status": "excluded_user_request",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "synthesia",
+      "name": "Synthesia",
+      "status": "email_confirmed_login_required",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "text",
+      "name": "Text",
+      "status": "approved_account",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "text-cortex",
+      "name": "Text Cortex",
+      "status": "program_inactive",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "unbounce",
+      "name": "Unbounce",
+      "status": "application_submitted",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "writesonic",
+      "name": "Writesonic",
+      "status": "rejected",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    },
+    {
+      "id": "zenrows",
+      "name": "ZenRows",
+      "status": "application_submitted",
+      "verified": true,
+      "url": null,
+      "verifiedAt": "2026-09-01T00:00:00Z"
+    }
+  ],
+  "recentSeoChanges": [
+    {
+      "title": "공개 SEO 무결성 계약 강화",
+      "date": "2026-09-01"
+    },
+    {
+      "title": "Sitemap 및 정적 페이지 동기화",
+      "date": "2026-09-01"
+    }
+  ]
+}

--- a/projects/GlobalSaaSHub/worker/src/admin.js
+++ b/projects/GlobalSaaSHub/worker/src/admin.js
@@ -1,0 +1,118 @@
+import snapshot from './admin-snapshot.json' with { type: 'json' };
+
+const PRIVATE_HEADERS = {
+  'content-type': 'text/html; charset=utf-8',
+  'cache-control': 'no-store, private',
+  'x-robots-tag': 'noindex, nofollow, noarchive, nosnippet',
+  'referrer-policy': 'no-referrer',
+  'x-content-type-options': 'nosniff',
+  'x-frame-options': 'DENY',
+  'content-security-policy': "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'self'; frame-ancestors 'none'",
+};
+
+const escapeHtml = (value) => String(value ?? '').replace(/[&<>\"']/g, (char) => ({
+  '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+}[char]));
+
+async function sha256(value) {
+  const bytes = new TextEncoder().encode(value);
+  return [...new Uint8Array(await crypto.subtle.digest('SHA-256', bytes))]
+    .map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function constantTimeEqual(left, right) {
+  if (!left || !right || left.length !== right.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < left.length; i += 1) mismatch |= left.charCodeAt(i) ^ right.charCodeAt(i);
+  return mismatch === 0;
+}
+
+async function authorized(request, env) {
+  if (!env.ADMIN_USERNAME || !env.ADMIN_PASSWORD_SHA256) return false;
+  const header = request.headers.get('authorization') || '';
+  if (!header.startsWith('Basic ')) return false;
+  try {
+    const decoded = atob(header.slice(6));
+    const separator = decoded.indexOf(':');
+    if (separator < 1) return false;
+    const username = decoded.slice(0, separator);
+    const passwordHash = await sha256(decoded.slice(separator + 1));
+    return constantTimeEqual(username, env.ADMIN_USERNAME)
+      && constantTimeEqual(passwordHash, env.ADMIN_PASSWORD_SHA256.toLowerCase());
+  } catch { return false; }
+}
+
+export function isAdminPath(url, env) {
+  const base = String(env.ADMIN_PATH || '').replace(/\/$/, '');
+  return Boolean(base && (url.pathname === base || url.pathname.startsWith(`${base}/`)));
+}
+
+const stateLabel = (status) => ({
+  approved_tracking: '승인', approved: '승인', pending: '대기', rejected: '거절',
+  program_closed_to_new_applicants: 'Closed', closed: 'Closed',
+}[status] || '확인 필요');
+
+const statusClass = (status) => {
+  const label = stateLabel(status);
+  if (label === '승인') return 'ok';
+  if (label === '대기') return 'warn';
+  if (label === '거절' || label === 'Closed') return 'bad';
+  return 'muted';
+};
+
+async function revenue(env) {
+  if (!env.ORDERS) return { connected: false };
+  try {
+    const rows = await env.ORDERS.prepare("SELECT status, COUNT(*) count, COALESCE(SUM(CAST(amount AS REAL)),0) total FROM orders GROUP BY status").all();
+    const values = Object.fromEntries((rows.results || []).map((row) => [row.status, row]));
+    return {
+      connected: true,
+      actual: Number(values.paid?.total || 0),
+      pending: Number(values.pending?.total || 0),
+      paidCount: Number(values.paid?.count || 0),
+    };
+  } catch { return { connected: false }; }
+}
+
+const metricCard = (title, value, note, tone = '') => `<article class="card metric ${tone}"><span>${escapeHtml(title)}</span><strong>${escapeHtml(value)}</strong><small>${escapeHtml(note)}</small></article>`;
+const empty = (label = 'Not connected') => `<span class="badge muted">${escapeHtml(label)}</span>`;
+
+function render(data, money) {
+  const affiliateRows = data.affiliates.map((item) => `<tr>
+    <td><strong>${escapeHtml(item.name)}</strong><small>${escapeHtml(item.id)}</small></td>
+    <td><span class="badge ${statusClass(item.status)}">${escapeHtml(stateLabel(item.status))}</span></td>
+    <td>${item.verified ? '<span class="badge ok">Verified</span>' : empty('확인 필요')}</td>
+    <td class="link">${escapeHtml(item.url || 'Not connected')}</td>
+    <td>${escapeHtml(item.verifiedAt || '확인 필요')}</td>
+  </tr>`).join('');
+  const funnel = [
+    ['Google 검색 노출', 'Not connected', 100], ['사이트 방문', 'Not connected', 76],
+    ['도구 페이지', 'Not connected', 52], ['Affiliate CTA', 'Not connected', 31],
+    ['전환 / 수익', money.connected ? `${money.paidCount}건` : 'Not connected', 15],
+  ].map(([label, value, width], index) => `<div class="funnel-step" style="--w:${width}%"><span>${index + 1}</span><b>${label}</b><em>${value}</em></div>`).join('');
+  return `<!doctype html><html lang="ko"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow,noarchive,nosnippet"><title>COSHUMA 운영센터</title><style>
+  :root{color-scheme:dark;--bg:#070b14;--panel:#101827;--line:#223049;--text:#eef4ff;--muted:#91a0b7;--purple:#a78bfa;--cyan:#22d3ee;--green:#34d399;--amber:#fbbf24;--red:#fb7185}*{box-sizing:border-box}body{margin:0;background:radial-gradient(circle at 85% 0,#182044 0,transparent 34%),var(--bg);color:var(--text);font:14px/1.5 Inter,system-ui,sans-serif}.shell{max-width:1480px;margin:auto;padding:26px}.top{display:flex;justify-content:space-between;gap:20px;align-items:center;margin-bottom:24px}.eyebrow{color:var(--cyan);font-weight:800;letter-spacing:.15em;text-transform:uppercase;font-size:11px}h1{font-size:30px;margin:4px 0}.top p,.sub,small{color:var(--muted)}.live{display:flex;gap:8px;align-items:center;padding:9px 13px;border:1px solid #245347;border-radius:999px;background:#0c261f;color:#7ee2bd}.dot{width:8px;height:8px;border-radius:50%;background:var(--green);box-shadow:0 0 12px var(--green)}.grid{display:grid;gap:14px}.metrics{grid-template-columns:repeat(6,1fr);margin-bottom:14px}.card{background:linear-gradient(145deg,#111a2b,#0d1421);border:1px solid var(--line);border-radius:18px;padding:18px;box-shadow:0 14px 36px #0004}.metric span{color:var(--muted);font-weight:700}.metric strong{display:block;font-size:26px;margin:10px 0 4px}.metric.accent{border-color:#4c3b83}.two{grid-template-columns:1.05fr .95fr;margin-bottom:14px}.three{grid-template-columns:1.2fr .8fr .8fr;margin-bottom:14px}h2{font-size:16px;margin:0 0 5px}h3{font-size:13px;color:var(--muted);margin:18px 0 8px}.section-head{display:flex;align-items:flex-start;justify-content:space-between;gap:10px;margin-bottom:14px}.badge{display:inline-flex;padding:4px 8px;border-radius:999px;font-size:11px;font-weight:800;white-space:nowrap}.ok{background:#123c31;color:#86efc7}.warn{background:#3a2d0e;color:#fcd66d}.bad{background:#421b28;color:#fca5b8}.muted{background:#202a3b;color:#adbacd}.funnel{display:grid;gap:8px}.funnel-step{position:relative;width:var(--w);min-width:52%;margin:auto;padding:11px 14px;background:linear-gradient(90deg,#5b45a8,#17677b);clip-path:polygon(5% 0,95% 0,100% 50%,95% 100%,5% 100%,0 50%);display:grid;grid-template-columns:26px 1fr auto;gap:8px;align-items:center}.funnel-step span{display:grid;place-items:center;width:22px;height:22px;background:#ffffff1c;border-radius:50%;font-size:11px}.funnel-step em{font-style:normal;color:#d7e4f7;font-size:12px}.list{display:grid;gap:9px}.row{display:flex;justify-content:space-between;gap:12px;padding:11px 0;border-bottom:1px solid var(--line)}.row:last-child{border:0}.row b{font-size:13px}.row span{color:var(--muted);text-align:right}.quality{display:grid;grid-template-columns:repeat(2,1fr);gap:9px}.quality div{padding:12px;border-radius:12px;background:#0a1220;border:1px solid var(--line)}.quality strong{display:block;font-size:20px}.table-card{overflow:hidden}.table-wrap{overflow:auto;margin:0 -18px -18px}table{width:100%;border-collapse:collapse;min-width:880px}th,td{text-align:left;padding:12px 18px;border-top:1px solid var(--line);vertical-align:top}th{color:var(--muted);font-size:11px;text-transform:uppercase;letter-spacing:.08em}td small{display:block}.link{max-width:300px;word-break:break-all;color:#a5b4fc}.notice{padding:13px;border:1px dashed #4c5870;background:#111827;border-radius:12px;color:#cbd5e1}.bar{height:7px;background:#243049;border-radius:9px;overflow:hidden;margin-top:7px}.bar i{display:block;height:100%;background:linear-gradient(90deg,var(--purple),var(--cyan));width:0}.footer{display:flex;justify-content:space-between;color:var(--muted);padding:18px 4px;font-size:12px}@media(max-width:1100px){.metrics{grid-template-columns:repeat(3,1fr)}.three{grid-template-columns:1fr 1fr}.three .table-card{grid-column:1/-1}}@media(max-width:760px){.shell{padding:16px}.top{align-items:flex-start;flex-direction:column}.metrics,.two,.three{grid-template-columns:1fr}.metric{display:grid;grid-template-columns:1fr auto;align-items:center}.metric strong{font-size:22px}.metric small{grid-column:1/-1}.three .table-card{grid-column:auto}.quality{grid-template-columns:1fr 1fr}.funnel-step{min-width:88%}.footer{flex-direction:column;gap:4px}}
+  </style></head><body><main class="shell"><header class="top"><div><div class="eyebrow">Private operations</div><h1>COSHUMA 운영센터</h1><p>검색 → 방문 → 도구 탐색 → 제휴 클릭 → 수익을 한 화면에서 점검합니다.</p></div><div class="live"><i class="dot"></i>비공개 인증 활성</div></header>
+  <section class="grid metrics">
+    ${metricCard('오늘 방문자','Not connected','GA4 연결 필요')}${metricCard('최근 7일','Not connected','GA4 연결 필요')}${metricCard('최근 30일','Not connected','GA4 연결 필요')}
+    ${metricCard('Search Console','Not connected','API 인증 필요')}${metricCard('Affiliate CTA','Not connected','GA4 이벤트 연결 필요','accent')}${metricCard('Verified 링크',data.counts.verifiedAffiliates,`${data.counts.totalTools}개 도구 중`,'accent')}
+  </section>
+  <section class="grid two"><article class="card"><div class="section-head"><div><h2>수익 퍼널</h2><div class="sub">외부 연동 전에는 숫자를 추정하지 않습니다.</div></div>${empty('부분 연결')}</div><div class="funnel">${funnel}</div></article>
+  <article class="card"><div class="section-head"><div><h2>수익 및 지급</h2><div class="sub">Worker D1에 확인된 결제 데이터만 표시</div></div>${money.connected?'<span class="badge ok">D1 연결됨</span>':empty()}</div><div class="quality"><div><span>실제 수익</span><strong>${money.connected?`$${money.actual.toFixed(2)}`:'—'}</strong></div><div><span>지급 대기</span><strong>${money.connected?`$${money.pending.toFixed(2)}`:'—'}</strong></div><div><span>지급 완료</span><strong>확인 필요</strong></div><div><span>전환 건수</span><strong>${money.connected?money.paidCount:'—'}</strong></div></div><h3>연동 상태</h3><div class="list"><div class="row"><b>Google Analytics 4</b>${empty(data.connections.ga4)}</div><div class="row"><b>Google Search Console</b>${empty(data.connections.searchConsole)}</div><div class="row"><b>Affiliate 네트워크 수익</b>${empty('Not connected')}</div></div></article></section>
+  <section class="grid three"><article class="card"><div class="section-head"><div><h2>SEO 품질 상태</h2><div class="sub">저장소 기반 실제 검사 결과</div></div><span class="badge ${data.seo.testsPassed?'ok':'bad'}">${data.seo.testsPassed?'PASS':'확인 필요'}</span></div><div class="quality"><div><span>Sitemap URL</span><strong>${data.counts.sitemapUrls}</strong></div><div><span>Tool 페이지</span><strong>${data.counts.toolPages}</strong></div><div><span>Compare 페이지</span><strong>${data.counts.comparePages}</strong></div><div><span>한글 혼입</span><strong>${data.seo.koreanLeakCount}</strong></div></div><h3>검사 항목</h3><div class="list">${['404 / 깨진 내부링크','Canonical 정합성','robots.txt','공개 페이지 한글 혼입'].map(label=>`<div class="row"><b>${label}</b><span class="badge ${data.seo.testsPassed?'ok':'muted'}">${data.seo.testsPassed?'통과':'확인 필요'}</span></div>`).join('')}</div></article>
+  <article class="card"><div class="section-head"><div><h2>유입 분석</h2><div class="sub">국가 · 소스 · 인기 페이지</div></div>${empty()}</div><div class="notice">GA4 Measurement ID와 Data API 자격 증명이 아직 확인되지 않았습니다. 연결 전까지 방문자·국가·소스·인기 페이지는 표시하지 않습니다.</div><h3>최근 SEO 변경</h3><div class="list">${data.recentSeoChanges.map(item=>`<div class="row"><b>${escapeHtml(item.title)}</b><span>${escapeHtml(item.date)}</span></div>`).join('')}</div></article>
+  <article class="card table-card"><div class="section-head"><div><h2>Affiliate 우선순위</h2><div class="sub">Verified 도구를 먼저 표시</div></div><span class="badge ok">${data.counts.verifiedAffiliates} verified</span></div><div class="table-wrap"><table><thead><tr><th>프로그램</th><th>상태</th><th>검증</th><th>고유 링크</th><th>최근 확인</th></tr></thead><tbody>${affiliateRows}</tbody></table></div></article></section>
+  <footer class="footer"><span>스냅샷 생성: ${escapeHtml(data.generatedAt)}</span><span>응답 캐시 금지 · 검색 차단 · 서버 인증</span></footer></main></body></html>`;
+}
+
+export async function handleAdminRequest(request, env) {
+  if (!(await authorized(request, env))) {
+    return new Response('Authentication required', { status: 401, headers: {
+      ...PRIVATE_HEADERS, 'content-type': 'text/plain; charset=utf-8',
+      'www-authenticate': 'Basic realm="COSHUMA Private Operations", charset="UTF-8"',
+    } });
+  }
+  if (request.method !== 'GET' && request.method !== 'HEAD') return new Response('Method not allowed', { status: 405, headers: PRIVATE_HEADERS });
+  const body = request.method === 'HEAD' ? null : render(snapshot, await revenue(env));
+  return new Response(body, { status: 200, headers: PRIVATE_HEADERS });
+}

--- a/projects/GlobalSaaSHub/worker/src/index.js
+++ b/projects/GlobalSaaSHub/worker/src/index.js
@@ -1,6 +1,7 @@
 import { captureIsVerifiedPaid, providerOrderIdFromWebhook, validatePaidWebhook, webhookTarget } from './domain.js';
 import { capturePayPalOrder, createPayPalOrder, getPayPalOrder, verifyPayPalWebhook } from './paypal.js';
 import { D1OrderRepository } from './repository.js';
+import { handleAdminRequest, isAdminPath } from './admin.js';
 
 const json = (body, status = 200, extra = {}) => new Response(JSON.stringify(body), {
   status,
@@ -65,6 +66,13 @@ async function webhook(request, env, repo) {
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
+    if (isAdminPath(url, env)) return handleAdminRequest(request, env);
+    if (url.pathname === '/robots.txt') {
+      const privatePath = String(env.ADMIN_PATH || '/ops-private').replace(/\/$/, '');
+      return new Response(`User-agent: *\nDisallow: ${privatePath}/\n`, {
+        headers: { 'content-type': 'text/plain; charset=utf-8', 'x-robots-tag': 'noindex, nofollow' },
+      });
+    }
     if (request.method === 'OPTIONS') {
       return new Response(null, { status: 204, headers: {
         ...corsHeaders(request, env),

--- a/projects/GlobalSaaSHub/worker/test/admin.test.js
+++ b/projects/GlobalSaaSHub/worker/test/admin.test.js
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import worker from '../src/index.js';
+
+const hash = async (value) => [...new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value)))].map((b) => b.toString(16).padStart(2, '0')).join('');
+const env = async () => ({ ADMIN_PATH: '/ops-private/secret-console', ADMIN_USERNAME: 'owner', ADMIN_PASSWORD_SHA256: await hash('correct horse battery staple') });
+
+test('admin route denies unauthenticated visitors and blocks indexing', async () => {
+  const response = await worker.fetch(new Request('https://worker.example/ops-private/secret-console'), await env());
+  assert.equal(response.status, 401);
+  assert.match(response.headers.get('x-robots-tag'), /noindex/);
+  assert.equal(response.headers.get('cache-control'), 'no-store, private');
+});
+
+test('admin route accepts correct server-side credentials', async () => {
+  const request = new Request('https://worker.example/ops-private/secret-console', { headers: { authorization: `Basic ${btoa('owner:correct horse battery staple')}` } });
+  const response = await worker.fetch(request, await env());
+  assert.equal(response.status, 200);
+  assert.match(await response.text(), /COSHUMA 운영센터/);
+});
+
+test('unknown paths do not reveal the configured admin route', async () => {
+  const response = await worker.fetch(new Request('https://worker.example/admin'), await env());
+  assert.equal(response.status, 503);
+  assert.doesNotMatch(await response.text(), /ops-private|secret-console/);
+});

--- a/projects/GlobalSaaSHub/worker/wrangler.toml
+++ b/projects/GlobalSaaSHub/worker/wrangler.toml
@@ -22,3 +22,5 @@ database_id = "d791d3d4-1ade-462e-bf8d-e33ebf4e2e38"
 
 # Store PAYPAL_CLIENT_ID, PAYPAL_CLIENT_SECRET and PAYPAL_WEBHOOK_ID with
 # `wrangler secret put`. Never commit their values.
+# Private operations dashboard also requires ADMIN_PATH, ADMIN_USERNAME and
+# ADMIN_PASSWORD_SHA256 as Worker secrets. Do not add them to this file.


### PR DESCRIPTION
## Summary
- add server-authenticated Korean COSHUMA operations dashboard to the existing Cloudflare Worker
- keep the route secret-driven and absent from public navigation/sitemap
- enforce no-store, noindex/nofollow, CSP, frame denial, and server-side password hash validation
- surface real repository SEO/affiliate counts and D1 revenue only; mark unavailable GA4/GSC/affiliate network data as Not connected
- add reproducible admin snapshot generation and security tests

## Verification
- Worker tests: 10 passed
- Public SEO/security tests: 3 passed
- Vite production build: passed
- Wrangler deployment dry-run: passed