### PR TITLE
Optimize ElevenLabs pricing landing for affiliate conversion

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/elevenlabs.html
+++ b/projects/GlobalSaaSHub/public/tool/elevenlabs.html
@@ -3,29 +3,27 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ElevenLabs Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="The leading generative voice AI software that creates lifelike speech, voice clones, and sound effects in any language and voice style.... Discover features, pricing (Varies), and official links for ElevenLabs on GlobalSaaSHub." />
+    <title>ElevenLabs Pricing, Free Plan & Voice AI Review (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="ElevenLabs pricing and buyer guide for 2026: Free $0, Starter $6, Creator $22, Pro $99, plus voice cloning, text-to-speech, commercial-use considerations and verified signup links." />
     <link rel="canonical" href="https://coshuma.com/tool/elevenlabs.html" />
-    
-    <!-- Open Graph SEO Tags -->
+
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/elevenlabs.html" />
-    <meta property="og:title" content="ElevenLabs Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="The leading generative voice AI software that creates lifelike speech, voice clones, and sound effects in any language and voice style.... Check rating, pricing, and features." />
+    <meta property="og:title" content="ElevenLabs Pricing & Free Plan (2026) | GlobalSaaSHub" />
+    <meta property="og:description" content="Compare ElevenLabs Free, Starter, Creator and Pro plans, then choose the right voice AI tier for commercial use, cloning and higher-volume generation." />
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "ElevenLabs",
       "operatingSystem": "Web",
-      "applicationCategory": "Voice & Speech AI",
-      "description": "The leading generative voice AI software that creates lifelike speech, voice clones, and sound effects in any language and voice style."
+      "applicationCategory": "MultimediaApplication",
+      "description": "Voice AI platform for text-to-speech, speech-to-text, voice cloning, sound effects, music and audio production.",
+      "url": "https://elevenlabs.io/"
     }
     </script>
 
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,134 +34,100 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
     <main class="max-w-4xl mx-auto px-4 py-12 w-full">
       <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
         <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=elevenlabs.io&sz=128" alt="ElevenLabs logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=elevenlabs.io&sz=128" alt="ElevenLabs logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Voice & Speech AI</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">ElevenLabs</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">Voice & Speech AI</div>
+              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">ElevenLabs Pricing & Free Plan</h1>
+              <p class="text-sm text-slate-400 mt-2">Pricing checked September 1, 2026 against ElevenLabs' official pricing pages.</p>
             </div>
           </div>
+        </div>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
+        <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/20">
+          <p class="text-sm text-slate-300 leading-relaxed"><strong class="text-white">Affiliate disclosure:</strong> GlobalSaaSHub may earn a commission if you start with ElevenLabs through the verified partner link below and later become a qualifying paid subscriber. This does not increase the price you pay.</p>
+        </div>
+
+        <section class="space-y-3">
+          <h2 class="text-xl font-bold text-white">Quick verdict</h2>
+          <p class="text-slate-300 leading-relaxed">ElevenLabs is a strong fit when you need realistic text-to-speech, voice cloning, sound effects or multilingual audio production in one platform. The free plan is enough to test core generation quality, while Starter is the first paid tier that adds a commercial license and instant voice cloning.</p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">Current ElevenLabs pricing</h2>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+              <div class="flex items-center justify-between gap-3"><h3 class="font-extrabold text-white">Free</h3><span class="text-emerald-400 font-black">$0/mo</span></div>
+              <p class="text-xs text-slate-400 mt-2">10,000 credits/month. Includes text-to-speech, speech-to-text, sound effects, Voice Design, music and 3 Studio projects.</p>
+            </div>
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+              <div class="flex items-center justify-between gap-3"><h3 class="font-extrabold text-white">Starter</h3><span class="text-emerald-400 font-black">$6/mo</span></div>
+              <p class="text-xs text-slate-400 mt-2">30,000 credits/month. Adds a commercial license, instant voice cloning, 20 Studio projects and commercial music use.</p>
+            </div>
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+              <div class="flex items-center justify-between gap-3"><h3 class="font-extrabold text-white">Creator</h3><span class="text-emerald-400 font-black">$22/mo</span></div>
+              <p class="text-xs text-slate-400 mt-2">121,000 credits/month. Official pricing currently shows the first month at $11 and adds professional voice cloning.</p>
+            </div>
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+              <div class="flex items-center justify-between gap-3"><h3 class="font-extrabold text-white">Pro</h3><span class="text-emerald-400 font-black">$99/mo</span></div>
+              <p class="text-xs text-slate-400 mt-2">600,000 credits/month. Adds 44.1kHz PCM API output and 192kbps audio quality.</p>
+            </div>
           </div>
