### PR TITLE
fix(GlobalSaaSHub): prevent GA4 fallback property contamination

### DIFF
--- a/projects/GlobalSaaSHub/src/utils/ga4.js
+++ b/projects/GlobalSaaSHub/src/utils/ga4.js
@@ -2,8 +2,9 @@ const MEASUREMENT_ID_PATTERN = /^G-[A-Z0-9]{8,14}$/
 
 export function configureGA4() {
   // A GA4 measurement ID is a public site identifier, not a credential.
-  // The environment variable remains the deployment override.
-  const measurementId = import.meta.env.VITE_GA4_MEASUREMENT_ID || 'G-ZSFMKB7S5C'
+  // Keep the measurement ID deployment-controlled so local/dev builds never
+  // fall back to a different analytics property and contaminate attribution.
+  const measurementId = import.meta.env.VITE_GA4_MEASUREMENT_ID
   if (!MEASUREMENT_ID_PATTERN.test(measurementId || '')) return false
 
   window.dataLayer = window.dataLayer || []


### PR DESCRIPTION
## Why
Production is currently built with `VITE_GA4_MEASUREMENT_ID=G-J7E0J89VCV`, but `src/utils/ga4.js` still contained a fallback to a different GA4 property (`G-ZSFMKB7S5C`). A build without the production env could therefore silently send COSHUMA attribution data to the wrong property.

## Change
- Remove the hardcoded fallback measurement ID.
- Configure GA4 only when `VITE_GA4_MEASUREMENT_ID` is present and valid.
- Preserve the existing production behavior because `.env.production` supplies the current production measurement ID.

## Revenue/attribution impact
This is a fail-closed attribution safety fix: it prevents page-view and affiliate-click analytics from being contaminated by an unintended GA4 property while keeping the current production property deployment-controlled.

No paid service or subscription is introduced. No deployment is performed by this PR itself.