### PR TITLE
Publish verified CartStack referral funnel

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/cartstack.html
+++ b/projects/GlobalSaaSHub/public/tool/cartstack.html
@@ -3,166 +3,88 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CartStack Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="CartStack is the ultimate customer recovery tool, deploying targeted remarketing emails, SMS texts, and push notifications to help retailers re-engage... Discover features, pricing (Contact for pricing), and official links for CartStack on GlobalSaaSHub." />
+    <title>CartStack Pricing, 14-Day Trial & Abandoned Cart Review (2026) | COSHUMA</title>
+    <meta name="description" content="CartStack review for 2026: compare abandoned-cart email, SMS and push recovery features, current plan structure, 14-day free trial and the best fit for ecommerce teams." />
     <link rel="canonical" href="https://coshuma.com/tool/cartstack.html" />
-    
-    <!-- Open Graph SEO Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/cartstack.html" />
-    <meta property="og:title" content="CartStack Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="CartStack is the ultimate customer recovery tool, deploying targeted remarketing emails, SMS texts, and push notifications to help retailers re-engage... Check rating, pricing, and features." />
-
-    <!-- JSON-LD Structured Data for Google Indexing -->
+    <meta property="og:title" content="CartStack Pricing, 14-Day Trial & Review (2026) | COSHUMA" />
+    <meta property="og:description" content="See CartStack's current abandoned-cart recovery plans, free trial and buyer-fit guidance before choosing a plan." />
     <script type="application/ld+json">
     {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "CartStack",
-      "operatingSystem": "Web",
-      "applicationCategory": "Email & Outreach",
-      "description": "CartStack is the ultimate customer recovery tool, deploying targeted remarketing emails, SMS texts, and push notifications to help retailers re-engage and recover abandoned carts and much more."
+      "@context":"https://schema.org",
+      "@type":"SoftwareApplication",
+      "name":"CartStack",
+      "operatingSystem":"Web",
+      "applicationCategory":"BusinessApplication",
+      "url":"https://www.cartstack.com/",
+      "description":"Cart and browse abandonment recovery platform using email, SMS, browser push and onsite conversion tools."
     }
     </script>
