### PR TITLE
fix(GlobalSaaSHub): close Decktopus and LoopCV static affiliate leaks

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/decktopus.html
+++ b/projects/GlobalSaaSHub/public/tool/decktopus.html
@@ -126,6 +126,7 @@
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
           </div>
           <a data-cta="official" href="https://decktopus.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Decktopus Site</span><span>→</span></a>
+<a data-cta="affiliate" href="https://www.decktopus.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Decktopus via Verified Affiliate Link</span><span>→</span></a>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->

--- a/projects/GlobalSaaSHub/public/tool/loopcv.html
+++ b/projects/GlobalSaaSHub/public/tool/loopcv.html
@@ -126,6 +126,7 @@
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
           </div>
           <a data-cta="official" href="https://loopcv.pro/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official LoopCV Site</span><span>→</span></a>
+<a data-cta="affiliate" href="https://loopcv.pro?via=sang-kwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit LoopCV via Verified Affiliate Link</span><span>→</span></a>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->

--- a/projects/GlobalSaaSHub/scripts/tests/test_public_seo_integrity.py
+++ b/projects/GlobalSaaSHub/scripts/tests/test_public_seo_integrity.py
@@ -1,4 +1,4 @@
-"""SEO and English-only contract for public GlobalSaaSHub pages."""
+"""SEO, English-only, and revenue-link contract for public GlobalSaaSHub pages."""
 import json
 import re
 import sys
@@ -43,6 +43,22 @@ def main():
             slugs = path.stem.split("-vs-")
             if len(slugs) != 2 or any(f'href="/tool/{slug}.html"' not in text for slug in slugs):
                 errors.append(f"Missing comparison-to-tool internal links: {relative}")
+
+    tools = json.loads((PROJECT / "data" / "tools.json").read_text(encoding="utf-8"))
+    for tool in tools:
+        if tool.get("affiliate_verified") is not True or tool.get("affiliate_status") != "approved_tracking":
+            continue
+        affiliate_url = tool.get("affiliate_url")
+        if not affiliate_url:
+            errors.append(f"Verified affiliate missing URL in tools.json: {tool.get('id')}")
+            continue
+        page = PUBLIC / "tool" / f"{tool['id']}.html"
+        if not page.exists():
+            errors.append(f"Verified affiliate missing static tool page: {tool['id']}")
+            continue
+        text = page.read_text(encoding="utf-8")
+        if 'data-cta="affiliate"' not in text or f'href="{affiliate_url}"' not in text:
+            errors.append(f"Verified affiliate CTA drift: {tool['id']}")
 
     root = ET.parse(PUBLIC / "sitemap.xml").getroot()
     namespace = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}


### PR DESCRIPTION
## Revenue impact
Decktopus and LoopCV already had verified approved affiliate URLs in the canonical dataset, but their committed static SEO tool pages still exposed only the official non-affiliate CTA. Organic visitors landing directly on those indexed pages could therefore leave without COSHUMA attribution.

## Changes
- Decktopus: add verified CTA `https://www.decktopus.com?via=sangkwon`
- LoopCV: add verified CTA `https://loopcv.pro?via=sang-kwon`
- preserve official-site CTAs
- mark affiliate links with `data-cta="affiliate"` and `rel="sponsored noopener noreferrer"`
- extend the public SEO integrity test so any future `affiliate_verified=true` + `approved_tracking` tool must have its exact verified URL in the matching static tool page

No paid service, subscription, advertising, or guessed affiliate URL is introduced.