### PR TITLE
Optimize Brand24 search intent with verified Followr revenue path

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/brand24.html
+++ b/projects/GlobalSaaSHub/public/tool/brand24.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Brand24 Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="An essential social media monitoring tool that helps businesses track mentions, analyze sentiment, and understand their online presence.... Discover features, pricing (See official pricing), and official links for Brand24 on GlobalSaaSHub." />
+    <title>Brand24 Pricing, Features & Alternatives (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Review Brand24 for social media monitoring, pricing, features, and alternatives. Compare Brand24 with social media workflow options before choosing a tool." />
     <link rel="canonical" href="https://coshuma.com/tool/brand24.html" />
     
     <!-- Open Graph SEO Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/brand24.html" />
-    <meta property="og:title" content="Brand24 Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="An essential social media monitoring tool that helps businesses track mentions, analyze sentiment, and understand their online presence.... Check rating, pricing, and features." />
+    <meta property="og:title" content="Brand24 Pricing, Features & Alternatives (2026) | GlobalSaaSHub" />
+    <meta property="og:description" content="Review Brand24 for social media monitoring and compare features, pricing information, and relevant alternatives." />
 
     <!-- JSON-LD Structured Data for Google Indexing -->
     <script type="application/ld+json">
@@ -113,9 +113,9 @@
             <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
           </h2>
           <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <a href="/tool/followr.html" class="p-3.5 rounded-xl bg-[#181a29] border border-purple-500/30 hover:border-purple-400 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=followr.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Followr</span></div><span class="text-[10px] font-extrabold text-emerald-400">Social workflow</span></a>
             <a href="/tool/text-cortex.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=textcortex.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Text Cortex</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
 <a href="/tool/triple-whale.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=triplewhale.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Triple Whale</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/time2book.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=time2book.me&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Time2book</span></div><span class="text-[10px] font-extrabold text-emerald-400">Contact for pricing.</span></a>
           </div>
         </div>
 
@@ -126,6 +126,17 @@
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
           </div>
           <a data-cta="official" href="https://brand24.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Brand24 Site</span><span>→</span></a>
+        </div>
+
+        <!-- Revenue-safe alternative path -->
+        <div class="p-6 rounded-2xl bg-purple-500/5 border border-purple-500/25 space-y-3">
+          <h2 class="text-lg font-bold text-white">Need social media workflow automation instead?</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">Brand24 focuses on monitoring mentions and sentiment. If your priority is managing and growing a social media presence with automation and AI-assisted workflows, compare Followr before deciding.</p>
+          <div class="flex flex-col sm:flex-row gap-3">
+            <a href="/tool/followr.html" class="px-5 py-3 rounded-xl font-bold text-sm border border-purple-500/30 text-purple-200 text-center hover:bg-purple-500/10 transition-all">Review Followr</a>
+            <a data-cta="affiliate" href="https://followr.ai/?ref=support22" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center hover:bg-purple-500 transition-all">Try Followr →</a>
+          </div>
+          <p class="text-[11px] text-slate-500">Affiliate disclosure: GlobalSaaSHub may earn a commission if you purchase through the Followr link, at no extra cost to you.</p>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->


### PR DESCRIPTION
Revenue-first, zero-cost change based on the latest stored COSHUMA Search Console snapshot: `brand24` has 44 impressions and 0 clicks. Gmail also confirms the Brand24 affiliate application is still only submitted/pending, so this PR does not invent or use a Brand24 affiliate URL.

Changes:
- sharpen Brand24 title/meta/OG toward pricing + alternatives intent
- replace an irrelevant alternative slot with Followr, a verified social-media workflow affiliate already approved in COSHUMA
- preserve the official Brand24 CTA
- add a clearly disclosed, separate Followr affiliate CTA using the exact verified URL `https://followr.ai/?ref=support22`

No paid service, ad spend, subscription, or guessed tracking URL is introduced.