-        </div>
+          <p class="text-xs text-slate-500">Higher tiers are also available: Scale $299/month, Business $990/month and Enterprise custom pricing. Taxes, billing options and promotional pricing can change; verify the final checkout before purchase.</p>
+        </section>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">The leading generative voice AI software that creates lifelike speech, voice clones, and sound effects in any language and voice style.</p>
-        </div>
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">Which plan should you choose?</h2>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">Testing voice quality:</strong><span class="text-slate-300"> start with Free before paying.</span></div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">Commercial creator work:</strong><span class="text-slate-300"> Starter is the first paid tier with a commercial license.</span></div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">Professional voice cloning:</strong><span class="text-slate-300"> Creator adds professional voice cloning and more monthly credits.</span></div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">High-volume/API work:</strong><span class="text-slate-300"> compare Pro, Scale or Business based on output volume and team needs.</span></div>
+          </div>
+        </section>
 
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
+        <section class="space-y-4 pt-4 border-t border-[#222538]">
+          <h2 class="text-xl font-bold text-white">Compare ElevenLabs alternatives</h2>
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI Voice Cloning</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Text-to-Speech</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Sound Effects Generator</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Multi-lingual Support</div>
+            <a href="/compare/elevenlabs-vs-murf-ai.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">ElevenLabs vs Murf AI</div><div class="text-xs text-slate-400 mt-1">Compare voice generation workflows and pricing context.</div></a>
+            <a href="/compare/elevenlabs-vs-lovo.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">ElevenLabs vs Lovo</div><div class="text-xs text-slate-400 mt-1">Compare two voice-generation options before choosing a paid plan.</div></a>
           </div>
-        </div>
+        </section>
 
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (Varies)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to ElevenLabs</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/murf-ai.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=murf.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Murf AI</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/lovo.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=lovo.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Lovo</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/synthflow-ai.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=synthflow.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Synthflow AI</span></div><span class="text-[10px] font-extrabold text-emerald-400">Varies by paid referral plan</span></a>
-          </div>
-        </div>
-
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <section class="p-6 rounded-2xl bg-[#181a29] border border-purple-500/30 space-y-4">
           <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">Varies</div>
+            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Best low-risk next step</div>
+            <div class="text-2xl font-extrabold text-white mt-1">Start on the $0 Free plan</div>
+            <p class="text-sm text-slate-400 mt-2">Test the voices and workflow first. Upgrade only if you need commercial rights, cloning or more credits.</p>
           </div>
-          <a data-cta="official" href="https://elevenlabs.io/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official ElevenLabs Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://try.elevenlabs.io/ldc2xmh2x2t5" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit ElevenLabs via Verified Affiliate Link</span><span>→</span></a>
-        </div>
+          <div class="flex flex-col sm:flex-row gap-3">
+            <a data-cta="affiliate" data-tool-id="elevenlabs" href="https://try.elevenlabs.io/ldc2xmh2x2t5" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Start ElevenLabs Free</span><span>→</span></a>
+            <a data-cta="official" href="https://elevenlabs.io/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Check Official Pricing</a>
+          </div>
+          <p class="text-[11px] text-slate-500">Verified partner destination: try.elevenlabs.io/ldc2xmh2x2t5. ElevenLabs states eligible Starter, Creator, Pro and Scale referrals can generate affiliate commission for 12 months; Business uses a lower rate and Enterprise purchases are excluded.</p>
+        </section>
 
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of ElevenLabs?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim ElevenLabs Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/elevenlabs.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="ElevenLabs Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
+        <section class="p-5 rounded-2xl bg-[#0f1119] border border-[#222538] text-xs text-slate-400 leading-relaxed">
+          <strong class="text-slate-300">Sources checked:</strong> ElevenLabs official pricing pages and official affiliate-program terms/partner guide. Pricing and program terms can change, so the official checkout and current program terms control.
+        </section>
       </div>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
Revenue-focused, zero-cost update to the existing ElevenLabs production landing. Replaces generic `Varies`/editorial-placeholder copy with current official pricing and buyer-intent guidance, preserves the verified affiliate URL, adds explicit sponsored disclosure, and links existing ElevenLabs comparison pages. Current pricing and affiliate terms were checked against ElevenLabs official pricing, affiliate program, terms, and partner guide on 2026-09-01. No payment or paid service required.