### PR TITLE
Optimize BoldSign buyer-intent landing with verified pricing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/boldsign.html
+++ b/projects/GlobalSaaSHub/public/tool/boldsign.html
@@ -3,29 +3,24 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>BoldSign Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="A secure and efficient e-signature solution that streamlines document signing workflows, making legal agreements faster and more convenient.... Discover features, pricing (See official pricing), and official links for BoldSign on GlobalSaaSHub." />
+    <title>BoldSign Pricing, Free Trial & Docusign Alternative (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Compare BoldSign pricing, its 30-day free trial, unlimited-envelope Business plan, audit trails, API options, and how its published pricing compares with Docusign before you buy." />
     <link rel="canonical" href="https://coshuma.com/tool/boldsign.html" />
-    
-    <!-- Open Graph SEO Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/boldsign.html" />
-    <meta property="og:title" content="BoldSign Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="A secure and efficient e-signature solution that streamlines document signing workflows, making legal agreements faster and more convenient.... Check rating, pricing, and features." />
-
-    <!-- JSON-LD Structured Data for Google Indexing -->
+    <meta property="og:title" content="BoldSign Pricing, Free Trial & Docusign Alternative (2026)" />
+    <meta property="og:description" content="Research BoldSign pricing, unlimited-envelope plans, audit trails, API options and published Docusign pricing before choosing an e-signature platform." />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "BoldSign",
       "operatingSystem": "Web",
-      "applicationCategory": "Workflow Automation",
-      "description": "A secure and efficient e-signature solution that streamlines document signing workflows, making legal agreements faster and more convenient."
+      "applicationCategory": "BusinessApplication",
+      "url": "https://coshuma.com/tool/boldsign.html",
+      "description": "Electronic-signature software with templates, audit trails, integrations and API workflows."
     }
     </script>
-
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,134 +31,106 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
+    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
+      <section class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-6">
         <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=boldsign.com&sz=128" alt="BoldSign logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=boldsign.com&sz=128" alt="BoldSign logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Workflow Automation</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">BoldSign</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">E-signature software</div>
+              <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">BoldSign Pricing & Review</h1>
+              <p class="text-slate-400 text-sm mt-2">Buyer-focused summary checked September 1, 2026.</p>
             </div>
           </div>
+        </div>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
+        <p class="text-slate-300 leading-relaxed">BoldSign is an electronic-signature platform for sending, tracking and managing documents. Its official site currently advertises a 30-day free trial with no credit card required, along with plans aimed at individual senders, teams and higher-volume workflows.</p>
+
+        <div class="p-4 rounded-2xl bg-amber-500/5 border border-amber-500/20 text-xs text-amber-100 leading-relaxed">
+          Affiliate disclosure: the purple BoldSign button on this page uses a verified partner link. GlobalSaaSHub may earn a commission if you buy through it, at no extra cost to you.
+        </div>
+      </section>
+
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <div class="flex items-center justify-between gap-3 flex-wrap">
+          <h2 class="text-2xl font-bold text-white">Current published pricing signals</h2>
+          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">Vendor pages checked Sep 1, 2026</span>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs uppercase tracking-wider text-slate-400 font-bold">Free trial</div>
+            <div class="text-xl font-black text-white mt-1">30 days</div>
+            <p class="text-xs text-slate-400 mt-2">BoldSign advertises no credit card requirement for the trial.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20">
+            <div class="text-xs uppercase tracking-wider text-purple-300 font-bold">Business</div>
+            <div class="text-xl font-black text-emerald-400 mt-1">$15/month/user</div>
+            <p class="text-xs text-slate-400 mt-2">Published with unlimited envelopes and unlimited templates on the vendor site.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20">
+            <div class="text-xs uppercase tracking-wider text-blue-300 font-bold">Premium</div>
+            <div class="text-xl font-black text-emerald-400 mt-1">$99/month</div>
+            <p class="text-xs text-slate-400 mt-2">Published with 250 envelopes/month, unlimited templates and unlimited users.</p>
           </div>
         </div>
