### PR TITLE
Resolve current BoldSign and Docusign pricing-page conflicts

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/boldsign.html
+++ b/projects/GlobalSaaSHub/public/tool/boldsign.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BoldSign Pricing, Free Trial & Docusign Alternative (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Compare BoldSign pricing, its 30-day free trial, unlimited-envelope Business plan, audit trails, API options, and how its published pricing compares with Docusign before you buy." />
+    <meta name="description" content="Compare current BoldSign pricing displays, its 30-day free trial, unlimited-envelope Business plan, audit trails, API options, and Docusign alternative considerations before you buy." />
     <link rel="canonical" href="https://coshuma.com/tool/boldsign.html" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/boldsign.html" />
     <meta property="og:title" content="BoldSign Pricing, Free Trial & Docusign Alternative (2026)" />
-    <meta property="og:description" content="Research BoldSign pricing, unlimited-envelope plans, audit trails, API options and published Docusign pricing before choosing an e-signature platform." />
+    <meta property="og:description" content="Research BoldSign pricing displays, unlimited-envelope plans, audit trails, API options and Docusign alternative considerations before choosing an e-signature platform." />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -74,21 +74,21 @@
           </div>
           <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20">
             <div class="text-xs uppercase tracking-wider text-purple-300 font-bold">Business</div>
-            <div class="text-xl font-black text-emerald-400 mt-1">$15/month/user</div>
-            <p class="text-xs text-slate-400 mt-2">Published with unlimited envelopes and unlimited templates on the vendor site.</p>
+            <div class="text-xl font-black text-emerald-400 mt-1">$15–$25/month/user</div>
+            <p class="text-xs text-slate-400 mt-2">BoldSign currently displays both figures depending on billing mode; the plan includes unlimited envelopes and unlimited templates.</p>
           </div>
           <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20">
             <div class="text-xs uppercase tracking-wider text-blue-300 font-bold">Premium</div>
-            <div class="text-xl font-black text-emerald-400 mt-1">$99/month</div>
-            <p class="text-xs text-slate-400 mt-2">Published with 250 envelopes/month, unlimited templates and unlimited users.</p>
+            <div class="text-xl font-black text-emerald-400 mt-1">$99–$138/month</div>
+            <p class="text-xs text-slate-400 mt-2">BoldSign currently displays both figures depending on billing mode; the plan lists 250 envelopes/month, unlimited templates and unlimited users.</p>
           </div>
         </div>
-        <p class="text-[10px] text-slate-500">Prices are USD figures published by BoldSign and can change by billing cycle, region, taxes or promotion. Confirm the current checkout price before purchase.</p>
+        <p class="text-[10px] text-slate-500">Prices are USD figures shown on BoldSign's current public pages and can vary by billing cycle, region, taxes or promotion. Confirm the active checkout price before purchase.</p>
       </section>
 
       <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
         <h2 class="text-2xl font-bold text-white">BoldSign vs Docusign: what changes for a buyer?</h2>
-        <p class="text-slate-300 text-sm leading-relaxed">For buyers comparing e-signature costs, the biggest published difference is envelope allocation. BoldSign currently advertises its Business option at $15/month/user with unlimited envelopes. Docusign's U.S. eSignature page currently lists Standard at $25/month/user and Business Pro at $40/month/user when billed annually, with 100 envelopes per user per year on those plans.</p>
+        <p class="text-slate-300 text-sm leading-relaxed">For buyers comparing e-signature costs, envelope allocation is a useful distinction: BoldSign's Business plan is currently presented with unlimited envelopes. Docusign's public self-serve pages currently show 100 envelopes per user per year on Standard and Business Pro, but Docusign's displayed dollar prices differ across its public storefronts and market pages. For that reason, this page does not hard-code a single Docusign price—confirm the localized checkout before comparing total cost.</p>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
           <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
             <div class="font-bold text-purple-300">BoldSign may fit better when</div>
@@ -103,7 +103,7 @@
             <ul class="text-slate-300 text-xs space-y-2 list-disc list-inside">
               <li>Your organization already depends on Docusign-specific integrations or procurement standards.</li>
               <li>You need a particular enterprise or regional compliance configuration not covered by public plan summaries.</li>
-              <li>Your real envelope volume or contract terms differ from self-serve plan assumptions.</li>
+              <li>Your localized price, envelope volume or negotiated terms could differ from public self-serve pages.</li>
             </ul>
           </div>
         </div>
@@ -121,7 +121,7 @@
 
       <section class="p-6 rounded-3xl bg-gradient-to-br from-purple-950/40 to-[#131520] border border-purple-500/30 space-y-4 text-center">
         <h2 class="text-2xl font-black text-white">Check BoldSign's current plan before you buy</h2>
-        <p class="text-slate-300 text-sm max-w-2xl mx-auto">Use the verified partner link to confirm today's trial, plan limits and checkout price directly with BoldSign.</p>
+        <p class="text-slate-300 text-sm max-w-2xl mx-auto">Use the verified partner link to confirm today's trial, billing mode, plan limits and checkout price directly with BoldSign.</p>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-2xl mx-auto pt-2">
           <a data-cta="official" href="https://www.boldsign.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-slate-800 hover:bg-slate-700 border border-slate-600 font-extrabold text-xs text-white text-center transition-all">Visit official BoldSign site →</a>
           <a data-cta="affiliate" data-tool-id="boldsign" href="https://boldsign.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Start BoldSign via verified affiliate link →</a>


### PR DESCRIPTION
Accuracy correction after fresh vendor verification.

Both vendors currently expose multiple public pricing displays depending on billing mode/storefront. This PR removes the brittle single-price Docusign assertion and makes BoldSign's two current billing displays explicit:
- Business: $15–$25/month/user depending on billing mode, unlimited envelopes/templates
- Premium: $99–$138/month depending on billing mode, 250 envelopes/month, unlimited templates/users
- Docusign: retain the consistent 100 envelopes/user/year comparison but do not hard-code one dollar figure because current official public pages disagree across storefronts/markets

The exact verified BoldSign affiliate URL and disclosure remain unchanged. No paid service or guessed data is introduced.