### PR TITLE
feat(coshuma): sync verified affiliate email outcomes

### DIFF
--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -711,7 +711,11 @@
     "is_manual_override": false,
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
-    "official_evidence_url": "https://brand24.com/"
+    "official_evidence_url": "https://brand24.com/",
+    "affiliate_verified": true,
+    "affiliate_status": "application_submitted",
+    "affiliate_verified_at": "2026-08-31T22:59:47Z",
+    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Brand24 review"]
   },
   {
     "id": "socialchamp-io",
@@ -778,7 +782,11 @@
     "is_manual_override": false,
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
-    "official_evidence_url": "https://triplewhale.com/"
+    "official_evidence_url": "https://triplewhale.com/",
+    "affiliate_verified": true,
+    "affiliate_status": "application_submitted",
+    "affiliate_verified_at": "2026-08-31T23:01:13Z",
+    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Triple Whale review"]
   },
   {
     "id": "boldsign",
@@ -1068,7 +1076,11 @@
     "is_manual_override": false,
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
-    "official_evidence_url": "https://www.semrush.com/"
+    "official_evidence_url": "https://www.semrush.com/",
+    "affiliate_verified": true,
+    "affiliate_status": "rejected",
+    "affiliate_verified_at": "2026-09-01T08:45:37Z",
+    "affiliate_evidence_markers": ["Impact email", "Semrush Contract Terms Declined"]
   },
   {
     "id": "hubspot",
@@ -1554,7 +1566,7 @@
     "category": "workflow_auto",
     "category_display": "Workflow Automation",
     "description": "Vista Social is an AI-powered platform for comprehensive social media management, offering tools for publishing, engagement, analytics, and team collaboration.",
-    "affiliate_url": null,
+    "affiliate_url": "https://vistasocial.com?fpr=sangkwon14",
     "pricing": "See official pricing",
     "key_features": [
       "AI-powered social media management",
@@ -1576,7 +1588,11 @@
     "is_manual_override": false,
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
-    "official_evidence_url": "https://vistasocial.com/"
+    "official_evidence_url": "https://vistasocial.com/",
+    "affiliate_verified": true,
+    "affiliate_status": "approved_tracking",
+    "affiliate_verified_at": "2026-08-31T22:02:27Z",
+    "affiliate_evidence_markers": ["Vista Social approval email", "unique referral link in email body"]
   },
   {
     "id": "gravity-forms",
@@ -2383,9 +2399,9 @@
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://www.getresponse.com/",
     "affiliate_verified": true,
-    "affiliate_status": "application_submitted",
-    "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for GetResponse review"]
+    "affiliate_status": "rejected",
+    "affiliate_verified_at": "2026-09-01T09:14:55Z",
+    "affiliate_evidence_markers": ["PartnerStack decision email", "GetResponse application declined"]
   },
   {
     "id": "kit",
@@ -4056,7 +4072,11 @@
     "is_manual_override": false,
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
-    "official_evidence_url": "https://www.claap.ai/"
+    "official_evidence_url": "https://www.claap.ai/",
+    "affiliate_verified": true,
+    "affiliate_status": "application_not_submitted",
+    "affiliate_verified_at": "2026-08-31T16:05:00Z",
+    "affiliate_evidence_markers": ["Claap affiliate manager email", "application did not go through", "correct PartnerStack link provided"]
   },
   {
     "id": "cloudtalk",

--- a/projects/GlobalSaaSHub/data/tools.next.json
+++ b/projects/GlobalSaaSHub/data/tools.next.json
@@ -747,7 +747,11 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://brand24.com/",
-    "affiliate_url": null
+    "affiliate_url": null,
+    "affiliate_verified": true,
+    "affiliate_status": "application_submitted",
+    "affiliate_verified_at": "2026-08-31T22:59:47Z",
+    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Brand24 review"]
   },
   {
     "id": "socialchamp-io",
@@ -814,7 +818,11 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://triplewhale.com/",
-    "affiliate_url": null
+    "affiliate_url": null,
+    "affiliate_verified": true,
+    "affiliate_status": "application_submitted",
+    "affiliate_verified_at": "2026-08-31T23:01:13Z",
+    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Triple Whale review"]
   },
   {
     "id": "boldsign",
@@ -1099,7 +1107,11 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://www.semrush.com/",
-    "affiliate_url": null
+    "affiliate_url": null,
+    "affiliate_verified": true,
+    "affiliate_status": "rejected",
+    "affiliate_verified_at": "2026-09-01T08:45:37Z",
+    "affiliate_evidence_markers": ["Impact email", "Semrush Contract Terms Declined"]
   },
   {
     "id": "hubspot",
@@ -1592,7 +1604,11 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://vistasocial.com/",
-    "affiliate_url": null
+    "affiliate_url": "https://vistasocial.com?fpr=sangkwon14",
+    "affiliate_verified": true,
+    "affiliate_status": "approved_tracking",
+    "affiliate_verified_at": "2026-08-31T22:02:27Z",
+    "affiliate_evidence_markers": ["Vista Social approval email", "unique referral link in email body"]
   },
   {
     "id": "gravity-forms",
@@ -2398,11 +2414,11 @@
     "official_evidence_url": "https://www.getresponse.com/",
     "affiliate_url": null,
     "affiliate_verified": true,
-    "affiliate_status": "application_submitted",
-    "affiliate_verified_at": "2026-09-01T00:00:00Z",
+    "affiliate_status": "rejected",
+    "affiliate_verified_at": "2026-09-01T09:14:55Z",
     "affiliate_evidence_markers": [
-      "PartnerStack application received",
-      "submitted for GetResponse review"
+      "PartnerStack decision email",
+      "GetResponse application declined"
     ]
   },
   {
@@ -4082,7 +4098,11 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://www.claap.ai/",
-    "affiliate_url": null
+    "affiliate_url": null,
+    "affiliate_verified": true,
+    "affiliate_status": "application_not_submitted",
+    "affiliate_verified_at": "2026-08-31T16:05:00Z",
+    "affiliate_evidence_markers": ["Claap affiliate manager email", "application did not go through", "correct PartnerStack link provided"]
   },
   {
     "id": "cloudtalk",

--- a/projects/GlobalSaaSHub/public/tool/systeme-io.html
+++ b/projects/GlobalSaaSHub/public/tool/systeme-io.html
@@ -51,7 +51,7 @@
         <strong class="text-amber-300">Pricing verification note:</strong> Systeme.io's main official pricing page currently shows Free at $0, Webinar at $47/month and Unlimited at $97/month. Official Systeme.io landing pages currently show different Startup prices ($17 or $27/month), so check the final vendor checkout for the exact Startup offer available to you.
       </div>
       <div class="grid sm:grid-cols-2 gap-3">
-        <a data-cta="affiliate" href="https://systeme.io/?sa=sa0279779913657b281b5d2c1fed58680413f14dca" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold text-center bg-gradient-to-r from-purple-600 to-indigo-600 text-white">Start Systeme.io free →</a>
+        <a data-cta="affiliate" href="https://systeme.io/?sa=sa0279779913657b281b5d2c1fed58680413f14dca" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold text-center bg-gradient-to-r from-purple-600 to-indigo-600 text-white">Start Systeme.io free via Verified Affiliate Link →</a>
         <a data-cta="official" href="https://systeme.io/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-4 rounded-xl font-bold text-center bg-slate-800 border border-slate-600 text-white">Check official pricing →</a>
       </div>
       <p class="text-[11px] text-slate-500">Affiliate disclosure: the first button uses GlobalSaaSHub's verified Systeme.io affiliate link. If you later buy, GlobalSaaSHub may earn a commission at no additional cost to you.</p>


### PR DESCRIPTION
## Summary
- add the verified Vista Social referral URL from the approval email
- update GetResponse and Semrush to rejected
- record Brand24 and Triple Whale as submitted
- record Claap as not submitted based on the affiliate manager email
- restore the explicit Systeme.io affiliate CTA disclosure phrase

## Verification
- link integrity: 151/151 passed
- lint passed with one pre-existing warning
- production build passed
- npm audit: 0 vulnerabilities