### PR TITLE
Optimize Descript landing for proven affiliate click traffic

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/descript.html
+++ b/projects/GlobalSaaSHub/public/tool/descript.html
@@ -1,169 +1,118 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Descript Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Descript is an all-in-one AI-powered tool for transcription, audio/video editing, and podcast production, allowing you to edit media like a document. ... Discover features, pricing (See official pricing), and official links for Descript on GlobalSaaSHub." />
-    <link rel="canonical" href="https://coshuma.com/tool/descript.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://coshuma.com/tool/descript.html" />
-    <meta property="og:title" content="Descript Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Descript is an all-in-one AI-powered tool for transcription, audio/video editing, and podcast production, allowing you to edit media like a document. ... Check rating, pricing, and features." />
-
-    <!-- JSON-LD Structured Data for Google Indexing -->
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "Descript",
-      "operatingSystem": "Web",
-      "applicationCategory": "Video & Shorts Gen",
-      "description": "Descript is an all-in-one AI-powered tool for transcription, audio/video editing, and podcast production, allowing you to edit media like a document. Streamline your content creation workflow with powerful, intuitive features for creators."
-    }
-    </script>
-
-    <!-- Tailwind & Fonts -->
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Descript Pricing, Free Plan & AI Video Editor Review (2026) | GlobalSaaSHub</title>
+  <meta name="description" content="Compare Descript's free plan, Hobbyist and Creator pricing, AI video editing features, transcription, Studio Sound, Underlord and best-fit use cases. Start free through the verified Descript partner link." />
+  <link rel="canonical" href="https://coshuma.com/tool/descript.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://coshuma.com/tool/descript.html" />
+  <meta property="og:title" content="Descript Pricing, Free Plan & AI Video Editor Review (2026)" />
+  <meta property="og:description" content="Descript pricing and buyer guide for text-based video editing, transcription, Studio Sound, clips and AI-assisted editing." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"SoftwareApplication",
+    "name":"Descript",
+    "operatingSystem":"Web, Windows, macOS",
+    "applicationCategory":"MultimediaApplication",
+    "description":"AI-powered audio and video editor with text-based editing, transcription, Studio Sound, clips and AI-assisted editing.",
+    "offers":{"@type":"Offer","price":"0","priceCurrency":"USD","description":"Free plan available"}
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}
+  </style>
+</head>
+<body class="min-h-screen flex flex-col justify-between">
+<header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+  <div class="max-w-6xl mx-auto flex items-center justify-between">
+    <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div><span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span></a>
+    <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
+  </div>
+</header>
+<main class="max-w-4xl mx-auto px-4 py-12 w-full">
+  <div class="p-6 md:p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
+    <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
+      <div class="flex items-center gap-5">
+        <img src="https://www.google.com/s2/favicons?domain=descript.com&sz=128" alt="Descript logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" />
+        <div><div class="inline-flex items-center px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">AI Video & Audio Editing</div><h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Descript Pricing & Free Plan</h1></div>
       </div>
-    </header>
+      <div class="bg-emerald-500/10 border border-emerald-500/20 text-emerald-300 px-4 py-2 rounded-xl text-sm font-bold">Free plan available</div>
+    </div>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
-          <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=descript.com&sz=128" alt="Descript logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
-            <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Video & Shorts Gen</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Descript</h1>
-            </div>
-          </div>
-
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
-        </div>
-
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">Descript is an all-in-one AI-powered tool for transcription, audio/video editing, and podcast production, allowing you to edit media like a document. Streamline your content creation workflow with powerful, intuitive features for creators.</p>
-        </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI transcription</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Text-based video editing</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Podcast production tools</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Screen recording functionality</div>
-          </div>
-        </div>
-
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Descript</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/tubebuddy.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=tubebuddy.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">TubeBuddy</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/outlierkit.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=outlierkit.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">OutlierKit</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/pictory.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=pictory.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Pictory</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
-
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://www.descript.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Descript Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://get.descript.com/ole5fu20j5sq" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Descript via Verified Affiliate Link</span><span>→</span></a>
-        </div>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Descript?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Descript Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/descript.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Descript Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
+    <section class="space-y-4">
+      <h2 class="text-xl font-bold text-white">Best for creators who want to edit video by editing text</h2>
+      <p class="text-slate-300 leading-relaxed">Descript turns recorded audio and video into editable text, so deleting words can edit the underlying media. It combines transcription, screen recording, captions, audio cleanup, short-form clip creation and AI-assisted editing in one workflow.</p>
+      <div class="p-4 rounded-2xl bg-amber-500/5 border border-amber-500/20 text-sm text-slate-300"><strong class="text-amber-300">Affiliate disclosure:</strong> GlobalSaaSHub may earn a commission if you sign up through the verified Descript partner link below, at no additional cost to you.</div>
+      <div class="grid sm:grid-cols-2 gap-3">
+        <a data-cta="affiliate" data-tool-id="descript" href="https://get.descript.com/ole5fu20j5sq" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold text-center bg-gradient-to-r from-purple-600 to-indigo-600 text-white shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start Descript Free →</a>
+        <a data-cta="official" href="https://www.descript.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold text-center bg-slate-800 border border-slate-600 hover:bg-slate-700">Visit Descript Official Site</a>
       </div>
-    </main>
+      <p class="text-xs text-slate-500 text-center">Descript states that its Free plan does not require a credit card. Confirm current plan limits and checkout pricing on Descript before purchasing.</p>
+    </section>
 
