### PR TITLE
feat(coshuma): publish Text affiliate CTAs

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/text-vs-gallabox.html
+++ b/projects/GlobalSaaSHub/public/compare/text-vs-gallabox.html
@@ -71,7 +71,7 @@
             <span>🧠 Decision Summary & Evidence</span>
           </h2>
           <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
+            ✓ Publicly Available Data (Last updated: September 01, 2026)
           </span>
         </div>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
@@ -81,7 +81,7 @@
               You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
             </p>
             <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
+              Source: Official Documentation & Public Pricing Specs (September 01, 2026)
             </div>
           </div>
           <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
@@ -90,7 +90,7 @@
               You want an alternative approach with See official pricing pricing structure and Not rated.
             </p>
             <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
+              Source: Official Vendor Specifications & Benchmark Data (September 01, 2026)
             </div>
           </div>
         </div>
@@ -157,7 +157,7 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://text.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Text →</a>
+          <a href="https://www.text.com/?a=8IetMhQvR&utm_campaign=pp_text-wins-martech-awards&utm_source=PP" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Text →</a>
           <a href="https://www.gallabox.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Gallabox →</a>
         </div>
       </div>

--- a/projects/GlobalSaaSHub/public/compare/text-vs-gohighlevel.html
+++ b/projects/GlobalSaaSHub/public/compare/text-vs-gohighlevel.html
@@ -71,7 +71,7 @@
             <span>🧠 Decision Summary & Evidence</span>
           </h2>
           <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
+            ✓ Publicly Available Data (Last updated: September 01, 2026)
           </span>
         </div>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
@@ -81,7 +81,7 @@
               You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
             </p>
             <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
+              Source: Official Documentation & Public Pricing Specs (September 01, 2026)
             </div>
           </div>
           <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
@@ -90,7 +90,7 @@
               You want an alternative approach with See official pricing pricing structure and Not rated.
             </p>
             <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
+              Source: Official Vendor Specifications & Benchmark Data (September 01, 2026)
             </div>
           </div>
         </div>
@@ -157,7 +157,7 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://text.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Text →</a>
+          <a href="https://www.text.com/?a=8IetMhQvR&utm_campaign=pp_text-wins-martech-awards&utm_source=PP" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Text →</a>
           <a href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get GoHighLevel →</a>
         </div>
       </div>

--- a/projects/GlobalSaaSHub/public/tool/text.html
+++ b/projects/GlobalSaaSHub/public/tool/text.html
@@ -126,6 +126,7 @@
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
           </div>
           <a data-cta="official" href="https://text.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Text Site</span><span>→</span></a>
+<a data-cta="affiliate" href="https://www.text.com/?a=8IetMhQvR&utm_campaign=pp_text-wins-martech-awards&utm_source=PP" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Text via Verified Affiliate Link</span><span>→</span></a>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->


### PR DESCRIPTION
## Summary
- publish the verified Text affiliate CTA on the Text tool page
- route Text comparison CTAs through the verified tracking link

## Validation
- generated from the merged affiliate data
- tracking URL is account-specific and verified in the Text Partner dashboard