+        <p class="text-[10px] text-slate-500">Prices are USD figures published by BoldSign and can change by billing cycle, region, taxes or promotion. Confirm the current checkout price before purchase.</p>
+      </section>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">A secure and efficient e-signature solution that streamlines document signing workflows, making legal agreements faster and more convenient.</p>
-        </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Legally Binding E-signatures</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Secure Document Handling</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Audit Trails & History</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Integration Capabilities</div>
-          </div>
-        </div>
-
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-bold text-white">BoldSign vs Docusign: what changes for a buyer?</h2>
+        <p class="text-slate-300 text-sm leading-relaxed">For buyers comparing e-signature costs, the biggest published difference is envelope allocation. BoldSign currently advertises its Business option at $15/month/user with unlimited envelopes. Docusign's U.S. eSignature page currently lists Standard at $25/month/user and Business Pro at $40/month/user when billed annually, with 100 envelopes per user per year on those plans.</p>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
+            <div class="font-bold text-purple-300">BoldSign may fit better when</div>
+            <ul class="text-slate-300 text-xs space-y-2 list-disc list-inside">
+              <li>You expect frequent signature requests and want an unlimited-envelope Business plan.</li>
+              <li>You want reusable templates and audit-trail records in an e-signature workflow.</li>
+              <li>You need API or embedded-signing options and want to test with a free developer sandbox.</li>
             </ul>
           </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
+            <div class="font-bold text-blue-300">Verify Docusign directly when</div>
+            <ul class="text-slate-300 text-xs space-y-2 list-disc list-inside">
+              <li>Your organization already depends on Docusign-specific integrations or procurement standards.</li>
+              <li>You need a particular enterprise or regional compliance configuration not covered by public plan summaries.</li>
+              <li>Your real envelope volume or contract terms differ from self-serve plan assumptions.</li>
             </ul>
           </div>
         </div>
+      </section>
 
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to BoldSign</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/notion-ai.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=notion.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Notion AI</span></div><span class="text-[10px] font-extrabold text-emerald-400">Free trial; Business plan with Notion AI at $20/user/month</span></a>
-<a href="/tool/bolddesk.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=bolddesk.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">BoldDesk</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/socialchamp-io.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=socialchamp.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Social Champ</span></div><span class="text-[10px] font-extrabold text-emerald-400">Free plan; paid plans from $4/month billed annually</span></a>
-          </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-bold text-white">Verified capabilities worth checking</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-slate-300">
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Reusable templates</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Downloadable audit trails after signing</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ API and embedded-signing workflows</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Free developer sandbox for API testing</div>
         </div>
+      </section>
 
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://www.boldsign.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official BoldSign Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://boldsign.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit BoldSign via Verified Affiliate Link</span><span>→</span></a>
+      <section class="p-6 rounded-3xl bg-gradient-to-br from-purple-950/40 to-[#131520] border border-purple-500/30 space-y-4 text-center">
+        <h2 class="text-2xl font-black text-white">Check BoldSign's current plan before you buy</h2>
+        <p class="text-slate-300 text-sm max-w-2xl mx-auto">Use the verified partner link to confirm today's trial, plan limits and checkout price directly with BoldSign.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-2xl mx-auto pt-2">
+          <a data-cta="official" href="https://www.boldsign.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-slate-800 hover:bg-slate-700 border border-slate-600 font-extrabold text-xs text-white text-center transition-all">Visit official BoldSign site →</a>
+          <a data-cta="affiliate" data-tool-id="boldsign" href="https://boldsign.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Start BoldSign via verified affiliate link →</a>
         </div>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of BoldSign?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim BoldSign Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/boldsign.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="BoldSign Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
-      </div>
+      </section>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
Revenue-first, zero-cost optimization for an already verified affiliate landing.

Changes:
- retarget title/meta toward BoldSign pricing, free trial and Docusign-alternative intent
- replace generic/unsupported pros-cons copy with vendor-grounded pricing and capability facts checked September 1, 2026
- surface the published 30-day free trial, Business and Premium plan signals
- add a buyer-oriented BoldSign vs Docusign section using current official public pricing
- keep the official-site CTA and exact verified BoldSign affiliate URL `https://boldsign.com?via=sangkwon`
- add clear affiliate disclosure and pricing-change caveat

No paid services, ad spend, guessed tracking URL, editorial rating or unsupported superiority claim is introduced.