-    <!-- Footer -->
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
+    <section class="space-y-4 pt-2 border-t border-[#222538]">
+      <h2 class="text-xl font-bold text-white">Current public pricing signals</h2>
+      <div class="grid sm:grid-cols-3 gap-3">
+        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-sm font-bold text-white">Free</div><div class="text-2xl font-black text-emerald-400 mt-1">$0</div><p class="text-xs text-slate-400 mt-2">1 media hour/month, 100 AI credits/month, 720p watermark-free export, limited Underlord and AI tools.</p></div>
+        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-sm font-bold text-white">Hobbyist</div><div class="text-2xl font-black text-emerald-400 mt-1">$16–$24</div><p class="text-xs text-slate-400 mt-2">Per person/month depending on annual vs monthly billing. 10 media hours, 400 AI credits and 1080p watermark-free export.</p></div>
+        <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30"><div class="text-sm font-bold text-white">Creator</div><div class="text-2xl font-black text-emerald-400 mt-1">$24–$35</div><p class="text-xs text-slate-400 mt-2">Per person/month depending on annual vs monthly billing. 30 media hours, 800 AI credits and 4K watermark-free export.</p></div>
       </div>
-    </footer>
-  </body>
+      <p class="text-xs text-slate-500">Pricing checked against current Descript public pages on September 1, 2026. Descript also has older public pricing pages with legacy plan names and amounts, so the live checkout should be treated as final.</p>
+    </section>
+
+    <section class="space-y-4 pt-2 border-t border-[#222538]">
+      <h2 class="text-xl font-bold text-white">What you get</h2>
+      <div class="grid sm:grid-cols-2 gap-3 text-sm text-slate-200">
+        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Text-based video and audio editing</div>
+        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Automatic transcription</div>
+        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Underlord AI co-editor</div>
+        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Studio Sound noise and echo cleanup</div>
+        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Remove filler words and retakes</div>
+        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Create social clips and captions</div>
+        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Eye Contact and AI speech tools</div>
+        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Screen and remote recording workflows</div>
+      </div>
+    </section>
+
+    <section class="space-y-4 pt-2 border-t border-[#222538]">
+      <h2 class="text-xl font-bold text-white">Which plan fits?</h2>
+      <div class="space-y-3 text-sm text-slate-300">
+        <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">Try Free first</strong> if you want to test the text-based editing workflow, transcription and basic AI tools before paying.</div>
+        <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">Choose Hobbyist</strong> if 1080p output and 10 monthly media hours are enough for a solo creator workflow.</div>
+        <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">Choose Creator</strong> if you need 4K export, more media hours, more AI credits and broader AI creation tools.</div>
+      </div>
+    </section>
+
+    <section class="space-y-4 pt-2 border-t border-[#222538]">
+      <h2 class="text-xl font-bold text-white">Related alternatives</h2>
+      <div class="grid sm:grid-cols-3 gap-3">
+        <a href="/tool/pictory.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40"><div class="font-bold text-white">Pictory</div><div class="text-xs text-slate-400 mt-1">AI video creation and repurposing</div></a>
+        <a href="/tool/castmagic.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40"><div class="font-bold text-white">Castmagic</div><div class="text-xs text-slate-400 mt-1">Audio/video content repurposing</div></a>
+        <a href="/compare/descript-vs-tubebuddy.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40"><div class="font-bold text-white">Descript vs TubeBuddy</div><div class="text-xs text-slate-400 mt-1">Editing workflow vs YouTube optimization</div></a>
+      </div>
+    </section>
+
+    <section class="p-6 rounded-2xl bg-purple-500/5 border border-purple-500/25 text-center space-y-3">
+      <h2 class="text-xl font-black text-white">Ready to test Descript?</h2>
+      <p class="text-sm text-slate-300">The free plan is the lowest-risk way to see whether text-based editing saves you time before choosing a paid tier.</p>
+      <a data-cta="affiliate" data-tool-id="descript" href="https://get.descript.com/ole5fu20j5sq" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-4 rounded-xl font-extrabold bg-gradient-to-r from-purple-600 to-indigo-600 text-white hover:brightness-110">Start Descript Free via Verified Partner Link →</a>
+    </section>
+
+    <section class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
+      <div class="flex items-center justify-between"><div class="text-purple-300 font-bold text-sm">🏆 Are you the founder of Descript?</div><span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span></div>
+      <p class="text-xs text-slate-400">Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website.</p>
+      <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.</div>
+      <a href="/#submit" class="inline-block px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs">⚡ Claim Descript Profile ($49/yr)</a>
+    </section>
+  </div>
+</main>
+<footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div></footer>
+</body>
 </html>
-


### PR DESCRIPTION
Revenue-first, zero-cost conversion update for a partner that has already produced verified affiliate clicks.

Changes:
- move the exact verified Descript referral link above the fold and add a second closing CTA
- replace generic editorial placeholders with current buyer-oriented plan guidance
- add current public Free / Hobbyist / Creator pricing signals and billing-mode ranges checked on 2026-09-01
- add current Descript features including text-based editing, Underlord, Studio Sound, clips, transcription and Eye Contact
- add explicit affiliate disclosure and pricing-source caveat because Descript still exposes an older legacy pricing page
- preserve canonical, official-site link and founder claim path

Evidence: Descript affiliate email confirms this exact referral URL and separately confirms it has already earned clicks. No paid services, guessed tracking URLs, unsupported ratings or purchase claims are introduced.