### PR TITLE
feat(GlobalSaaSHub): activate verified Vista Social affiliate CTAs

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/vista-social-vs-bolddesk.html
+++ b/projects/GlobalSaaSHub/public/compare/vista-social-vs-bolddesk.html
@@ -157,7 +157,7 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://vistasocial.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Vista Social →</a>
+          <a data-cta="affiliate" href="https://vistasocial.com?fpr=sangkwon14" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Vista Social →</a>
           <a href="https://www.bolddesk.com/?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get BoldDesk →</a>
         </div>
       </div>

--- a/projects/GlobalSaaSHub/public/compare/vista-social-vs-notion-ai.html
+++ b/projects/GlobalSaaSHub/public/compare/vista-social-vs-notion-ai.html
@@ -157,7 +157,7 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://vistasocial.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Vista Social →</a>
+          <a data-cta="affiliate" href="https://vistasocial.com?fpr=sangkwon14" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Vista Social →</a>
           <a href="https://www.notion.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Notion AI →</a>
         </div>
       </div>

--- a/projects/GlobalSaaSHub/public/tool/vista-social.html
+++ b/projects/GlobalSaaSHub/public/tool/vista-social.html
@@ -125,7 +125,10 @@
             <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
           </div>
-          <a data-cta="official" href="https://vistasocial.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Vista Social Site</span><span>→</span></a>
+          <div class="flex flex-col sm:flex-row gap-2">
+            <a data-cta="official" href="https://vistasocial.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Vista Social Site</span><span>→</span></a>
+            <a data-cta="affiliate" href="https://vistasocial.com?fpr=sangkwon14" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center border border-purple-500 hover:bg-purple-500 transition-all flex items-center justify-center gap-2"><span>Try Vista Social</span><span>→</span></a>
+          </div>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->


### PR DESCRIPTION
## Revenue impact
Vista Social approved COSHUMA on 2026-09-01 and supplied the exact customer-facing referral URL `https://vistasocial.com?fpr=sangkwon14`. The current static SEO tool page and two high-intent comparison pages still point Vista Social visitors to the non-affiliate homepage, creating an attribution leak.

## Changes
- add a separate verified affiliate CTA to `tool/vista-social.html` while preserving the official link
- route Vista Social purchase-intent CTAs on `vista-social-vs-bolddesk.html` and `vista-social-vs-notion-ai.html` through the exact approved referral URL
- mark affiliate links `data-cta="affiliate"` and `rel="sponsored noopener noreferrer"`

Evidence: approval email from Vista Social / FirstPromoter explicitly states “You've been approved” and gives this exact referral URL. No paid service, ad spend, subscription, or guessed link is introduced.