### PR TITLE
fix(GlobalSaaSHub): sync verified affiliate CTAs into static SEO pages

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/dorik.html
+++ b/projects/GlobalSaaSHub/public/tool/dorik.html
@@ -126,6 +126,7 @@
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
           </div>
           <a data-cta="official" href="https://dorik.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Dorik Site</span><span>→</span></a>
+<a data-cta="affiliate" href="https://dorik.com/?ref=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Dorik via Verified Affiliate Link</span><span>→</span></a>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->
@@ -165,4 +166,3 @@
     </footer>
   </body>
 </html>
-

--- a/projects/GlobalSaaSHub/public/tool/rytr.html
+++ b/projects/GlobalSaaSHub/public/tool/rytr.html
@@ -126,6 +126,7 @@
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
           </div>
           <a data-cta="official" href="https://rytr.me/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Rytr Site</span><span>→</span></a>
+<a data-cta="affiliate" href="https://rytr.me?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Rytr via Verified Affiliate Link</span><span>→</span></a>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->
@@ -165,4 +166,3 @@
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
## Revenue impact
The verified affiliate data for Rytr and Dorik was already present in `tools.json`, but their committed static SEO landing pages still sent visitors only to the non-affiliate official URLs. This closes that revenue leak for two indexed landing pages.

## Changes
- Rytr: add verified affiliate CTA `https://rytr.me?via=sangkwon`
- Dorik: add verified affiliate CTA `https://dorik.com/?ref=coshuma`
- preserve the existing official-site CTA
- use `data-cta="affiliate"` and `rel="sponsored noopener noreferrer"`

No paid service, subscription, or advertising is introduced. No production deployment is performed by this PR.