### PR TITLE
Optimize Beefree search intent with verified AWeber revenue path

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/beefree.html
+++ b/projects/GlobalSaaSHub/public/tool/beefree.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Beefree Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Beefree is a drag-and-drop editor for creating beautiful, responsive emails and landing pages quickly and without coding, ideal for marketers and desi... Discover features, pricing (See official pricing), and official links for Beefree on GlobalSaaSHub." />
+    <title>Beefree Pricing, Features & Alternatives (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Compare Beefree pricing, features, email-design workflow, and alternatives. See official Beefree details and compare AWeber as a full email-marketing alternative." />
     <link rel="canonical" href="https://coshuma.com/tool/beefree.html" />
     
     <!-- Open Graph SEO Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/beefree.html" />
-    <meta property="og:title" content="Beefree Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Beefree is a drag-and-drop editor for creating beautiful, responsive emails and landing pages quickly and without coding, ideal for marketers and desi... Check rating, pricing, and features." />
+    <meta property="og:title" content="Beefree Pricing, Features & Alternatives (2026) | GlobalSaaSHub" />
+    <meta property="og:description" content="Review Beefree for email and landing-page design, then compare alternatives including AWeber for broader email-marketing workflows." />
 
     <!-- JSON-LD Structured Data for Google Indexing -->
     <script type="application/ld+json">
@@ -117,6 +117,17 @@
 <a href="/tool/aweber.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=aweber.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">AWeber</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
 <a href="/tool/moosend.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=moosend.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Moosend</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
           </div>
+        </div>
+
+        <!-- Revenue-aware comparison path -->
+        <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/20 space-y-3">
+          <h3 class="text-base font-bold text-white">Need email marketing beyond design?</h3>
+          <p class="text-sm text-slate-300 leading-relaxed">Beefree is centered on creating email and landing-page content. If you also need subscriber management, campaigns, and automation, compare AWeber before choosing your workflow.</p>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <a href="/compare/beefree-vs-aweber.html" class="px-5 py-3 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Compare Beefree vs AWeber →</a>
+            <a data-cta="affiliate" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center hover:brightness-110 transition-all">Try AWeber via Verified Affiliate Link →</a>
+          </div>
+          <p class="text-[11px] text-slate-500">Affiliate disclosure: GlobalSaaSHub may earn a commission if you purchase through the AWeber link, at no extra cost to you.</p>
         </div>
 
         <!-- Pricing & Action -->


### PR DESCRIPTION
Revenue-first, zero-cost change based on the latest stored COSHUMA Search Console snapshot: `beefree` has 36 impressions and 0 clicks. Beefree has no verified affiliate URL, so this PR preserves the official Beefree CTA while improving alternatives intent and adding a clearly disclosed, verified AWeber affiliate alternative (`https://www.aweber.com/easy-email.htm?id=561868`).

Changes:
- sharpen Beefree title/meta/OG toward pricing + alternatives intent
- add a direct internal link to the existing Beefree vs AWeber comparison page
- add a separate verified AWeber affiliate CTA with `rel="sponsored noopener noreferrer"`
- preserve canonical, JSON-LD, official Beefree CTA, and founder/sponsorship flow

No paid service, ad spend, subscription, or guessed tracking URL is introduced.