### PR TITLE
Optimize Panda Video approved affiliate funnel

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/panda-video-vs-outlierkit.html
+++ b/projects/GlobalSaaSHub/public/compare/panda-video-vs-outlierkit.html
@@ -1,172 +1,31 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Panda Video vs OutlierKit Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Panda Video vs OutlierKit. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
-
-    <link rel="canonical" href="https://coshuma.com/compare/panda-video-vs-outlierkit.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/panda-video-vs-outlierkit.html" />
-    <meta property="og:title" content="Panda Video vs OutlierKit Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Panda Video and OutlierKit by pricing, features, and verified public information." />
-
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "Panda Video vs OutlierKit Comparison",
-      "url": "https://coshuma.com/compare/panda-video-vs-outlierkit.html",
-      "description": "Compare Panda Video and OutlierKit by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "Panda Video", "url": "https://coshuma.com/tool/panda-video.html"},
-        {"@type": "SoftwareApplication", "name": "OutlierKit", "url": "https://coshuma.com/tool/outlierkit.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
-      </div>
-    </header>
-
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Panda Video vs OutlierKit</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Video & Shorts Gen tool.
-        </p>
-      </div>
-
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Panda Video if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose OutlierKit if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
-      </div>
-
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/panda-video.html" class="hover:text-purple-300">Panda Video</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/outlierkit.html" class="hover:text-blue-300">OutlierKit</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Panda Video Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Secure video streaming</div>
-<div>✓ Customizable video player</div>
-<div>✓ Analytics and insights</div>
-<div>✓ DRM protection</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">OutlierKit Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ AI-powered trend analysis</div>
-<div>✓ Viral video idea generation</div>
-<div>✓ YouTube audience insights</div>
-<div>✓ Content strategy assistance</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://pandavideo.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Panda Video →</a>
-          <a href="https://outlierkit.com/?ref=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get OutlierKit →</a>
-        </div>
-      </div>
-    </main>
-
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
-  </body>
-</html>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Panda Video vs OutlierKit: Video Hosting vs YouTube Strategy (2026) | GlobalSaaSHub</title>
+  <meta name="description" content="Compare Panda Video secure hosting, DRM, analytics and AI Shorts with OutlierKit's YouTube trend, audience and content-strategy workflows." />
+  <link rel="canonical" href="https://coshuma.com/compare/panda-video-vs-outlierkit.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/panda-video-vs-outlierkit.html" />
+  <meta property="og:title" content="Panda Video vs OutlierKit: Hosting vs YouTube Strategy (2026)" />
+  <meta property="og:description" content="Choose Panda Video for secure hosted video and repurposing, or OutlierKit for YouTube trend and content-strategy workflows." />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen flex flex-col justify-between">
+<header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6"><div class="max-w-6xl mx-auto flex items-center justify-between"><a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div><span class="font-extrabold text-lg text-white">GlobalSaaSHub</span></a><a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">← Back to All Tools</a></div></header>
+<main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
+  <div class="text-center space-y-3"><div class="inline-flex px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Buyer-intent comparison</div><h1 class="text-3xl md:text-5xl font-black text-white">Panda Video vs OutlierKit</h1><p class="text-slate-400 text-sm max-w-2xl mx-auto">Panda Video is primarily a secure video-hosting and repurposing platform. OutlierKit is positioned around YouTube trend analysis, audience insights and content strategy. Pick based on the job you actually need done.</p></div>
+  <div class="p-4 rounded-2xl bg-amber-500/5 border border-amber-500/20 text-xs text-amber-100"><strong>Affiliate disclosure:</strong> COSHUMA may earn a commission from either vendor if you sign up through links on this page, at no extra cost to you.</div>
+  <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4"><h2 class="text-xl font-bold text-white">Choose Panda Video if...</h2><ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>You need hosted video for courses, launches or paid content</li><li>You want DRM/domain controls, player customization and analytics</li><li>You want AI Shorts, subtitles, dubbing and repurposing features in the hosting stack</li></ul><div class="text-sm text-emerald-400 font-bold">Public pricing: Bronze $17.90/mo · Silver $37.90/mo · Gold $97.90/mo</div><a data-cta="affiliate" data-tool-id="panda-video" href="https://pandavideo.com?ref=wds66lmt&refc=usd" target="_blank" rel="sponsored noopener noreferrer" class="block py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center">Start Panda Video free →</a></div>
+    <div class="p-6 rounded-3xl bg-[#131520] border border-blue-500/30 space-y-4"><h2 class="text-xl font-bold text-white">Choose OutlierKit if...</h2><ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>You mainly publish on YouTube rather than hosting your own video library</li><li>You need trend analysis and viral-video idea workflows</li><li>You want audience insights and content-strategy assistance</li></ul><div class="text-sm text-slate-400 font-bold">Check OutlierKit's current pricing and plan limits before upgrading.</div><a data-cta="affiliate" data-tool-id="outlierkit" href="https://outlierkit.com/?ref=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="block py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center">Check OutlierKit →</a></div>
+  </section>
+  <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5"><h2 class="text-xl font-bold text-white">Quick decision table</h2><div class="grid grid-cols-3 gap-2 text-xs"><div class="font-bold text-slate-400">Need</div><div class="font-bold text-purple-300">Panda Video</div><div class="font-bold text-blue-300">OutlierKit</div><div class="text-slate-400">Secure hosted video</div><div class="text-white font-bold">Best fit</div><div class="text-slate-500">Not the main job</div><div class="text-slate-400">DRM/domain controls</div><div class="text-white font-bold">Available</div><div class="text-slate-500">Not the core use case</div><div class="text-slate-400">YouTube trends/ideas</div><div class="text-slate-300">Repurposing focus</div><div class="text-white font-bold">Best fit</div><div class="text-slate-400">AI Shorts</div><div class="text-white font-bold">Included workflow</div><div class="text-slate-300">Strategy/idea focus</div></div></section>
+  <section class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">Pricing note:</strong> Panda Video pricing above was checked against its public pricing page on September 1, 2026. Always verify live checkout pricing, included usage and regional terms before paying.</section>
+</main>
+<footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.</div></footer>
+</body></html>

--- a/projects/GlobalSaaSHub/public/compare/panda-video-vs-tubebuddy.html
+++ b/projects/GlobalSaaSHub/public/compare/panda-video-vs-tubebuddy.html
@@ -1,172 +1,31 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Panda Video vs TubeBuddy Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Panda Video vs TubeBuddy. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
-
-    <link rel="canonical" href="https://coshuma.com/compare/panda-video-vs-tubebuddy.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/panda-video-vs-tubebuddy.html" />
-    <meta property="og:title" content="Panda Video vs TubeBuddy Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Panda Video and TubeBuddy by pricing, features, and verified public information." />
-
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "Panda Video vs TubeBuddy Comparison",
-      "url": "https://coshuma.com/compare/panda-video-vs-tubebuddy.html",
-      "description": "Compare Panda Video and TubeBuddy by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "Panda Video", "url": "https://coshuma.com/tool/panda-video.html"},
-        {"@type": "SoftwareApplication", "name": "TubeBuddy", "url": "https://coshuma.com/tool/tubebuddy.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
-      </div>
-    </header>
-
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Panda Video vs TubeBuddy</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Video & Shorts Gen tool.
-        </p>
-      </div>
-
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Panda Video if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose TubeBuddy if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
-      </div>
-
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/panda-video.html" class="hover:text-purple-300">Panda Video</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/tubebuddy.html" class="hover:text-blue-300">TubeBuddy</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Panda Video Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Secure video streaming</div>
-<div>✓ Customizable video player</div>
-<div>✓ Analytics and insights</div>
-<div>✓ DRM protection</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">TubeBuddy Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Video SEO optimization</div>
-<div>✓ Keyword research tools</div>
-<div>✓ Bulk processing features</div>
-<div>✓ Channel health reports</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://pandavideo.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Panda Video →</a>
-          <a href="https://www.tubebuddy.com/pricing?a=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get TubeBuddy →</a>
-        </div>
-      </div>
-    </main>
-
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
-  </body>
-</html>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Panda Video vs TubeBuddy: Hosting vs YouTube SEO (2026) | GlobalSaaSHub</title>
+  <meta name="description" content="Panda Video vs TubeBuddy in 2026: compare secure video hosting, AI Shorts, DRM and analytics against YouTube SEO, keyword research and channel optimization." />
+  <link rel="canonical" href="https://coshuma.com/compare/panda-video-vs-tubebuddy.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/panda-video-vs-tubebuddy.html" />
+  <meta property="og:title" content="Panda Video vs TubeBuddy: Hosting vs YouTube SEO (2026)" />
+  <meta property="og:description" content="Choose Panda Video for secure hosted video and repurposing, or TubeBuddy for YouTube SEO and channel-growth workflows." />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen flex flex-col justify-between">
+<header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6"><div class="max-w-6xl mx-auto flex items-center justify-between"><a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div><span class="font-extrabold text-lg text-white">GlobalSaaSHub</span></a><a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">← Back to All Tools</a></div></header>
+<main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
+  <div class="text-center space-y-3"><div class="inline-flex px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Buyer-intent comparison</div><h1 class="text-3xl md:text-5xl font-black text-white">Panda Video vs TubeBuddy</h1><p class="text-slate-400 text-sm max-w-2xl mx-auto">These tools solve different jobs: Panda Video is primarily a secure video-hosting and repurposing platform, while TubeBuddy focuses on YouTube SEO, keyword research and channel optimization.</p></div>
+  <div class="p-4 rounded-2xl bg-amber-500/5 border border-amber-500/20 text-xs text-amber-100"><strong>Affiliate disclosure:</strong> COSHUMA may earn a commission from either vendor if you sign up through links on this page, at no extra cost to you.</div>
+  <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4"><h2 class="text-xl font-bold text-white">Choose Panda Video if...</h2><ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>You need hosted video for courses, launches or membership content</li><li>You want DRM/domain controls, analytics, CTA buttons and tracking pixels</li><li>You want AI Shorts, subtitles, dubbing and repurposing tools in the same stack</li></ul><div class="text-sm text-emerald-400 font-bold">Public pricing: Bronze $17.90/mo · Silver $37.90/mo · Gold $97.90/mo</div><a data-cta="affiliate" data-tool-id="panda-video" href="https://pandavideo.com?ref=wds66lmt&refc=usd" target="_blank" rel="sponsored noopener noreferrer" class="block py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center">Start Panda Video free →</a></div>
+    <div class="p-6 rounded-3xl bg-[#131520] border border-blue-500/30 space-y-4"><h2 class="text-xl font-bold text-white">Choose TubeBuddy if...</h2><ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>Your content already lives mainly on YouTube</li><li>You need keyword research and video SEO workflows</li><li>You want bulk processing and channel-health tools rather than a separate video host</li></ul><div class="text-sm text-slate-400 font-bold">Check TubeBuddy's current pricing at checkout; plans and promotions can change.</div><a data-cta="affiliate" data-tool-id="tubebuddy" href="https://www.tubebuddy.com/pricing?a=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="block py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center">Check TubeBuddy pricing →</a></div>
+  </section>
+  <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5"><h2 class="text-xl font-bold text-white">Quick decision table</h2><div class="grid grid-cols-3 gap-2 text-xs"><div class="font-bold text-slate-400">Need</div><div class="font-bold text-purple-300">Panda Video</div><div class="font-bold text-blue-300">TubeBuddy</div><div class="text-slate-400">Secure hosted video</div><div class="text-white font-bold">Best fit</div><div class="text-slate-500">Not the main job</div><div class="text-slate-400">YouTube SEO/keywords</div><div class="text-slate-500">Not the main job</div><div class="text-white font-bold">Best fit</div><div class="text-slate-400">AI Shorts/repurposing</div><div class="text-white font-bold">Included workflow</div><div class="text-slate-300">YouTube optimization focus</div><div class="text-slate-400">DRM/domain controls</div><div class="text-white font-bold">Available</div><div class="text-slate-500">Not the core use case</div></div></section>
+  <section class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">Pricing note:</strong> Panda Video pricing above was checked against its public pricing page on September 1, 2026. Always verify live checkout pricing, included usage and regional terms before paying.</section>
+</main>
+<footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.</div></footer>
+</body></html>

--- a/projects/GlobalSaaSHub/public/tool/panda-video.html
+++ b/projects/GlobalSaaSHub/public/tool/panda-video.html
@@ -3,29 +3,24 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Panda Video Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="A secure and high-performance video hosting platform designed for course creators and video marketers.... Discover features, pricing (See official pricing), and official links for Panda Video on GlobalSaaSHub." />
+    <title>Panda Video Pricing, 14-Day Trial & Review (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Compare Panda Video pricing, its 14-day trial, secure video hosting, AI Shorts, DRM, analytics and creator features. Bronze starts at $17.90/month." />
     <link rel="canonical" href="https://coshuma.com/tool/panda-video.html" />
-    
-    <!-- Open Graph SEO Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/panda-video.html" />
-    <meta property="og:title" content="Panda Video Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="A secure and high-performance video hosting platform designed for course creators and video marketers.... Check rating, pricing, and features." />
-
-    <!-- JSON-LD Structured Data for Google Indexing -->
+    <meta property="og:title" content="Panda Video Pricing, 14-Day Trial & Review (2026)" />
+    <meta property="og:description" content="Secure video hosting for creators, course businesses and marketers with AI Shorts, analytics, DRM and a 14-day trial." />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Panda Video",
       "operatingSystem": "Web",
-      "applicationCategory": "Video & Shorts Gen",
-      "description": "A secure and high-performance video hosting platform designed for course creators and video marketers."
+      "applicationCategory": "MultimediaApplication",
+      "description": "Secure video hosting platform with customizable player, analytics, DRM, AI features, Shorts generation, live video and API integrations.",
+      "url": "https://coshuma.com/tool/panda-video.html"
     }
     </script>
-
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,133 +31,85 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div><span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span></a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
     <main class="max-w-4xl mx-auto px-4 py-12 w-full">
       <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
         <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=pandavideo.com&sz=128" alt="Panda Video logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=pandavideo.com&sz=128" alt="Panda Video logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Video & Shorts Gen</span>
-              </div>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">Video Hosting & Shorts</div>
               <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Panda Video</h1>
+              <p class="text-slate-400 text-sm mt-2">Secure hosting, creator analytics and AI-assisted video tools in one platform.</p>
             </div>
           </div>
+          <a data-cta="affiliate" data-tool-id="panda-video" href="https://pandavideo.com?ref=wds66lmt&refc=usd" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center hover:bg-purple-500 transition-all">Start Panda Video free →</a>
+        </div>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
+        <div class="p-4 rounded-2xl bg-amber-500/5 border border-amber-500/20 text-xs text-amber-100 leading-relaxed">
+          <strong>Affiliate disclosure:</strong> COSHUMA may earn a commission if you sign up through the Panda Video links on this page, at no extra cost to you. Pricing below was checked against Panda Video's public pricing pages on September 1, 2026 and can change.
+        </div>
+
+        <section class="space-y-3">
+          <h2 class="text-xl font-bold text-white">What Panda Video is best for</h2>
+          <p class="text-slate-300 text-base leading-relaxed">Panda Video is aimed at course creators, video marketers and online businesses that want hosted video with a customizable player, analytics, domain controls, DRM options, live video and AI-assisted content tools. Its current product also includes Shorts/viral clips, subtitles, dubbing and other AI utilities on supported plans.</p>
+        </section>
+
+        <section class="space-y-4">
+          <div class="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-2">
+            <div><h2 class="text-xl font-bold text-white">Current public pricing</h2><p class="text-xs text-slate-400 mt-1">All complete hosting plans currently advertise a 14-day trial.</p></div>
+            <span class="text-xs font-bold text-emerald-400">Checked Sep 1, 2026</span>
           </div>
-        </div>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-xs font-bold text-purple-300 uppercase">Bronze</div><div class="text-2xl font-black text-white mt-1">$17.90<span class="text-sm text-slate-400 font-semibold">/mo</span></div><div class="text-xs text-slate-300 mt-3 space-y-1"><div>200 GB storage</div><div>500 GB monthly bandwidth</div><div>1 team member</div></div></div>
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/30"><div class="text-xs font-bold text-purple-300 uppercase">Silver</div><div class="text-2xl font-black text-white mt-1">$37.90<span class="text-sm text-slate-400 font-semibold">/mo</span></div><div class="text-xs text-slate-300 mt-3 space-y-1"><div>512 GB storage</div><div>1 TB monthly bandwidth</div><div>Up to 2 users</div></div></div>
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-xs font-bold text-purple-300 uppercase">Gold</div><div class="text-2xl font-black text-white mt-1">$97.90<span class="text-sm text-slate-400 font-semibold">/mo</span></div><div class="text-xs text-slate-300 mt-3 space-y-1"><div>1 TB storage</div><div>4 TB monthly bandwidth</div><div>Up to 10 users</div></div></div>
+          </div>
+          <p class="text-xs text-slate-400 leading-relaxed">Panda Video also lists Enterprise pricing on request and separate specialist plans. Storage and bandwidth overages can add cost, so high-volume publishers should check current limits before upgrading.</p>
+        </section>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">A secure and high-performance video hosting platform designed for course creators and video marketers.</p>
-        </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">Features that matter before you buy</h2>
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Secure video streaming</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Customizable video player</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Analytics and insights</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> DRM protection</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-200"><strong class="text-white">Secure hosting:</strong> allowed domains, anti-download controls, DRM options and account security tools.</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-200"><strong class="text-white">Conversion tools:</strong> CTA buttons, tracking pixels, video funnels, smart autoplay and A/B testing.</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-200"><strong class="text-white">AI workflow:</strong> Shorts, subtitles, dubbing, tutor, mind map, quiz and eBook generation on supported plans.</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-200"><strong class="text-white">Creator stack:</strong> customizable player, analytics, live video, API integration, playlists and chapters.</div>
           </div>
-        </div>
+        </section>
 
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
+        <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20"><h3 class="text-sm font-bold text-emerald-400">Good fit if you need</h3><ul class="text-xs text-slate-300 mt-3 space-y-2 list-disc list-inside"><li>Hosted video for courses, launches or membership content</li><li>DRM/domain controls plus analytics and marketing CTAs</li><li>Short-form repurposing and AI-assisted video utilities</li></ul></div>
+          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20"><h3 class="text-sm font-bold text-rose-400">Check carefully if</h3><ul class="text-xs text-slate-300 mt-3 space-y-2 list-disc list-inside"><li>Your audience will exceed the included bandwidth quickly</li><li>You only need YouTube SEO or keyword research rather than hosting</li><li>You need enterprise-specific limits or contractual terms</li></ul></div>
+        </section>
 
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
+        <section class="space-y-4 pt-4 border-t border-[#222538]">
+          <h2 class="text-xl font-bold text-white">Compare before choosing</h2>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <a href="/compare/panda-video-vs-tubebuddy.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 text-sm font-bold text-slate-200">Panda Video vs TubeBuddy →</a>
+            <a href="/compare/panda-video-vs-outlierkit.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 text-sm font-bold text-slate-200">Panda Video vs OutlierKit →</a>
           </div>
-        </div>
+        </section>
 
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Panda Video</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/tubebuddy.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=tubebuddy.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">TubeBuddy</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/outlierkit.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=outlierkit.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">OutlierKit</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/pictory.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=pictory.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Pictory</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
+        <section class="p-6 rounded-2xl bg-purple-500/10 border border-purple-500/30 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <div><div class="text-xs uppercase font-bold text-purple-300 tracking-wider">Try before upgrading</div><div class="text-xl font-extrabold text-white mt-1">Start with Panda Video's current free trial</div><div class="text-xs text-slate-400 mt-1">Confirm current checkout pricing and regional terms before paying.</div></div>
+          <a data-cta="affiliate" data-tool-id="panda-video" href="https://pandavideo.com?ref=wds66lmt&refc=usd" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center hover:bg-purple-500 transition-all">Start Panda Video free →</a>
+        </section>
 
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://pandavideo.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Panda Video Site</span><span>→</span></a>
-        </div>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Panda Video?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Panda Video Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/panda-video.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Panda Video Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
+        <section class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
+          <div class="flex items-center justify-between"><div class="flex items-center gap-2 text-purple-300 font-bold text-sm"><span>🏆 Are you the founder of Panda Video?</span></div><span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span></div>
+          <p class="text-xs text-slate-400 leading-relaxed">Claim this profile to update verified product information and manage company details. Claiming a profile does not guarantee or alter editorial treatment.</p>
+          <a href="/#submit" class="inline-flex px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">⚡ Claim Panda Video Profile ($49/yr)</a>
+        </section>
       </div>
     </main>
 
-    <!-- Footer -->
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
-    </footer>
+    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div></footer>
   </body>
 </html>
-


### PR DESCRIPTION
Revenue-first, zero-cost update after Panda Video's exact tracking URL was recorded as `approved_tracking` in PR #72.

Changes:
- publish the exact verified Panda Video tracking URL above the fold and in the final CTA
- replace generic editorial placeholders with current public Bronze/Silver/Gold pricing checked on 2026-09-01
- add the current 14-day trial, storage/bandwidth limits and buyer-fit guidance from Panda Video official pricing/help pages
- route both Panda Video comparison pages through the verified Panda tracking URL
- preserve the already verified TubeBuddy and OutlierKit affiliate URLs
- remove unsupported `Not rated` decision copy and clarify the actual product-category differences
- add explicit sponsored disclosure and `data-cta` / `data-tool-id` attribution attributes

Evidence used:
- repository data: Panda Video affiliate URL `https://pandavideo.com?ref=wds66lmt&refc=usd`, status `approved_tracking`
- official Panda Video pricing: https://www.pandavideo.com/pricing
- official Panda Video help: https://help.pandavideo.com/pt-br/article/planos-e-adicionais-1xnilwu/
- official Panda Partners help: https://help.pandavideo.com/pt-br/article/como-funciona-o-programa-panda-partners-be0jrk/

No paid service, guessed tracking URL, unsupported rating, or revenue claim is introduced.