-
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
+      body { font-family:'Inter',sans-serif; background:#0b0c10; color:#f1f5f9; }
+      h1,h2,h3 { font-family:'Outfit',sans-serif; }
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+    <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div><span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span></a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← All AI & SaaS Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
-          <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=cartstack.com&sz=128" alt="CartStack logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
-            <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Email & Outreach</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">CartStack</h1>
+    <main class="max-w-5xl mx-auto px-4 py-10 w-full space-y-7">
+      <section class="p-7 md:p-9 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-7">
+        <div class="flex items-center gap-5">
+          <img src="https://www.google.com/s2/favicons?domain=cartstack.com&sz=128" alt="CartStack logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
+          <div><div class="text-xs font-bold text-purple-300 mb-2">ECOMMERCE · CART RECOVERY · EMAIL/SMS/PUSH</div><h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">CartStack Pricing, Trial & Review</h1><p class="text-slate-400 mt-2 text-sm">Updated September 1, 2026</p></div>
+        </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-[1.45fr_.75fr] gap-6 items-start">
+          <div class="space-y-4">
+            <p class="text-slate-200 leading-relaxed">CartStack is a revenue-recovery platform for ecommerce and booking sites. It identifies abandoned shopping or booking sessions and can re-engage visitors with email, SMS, browser push and onsite conversion campaigns.</p>
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm">
+              <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-white">14-day trial</div><div class="text-slate-400 text-xs mt-1">No credit card required</div></div>
+              <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-white">Multichannel</div><div class="text-slate-400 text-xs mt-1">Email, SMS and browser push</div></div>
+              <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-white">Order-volume pricing</div><div class="text-slate-400 text-xs mt-1">Plan cost scales with monthly orders</div></div>
             </div>
           </div>
-
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
+          <div class="p-5 rounded-2xl bg-gradient-to-br from-purple-500/10 to-indigo-500/10 border border-purple-500/30 space-y-4">
+            <div class="text-sm font-extrabold text-white">Best first step</div>
+            <p class="text-xs text-slate-300 leading-relaxed">Use the 14-day risk-free trial to measure recovered orders before committing to a monthly plan. CartStack says the trial does not require a credit card.</p>
+            <a data-cta="affiliate" data-tool-id="cartstack" href="http://www.cartstack.com/?afmc=wb" target="_blank" rel="sponsored noopener noreferrer" class="block w-full px-5 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center hover:brightness-110 transition-all">Start CartStack via Verified Referral Link →</a>
+            <p class="text-[11px] text-slate-400 leading-relaxed"><strong class="text-slate-300">Affiliate disclosure:</strong> COSHUMA may earn a commission if you sign up through this verified referral link, at no extra cost to you.</p>
           </div>
         </div>
+      </section>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">CartStack is the ultimate customer recovery tool, deploying targeted remarketing emails, SMS texts, and push notifications to help retailers re-engage and recover abandoned carts and much more.</p>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <div><h2 class="text-2xl font-black text-white">Current pricing structure</h2><p class="text-sm text-slate-400 mt-2">CartStack prices plans by the website's total monthly order volume. Its live pricing page currently shows entry pricing around $29/month for Basic, $49/month for Pro and $149/month for Agency, while the price increases as order volume rises. Annual billing advertises 20% off.</p></div>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <article class="p-5 rounded-2xl bg-[#181a29] border border-emerald-500/25 space-y-3"><div class="text-xs font-bold text-emerald-400 uppercase">Basic</div><h3 class="text-xl font-black text-white">Cart email recovery</h3><ul class="text-sm text-slate-300 space-y-2"><li>✓ Abandoned cart email</li><li>✓ Campaign optimization tools</li><li>✓ Best for smaller stores that mainly need email recovery</li></ul></article>
+          <article class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/30 space-y-3"><div class="text-xs font-bold text-purple-300 uppercase">Pro</div><h3 class="text-xl font-black text-white">Multichannel recovery</h3><ul class="text-sm text-slate-300 space-y-2"><li>✓ Cart + browse abandonment email</li><li>✓ SMS and browser push</li><li>✓ Exit-intent offers and conversion toolkit</li></ul></article>
+          <article class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/30 space-y-3"><div class="text-xs font-bold text-blue-300 uppercase">Agency</div><h3 class="text-xl font-black text-white">Multiple client accounts</h3><ul class="text-sm text-slate-300 space-y-2"><li>✓ Basic + Pro campaigns</li><li>✓ Multiple accounts and users</li><li>✓ White-labeling and aggregate reporting</li></ul></article>
         </div>
+        <div class="p-4 rounded-2xl bg-amber-500/5 border border-amber-500/20 text-xs text-amber-100 leading-relaxed"><strong>Pricing note:</strong> the exact Basic/Pro amount depends on monthly order volume, so the vendor's live pricing calculator should be treated as the final source before checkout. COSHUMA does not represent one entry price as universal for every store.</div>
+      </section>
 
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Targeted Remarketing Emails</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> SMS Text Re-engagement Campaigns</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Browser Push Notifications</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Abandoned Cart Recovery for Retailers</div>
-          </div>
-        </div>
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-5">
+        <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-4"><h2 class="text-xl font-black text-white">Why buyers consider CartStack</h2><ul class="text-sm text-slate-300 space-y-2.5"><li>✓ Abandoned-cart and browse-abandonment recovery</li><li>✓ Email, SMS and push campaigns from one platform</li><li>✓ Real-time email capture and visitor-journey tracking</li><li>✓ A/B testing, product recommendations and session replays</li><li>✓ Zapier, APIs and optional webhooks for integrations</li></ul></div>
+        <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-4"><h2 class="text-xl font-black text-white">What to check before paying</h2><ul class="text-sm text-slate-300 space-y-2.5"><li>• Pricing scales with total monthly order volume, not only recovered carts</li><li>• SMS/push and advanced conversion features are concentrated in Pro</li><li>• Webhooks may require support activation</li><li>• Trial campaigns pause after 14 days unless a paid plan is selected</li><li>• Stores handling customer data should review their own privacy/consent obligations</li></ul></div>
+      </section>
 
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (Contact for pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5"><h2 class="text-2xl font-black text-white">Who CartStack is best for</h2><div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm"><div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white">Ecommerce stores</div><p class="text-slate-400 text-xs mt-2 leading-relaxed">Recover shoppers who abandon carts or browse product pages without finishing a purchase.</p></div><div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white">Booking businesses</div><p class="text-slate-400 text-xs mt-2 leading-relaxed">CartStack also markets booking-abandonment workflows for reservation and booking engines.</p></div><div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white">Agencies</div><p class="text-slate-400 text-xs mt-2 leading-relaxed">Agency features support multiple accounts, users, reporting and white-label workflows.</p></div></div></section>
 
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5"><h2 class="text-2xl font-black text-white">Compare alternatives</h2><div class="grid grid-cols-1 sm:grid-cols-2 gap-4"><a href="/compare/cartstack-vs-aweber.html" class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">CartStack vs AWeber</div><div class="text-xs text-slate-400 mt-1">Recovery automation vs broader email marketing</div></a><a href="/compare/cartstack-vs-convertkit.html" class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">CartStack vs Kit</div><div class="text-xs text-slate-400 mt-1">Abandonment recovery vs creator email marketing</div></a></div></section>
 
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to CartStack</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/convertkit.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=kit.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Kit (formerly ConvertKit)</span></div><span class="text-[10px] font-extrabold text-emerald-400">Free plan; Creator plan from $33/month for 1,000 subscribers</span></a>
-<a href="/tool/aweber.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=aweber.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">AWeber</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/moosend.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=moosend.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Moosend</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
-
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">Contact for pricing</div>
-          </div>
-          <a data-cta="official" href="https://www.cartstack.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official CartStack Site</span><span>→</span></a>
-        </div>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of CartStack?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim CartStack Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/cartstack.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="CartStack Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
-      </div>
+      <section class="p-7 rounded-3xl bg-gradient-to-r from-purple-500/10 to-indigo-500/10 border border-purple-500/30 text-center space-y-4"><h2 class="text-2xl md:text-3xl font-black text-white">Measure recovered revenue during the trial</h2><p class="text-sm text-slate-300 max-w-2xl mx-auto">The most useful test is whether CartStack recovers enough otherwise-lost orders to justify the volume-based monthly fee.</p><a data-cta="affiliate" data-tool-id="cartstack" href="http://www.cartstack.com/?afmc=wb" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white hover:brightness-110 transition-all">Start CartStack via Verified Referral Link →</a><div class="text-[11px] text-slate-400">Referral URL verified from CartStack's welcome email to COSHUMA on September 1, 2026.</div></section>
     </main>
 
-    <!-- Footer -->
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
-    </footer>
+    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS decision guides.</div></footer>
   </body>
 </html>
-

--- a/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
+++ b/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
@@ -7,6 +7,7 @@ const verified = {
   'fireflies-ai': 'https://fireflies.ai/?fpr=sangkwon53',
   pictory: 'https://pictory.ai?fpr=sangkwon-an23',
   vidiq: 'https://vidiq.com/coshuma',
+  cartstack: 'http://www.cartstack.com/?afmc=wb',
 };
 
 for (const file of ['data/tools.json', 'data/tools.next.json']) {


### PR DESCRIPTION
## Summary
- publishes the exact CartStack referral URL supplied directly to COSHUMA by CartStack's referral welcome email
- upgrades the generic CartStack page into a buyer-intent 2026 landing with the 14-day trial, order-volume pricing structure, product fit and conversion-focused CTA
- adds CartStack to the verified affiliate sync map so future data syncs preserve the approved referral URL

## Evidence
- CartStack referral welcome email to support@coshuma.com on 2026-09-01: `http://www.cartstack.com/?afmc=wb`; email explicitly says clicks/signups through this URL are credited to the referral account
- CartStack official pricing: 14-day trial with no card; Basic/Pro/Agency structure and volume-based pricing
- CartStack official product/help pages: abandoned cart/browse recovery via email, SMS and push

## Safety
- exact referral URL preserved; dashboard URL is not used as a revenue link
- no commission rate claimed because the welcome email does not specify one
- no paid action, subscription or ad spend