### PR TITLE
Optimize Pipedrive search intent for verified GoHighLevel revenue path

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/pipedrive.html
+++ b/projects/GlobalSaaSHub/public/tool/pipedrive.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Pipedrive Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Pipedrive is a sales-focused CRM platform designed to help small and medium businesses manage their sales pipeline, track deals, and automate workflow... Discover features, pricing (See official pricing), and official links for Pipedrive on GlobalSaaSHub." />
+    <title>Pipedrive Pricing, Features & Alternatives (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Research Pipedrive pricing, CRM features, and alternatives for 2026. Review the official Pipedrive option and compare a verified GoHighLevel alternative for agency-focused sales and marketing workflows." />
     <link rel="canonical" href="https://coshuma.com/tool/pipedrive.html" />
     
     <!-- Open Graph SEO Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/pipedrive.html" />
-    <meta property="og:title" content="Pipedrive Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Pipedrive is a sales-focused CRM platform designed to help small and medium businesses manage their sales pipeline, track deals, and automate workflow... Check rating, pricing, and features." />
+    <meta property="og:title" content="Pipedrive Pricing, Features & Alternatives (2026) | GlobalSaaSHub" />
+    <meta property="og:description" content="Research Pipedrive pricing and features, then compare a verified GoHighLevel alternative for agency-focused CRM, sales, and marketing workflows." />
 
     <!-- JSON-LD Structured Data for Google Indexing -->
     <script type="application/ld+json">
@@ -112,11 +112,29 @@
             <span>Top Alternatives to Pipedrive</span>
             <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
           </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
             <a href="/tool/privy.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=privy.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Privy</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
 <a href="/tool/reply-io.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=reply.io&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Reply.io</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
 <a href="/tool/omnisend.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=omnisend.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Omnisend</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
+<a href="/tool/gohighlevel.html" class="p-3.5 rounded-xl bg-[#181a29] border border-purple-500/30 hover:border-purple-400 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=gohighlevel.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">GoHighLevel</span></div><span class="text-[10px] font-extrabold text-purple-300">Agency CRM alternative</span></a>
           </div>
+        </div>
+
+        <!-- Verified Revenue Alternative -->
+        <div class="p-6 rounded-2xl bg-purple-500/5 border border-purple-500/30 space-y-4">
+          <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-3">
+            <div>
+              <div class="text-[10px] uppercase font-extrabold tracking-[0.16em] text-purple-300">Alternative for agency workflows</div>
+              <h2 class="text-xl font-black text-white mt-1">Compare Pipedrive with GoHighLevel</h2>
+              <p class="text-sm text-slate-300 mt-2 leading-relaxed">If you are evaluating Pipedrive for an agency or an all-in-one sales and marketing workflow, GoHighLevel is another CRM option worth comparing. GlobalSaaSHub has a verified affiliate relationship with GoHighLevel; Pipedrive itself remains linked to its official website below.</p>
+            </div>
+            <span class="text-[10px] font-extrabold px-2.5 py-1 rounded-full border border-emerald-500/30 bg-emerald-500/10 text-emerald-300 whitespace-nowrap">Verified affiliate link</span>
+          </div>
+          <div class="flex flex-col sm:flex-row gap-3">
+            <a href="/tool/gohighlevel.html" class="px-5 py-3 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Review GoHighLevel on GlobalSaaSHub</a>
+            <a data-cta="affiliate" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Visit GoHighLevel via Verified Affiliate Link →</a>
+          </div>
+          <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: GlobalSaaSHub may earn a commission if you purchase through the verified GoHighLevel affiliate link, at no additional cost to you. This does not alter editorial rankings or ratings.</p>
         </div>
 
         <!-- Pricing & Action -->


### PR DESCRIPTION
Revenue-first, zero-cost change based on the latest COSHUMA Search Console snapshot: `pipedrive pricing` has 46 impressions and 0 clicks. Pipedrive itself has no verified affiliate URL, so this keeps the official Pipedrive CTA intact while improving pricing/alternatives search intent and adding a clearly disclosed, verified GoHighLevel affiliate alternative (`https://www.gohighlevel.com/?fp_ref=sangkwon56`).

Scope:
- retitle/describe the Pipedrive landing for pricing + alternatives intent
- add GoHighLevel as an internal alternative
- add a clearly disclosed verified affiliate CTA without misrepresenting Pipedrive as an affiliate partner
- preserve canonical, JSON-LD, official Pipedrive CTA, and founder/sponsorship flow

No paid services or ads involved.