### PR TITLE
feat: add verified LoopCV affiliate tracking

### DIFF
--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -2256,7 +2256,7 @@
     "category": "email_outreach",
     "category_display": "Email & Outreach",
     "description": "LoopCV leverages AI to automate the laborious job application process, finding matching roles across multiple boards and applying on the user's behalf. It significantly streamlines the job search, saving users valuable time and effort.",
-    "affiliate_url": null,
+    "affiliate_url": "https://loopcv.pro?via=sang-kwon",
     "pricing": "See official pricing",
     "key_features": [
       "AI-powered job application automation",
@@ -2278,7 +2278,17 @@
     "is_manual_override": false,
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
-    "official_evidence_url": "https://loopcv.pro/"
+    "official_evidence_url": "https://loopcv.pro/",
+    "affiliate_verified": true,
+    "affiliate_status": "approved_tracking",
+    "affiliate_source_url": "https://loopcv.getrewardful.com/",
+    "affiliate_final_url": "https://loopcv.pro?via=sang-kwon",
+    "affiliate_verified_at": "2026-09-01T00:00:00Z",
+    "affiliate_evidence_markers": [
+      "active affiliate dashboard",
+      "25% commission on all payments",
+      "PayPal payout email confirmed"
+    ]
   },
   {
     "id": "clickfunnels",

--- a/projects/GlobalSaaSHub/data/tools.next.json
+++ b/projects/GlobalSaaSHub/data/tools.next.json
@@ -2293,7 +2293,17 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://loopcv.pro/",
-    "affiliate_url": null
+    "affiliate_url": "https://loopcv.pro?via=sang-kwon",
+    "affiliate_verified": true,
+    "affiliate_status": "approved_tracking",
+    "affiliate_source_url": "https://loopcv.getrewardful.com/",
+    "affiliate_final_url": "https://loopcv.pro?via=sang-kwon",
+    "affiliate_verified_at": "2026-09-01T00:00:00Z",
+    "affiliate_evidence_markers": [
+      "active affiliate dashboard",
+      "25% commission on all payments",
+      "PayPal payout email confirmed"
+    ]
   },
   {
     "id": "clickfunnels",


### PR DESCRIPTION
Adds the verified LoopCV affiliate tracking recovered from the live Rewardful dashboard.

- Active tracking link: https://loopcv.pro?via=sang-kwon
- 25% commission on all payments
- PayPal payout email confirmed
- Updates tools.json and tools.next.json

Validation: link integrity 151/151 passed; production build passed.