### PR TITLE
feat(coshuma): add verified Text affiliate link

### DIFF
--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -3451,7 +3451,7 @@
     "category": "chatbots_support",
     "category_display": "Chatbots & Support",
     "description": "An AI-powered customer service platform unifying live chat, helpdesk functionalities, and chatbot automation into one seamless system.",
-    "affiliate_url": null,
+    "affiliate_url": "https://www.text.com/?a=8IetMhQvR&utm_campaign=pp_text-wins-martech-awards&utm_source=PP",
     "pricing": "See official pricing",
     "key_features": [
       "AI customer service platform",
@@ -3475,9 +3475,9 @@
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://text.com/",
     "affiliate_verified": true,
-    "affiliate_status": "approved_account",
-    "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["Welcome to the Text Partner Program"]
+    "affiliate_status": "approved_tracking",
+    "affiliate_verified_at": "2026-09-01T10:04:07Z",
+    "affiliate_evidence_markers": ["Text Partner Program dashboard", "Share your default signup link without campaign customization"]
   },
   {
     "id": "typedesk",

--- a/projects/GlobalSaaSHub/data/tools.next.json
+++ b/projects/GlobalSaaSHub/data/tools.next.json
@@ -3491,12 +3491,13 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://text.com/",
-    "affiliate_url": null,
+    "affiliate_url": "https://www.text.com/?a=8IetMhQvR&utm_campaign=pp_text-wins-martech-awards&utm_source=PP",
     "affiliate_verified": true,
-    "affiliate_status": "approved_account",
-    "affiliate_verified_at": "2026-09-01T00:00:00Z",
+    "affiliate_status": "approved_tracking",
+    "affiliate_verified_at": "2026-09-01T10:04:07Z",
     "affiliate_evidence_markers": [
-      "Welcome to the Text Partner Program"
+      "Text Partner Program dashboard",
+      "Share your default signup link without campaign customization"
     ]
   },
   {


### PR DESCRIPTION
## Summary
- replace the approved-account placeholder for Text with the verified default signup tracking link
- mark Text as approved_tracking with dashboard evidence

## Validation
- link integrity: PASS (151/151)
- npm audit: 0 vulnerabilities
- lint: pass with one pre-existing warning
- production build: pass