### PR TITLE
fix(GlobalSaaSHub): sync AWeber verified affiliate CTA

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/aweber.html
+++ b/projects/GlobalSaaSHub/public/tool/aweber.html
@@ -126,6 +126,7 @@
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
           </div>
           <a data-cta="official" href="https://www.aweber.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official AWeber Site</span><span>→</span></a>
+<a data-cta="affiliate" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit AWeber via Verified Affiliate Link</span><span>→</span></a>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->


### PR DESCRIPTION
AWeber was newly marked `affiliate_verified=true` with an approved tracking URL, but its committed static SEO landing page still exposed only the generic official link. This creates a direct revenue attribution leak for organic/search visitors and causes `test_public_seo_integrity.py` to flag verified-affiliate CTA drift.

This PR adds the exact verified AWeber tracking URL to the static tool page as a separate sponsored CTA while preserving the official site link. No paid service or deployment change is introduced here.