### PR TITLE
Optimize Unbounce revenue landing for verified Make.com alternative

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/unbounce.html
+++ b/projects/GlobalSaaSHub/public/tool/unbounce.html
@@ -105,13 +105,13 @@
           <div>
             <div class="text-[11px] uppercase font-extrabold tracking-wider text-purple-300">Decision path</div>
             <h2 class="text-xl font-bold text-white mt-1">Comparing Unbounce with Make.com?</h2>
-            <p class="text-sm text-slate-300 mt-2 leading-relaxed">Use the side-by-side comparison before choosing. If Make.com fits your workflow, the verified partner link below is the tracked COSHUMA revenue link.</p>
+            <p class="text-sm text-slate-300 mt-2 leading-relaxed">Use the side-by-side comparison before choosing. If Make.com fits your workflow, the verified partner link below can credit COSHUMA for a qualifying referral.</p>
           </div>
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <a href="/compare/make-com-vs-unbounce.html" class="px-5 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Compare Unbounce vs Make.com →</a>
             <a data-cta="affiliate" href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Explore Make.com via Verified Partner Link →</a>
           </div>
-          <p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if you purchase through the verified partner link, at no added cost to you.</p>
+          <p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if you purchase through this verified partner link.</p>
         </div>
 
         <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">

--- a/projects/GlobalSaaSHub/public/tool/unbounce.html
+++ b/projects/GlobalSaaSHub/public/tool/unbounce.html
@@ -3,17 +3,15 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Unbounce Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="A leading landing page builder that empowers marketers to create high-converting landing pages and pop-ups without any coding required.... Discover features, pricing (See official pricing), and official links for Unbounce on GlobalSaaSHub." />
+    <title>Unbounce Pricing, Features & Alternatives (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Compare Unbounce pricing, landing-page features, and alternatives. Review Unbounce vs Make.com and explore verified official and partner links on GlobalSaaSHub." />
     <link rel="canonical" href="https://coshuma.com/tool/unbounce.html" />
-    
-    <!-- Open Graph SEO Tags -->
+
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/unbounce.html" />
-    <meta property="og:title" content="Unbounce Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="A leading landing page builder that empowers marketers to create high-converting landing pages and pop-ups without any coding required.... Check rating, pricing, and features." />
+    <meta property="og:title" content="Unbounce Pricing, Features & Alternatives (2026) | GlobalSaaSHub" />
+    <meta property="og:description" content="Compare Unbounce features and alternatives, including a direct Unbounce vs Make.com decision path." />
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -25,7 +23,6 @@
     }
     </script>
 
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,90 +33,87 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
     <main class="max-w-4xl mx-auto px-4 py-12 w-full">
       <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
         <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
           <div class="flex items-center gap-5">
             <img src="https://www.google.com/s2/favicons?domain=unbounce.com&sz=128" alt="Unbounce logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Coding & Dev Tools</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Unbounce</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2"><span>Coding & Dev Tools</span></div>
+              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Unbounce Pricing, Features & Alternatives</h1>
             </div>
           </div>
-
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
+          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold"><span>Not yet editorially rated</span></div>
         </div>
 
-        <!-- Description -->
         <div class="space-y-3">
           <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">A leading landing page builder that empowers marketers to create high-converting landing pages and pop-ups without any coding required.</p>
+          <p class="text-slate-300 text-base leading-relaxed">Unbounce is a landing page builder for marketers who want to create landing pages and pop-ups without coding. This page also provides a direct comparison path to alternatives when you are deciding which workflow fits your needs.</p>
         </div>
 
-        <!-- Key Features -->
         <div class="space-y-4">
           <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Drag-and-Drop Page Builder</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> A/B Testing & Optimization</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI-Powered Copy Generation</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Conversion Rate Smart Features</div>
+            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> A/B Testing & Optimization</div>
+            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI-Powered Copy Generation</div>
+            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Conversion Rate Smart Features</div>
           </div>
         </div>
 
-        <!-- Pros & Cons Section -->
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
             <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
             <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
+              <li>No-code landing page workflow</li>
+              <li>A/B testing and conversion optimization features</li>
+              <li>Landing-page-focused marketing workflow</li>
             </ul>
           </div>
-
           <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
+            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations</h3>
             <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
+              <li>Pricing should be confirmed on the official site before purchase</li>
+              <li>Alternative automation or website workflows may fit some teams better</li>
             </ul>
           </div>
         </div>
 
-        <!-- Alternatives & Direct Competitors Section -->
         <div class="space-y-4 pt-4 border-t border-[#222538]">
           <h2 class="text-xl font-bold text-white flex items-center justify-between">
             <span>Top Alternatives to Unbounce</span>
             <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
           </h2>
           <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/make-com.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=make.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Make.com</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/jotform.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=jotform.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Jotform</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/webflow.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=webflow.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Webflow</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
+            <a href="/tool/make-com.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=make.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Make.com</span></div><span class="text-[10px] font-extrabold text-emerald-400">Compare</span></a>
+            <a href="/tool/jotform.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=jotform.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Jotform</span></div><span class="text-[10px] font-extrabold text-emerald-400">Compare</span></a>
+            <a href="/tool/webflow.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=webflow.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Webflow</span></div><span class="text-[10px] font-extrabold text-emerald-400">Compare</span></a>
           </div>
         </div>
 
-        <!-- Pricing & Action -->
+        <div class="p-6 rounded-2xl bg-purple-500/5 border border-purple-500/30 space-y-4">
+          <div>
+            <div class="text-[11px] uppercase font-extrabold tracking-wider text-purple-300">Decision path</div>
+            <h2 class="text-xl font-bold text-white mt-1">Comparing Unbounce with Make.com?</h2>
+            <p class="text-sm text-slate-300 mt-2 leading-relaxed">Use the side-by-side comparison before choosing. If Make.com fits your workflow, the verified partner link below is the tracked COSHUMA revenue link.</p>
+          </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <a href="/compare/make-com-vs-unbounce.html" class="px-5 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Compare Unbounce vs Make.com →</a>
+            <a data-cta="affiliate" href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Explore Make.com via Verified Partner Link →</a>
+          </div>
+          <p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if you purchase through the verified partner link, at no added cost to you.</p>
+        </div>
+
         <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
           <div>
             <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
@@ -128,41 +122,24 @@
           <a data-cta="official" href="https://unbounce.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Unbounce Site</span><span>→</span></a>
         </div>
 
-        <!-- Claim Profile & Official Founder Badge Section -->
         <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
           <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Unbounce?</span>
-            </div>
+            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm"><span>🏆 Are you the founder of Unbounce?</span></div>
             <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
           </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Unbounce Profile ($49/yr)
-            </a>
-          </div>
+          <p class="text-xs text-slate-400 leading-relaxed">Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:</p>
+          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.</div>
+          <div class="flex flex-col sm:flex-row items-center gap-3"><a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">⚡ Claim Unbounce Profile ($49/yr)</a></div>
           <div class="relative pt-2">
             <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
             <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/unbounce.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Unbounce Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
           </div>
         </div>
-
-
       </div>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
Revenue-first free optimization based on the latest checked Search Console snapshot: `unbounce` has 82 impressions and 0 clicks. This keeps the official Unbounce CTA, sharpens the search snippet toward pricing/features/alternatives, adds a direct internal comparison path to Make.com vs Unbounce, and adds the already verified Make.com partner URL (`https://www.make.com/?pc=coshuma`) with a clear affiliate disclosure. No pricing claims were invented and no paid services are added.