### PR TITLE
fix(GlobalSaaSHub): GA4 배치 조회 요청 형식 수정

### DIFF
--- a/projects/GlobalSaaSHub/worker/src/google-analytics.js
+++ b/projects/GlobalSaaSHub/worker/src/google-analytics.js
@@ -45,7 +45,7 @@ export async function fetchGoogleMetrics(env) {
   const property = env.GA_PROPERTY_ID || '552119661';
   const gaBase = `https://analyticsdata.googleapis.com/v1beta/properties/${property}`;
   const [kpis, countries, sources, pages, affiliate, searchTotals, search] = await Promise.all([
-    googlePost(`${gaBase}:batchRunReports`, token, { reports: [
+    googlePost(`${gaBase}:batchRunReports`, token, { requests: [
       { dateRanges: [{ startDate: 'today', endDate: 'today' }], metrics: [{ name: 'activeUsers' }] },
       { dateRanges: [{ startDate: '7daysAgo', endDate: 'today' }], metrics: [{ name: 'activeUsers' }] },
       { dateRanges: [{ startDate: '30daysAgo', endDate: 'today' }], metrics: [{ name: 'activeUsers' }] },


### PR DESCRIPTION
GA4 Data API batchRunReports가 요구하는 requests 필드로 수정합니다. 동일한 서비스 계정으로 개별 GA4·Search Console 요청은 모두 HTTP 200 확인했습니다.