### PR TITLE
Publish DocsBot approved affiliate funnel

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/docsbot.html
+++ b/projects/GlobalSaaSHub/public/tool/docsbot.html
@@ -3,165 +3,35 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>DocsBot Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Deploy custom AI agents trained on your unique business knowledge for superior automated support and enhanced team productivity.... Discover features, pricing (See official pricing), and official links for DocsBot on GlobalSaaSHub." />
+    <title>DocsBot Pricing, Free Plan & AI Support Agent Review (2026) | COSHUMA</title>
+    <meta name="description" content="DocsBot review for 2026: compare the free, Personal, Standard and Business plans, source limits, AI credits, support-agent features and current pricing." />
     <link rel="canonical" href="https://coshuma.com/tool/docsbot.html" />
-    
-    <!-- Open Graph SEO Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/docsbot.html" />
-    <meta property="og:title" content="DocsBot Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Deploy custom AI agents trained on your unique business knowledge for superior automated support and enhanced team productivity.... Check rating, pricing, and features." />
-
-    <!-- JSON-LD Structured Data for Google Indexing -->
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "DocsBot",
-      "operatingSystem": "Web",
-      "applicationCategory": "Autonomous AI Agents",
-      "description": "Deploy custom AI agents trained on your unique business knowledge for superior automated support and enhanced team productivity."
-    }
-    </script>
-
-    <!-- Tailwind & Fonts -->
+    <meta property="og:title" content="DocsBot Pricing, Free Plan & AI Support Agent Review (2026) | COSHUMA" />
+    <meta property="og:description" content="Compare DocsBot pricing, free-plan limits and AI customer-support features before upgrading." />
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"DocsBot","operatingSystem":"Web","applicationCategory":"BusinessApplication","url":"https://docsbot.ai/","description":"AI support and knowledge-agent platform that trains on business content and can answer customer or team questions using agentic RAG."}</script>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
+    <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
-      </div>
-    </header>
+    <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50 py-4 px-6"><div class="max-w-6xl mx-auto flex items-center justify-between"><a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div><span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span></a><a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← All AI & SaaS Tools</a></div></header>
+    <main class="max-w-5xl mx-auto px-4 py-10 w-full space-y-7">
+      <section class="p-7 md:p-9 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-7">
+        <div class="flex items-center gap-5"><img src="https://www.google.com/s2/favicons?domain=docsbot.ai&sz=128" alt="DocsBot logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'"/><div><div class="text-xs font-bold text-purple-300 mb-2">AI SUPPORT · RAG · KNOWLEDGE AGENTS</div><h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">DocsBot Pricing & Review</h1><p class="text-slate-400 mt-2 text-sm">Updated September 1, 2026</p></div></div>
+        <div class="grid grid-cols-1 lg:grid-cols-[1.45fr_.75fr] gap-6 items-start"><div class="space-y-4"><p class="text-slate-200 leading-relaxed">DocsBot builds AI agents from websites, documents and business knowledge for customer support and team automation. Its current product combines agentic RAG with chat widgets, actions, analytics, integrations and optional MCP workflows.</p><div class="grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm"><div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-white">Free plan</div><div class="text-slate-400 text-xs mt-1">$0, no credit card required</div></div><div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-white">100+ languages</div><div class="text-slate-400 text-xs mt-1">Multilingual answers from your sources</div></div><div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-white">28+ source types</div><div class="text-slate-400 text-xs mt-1">Web, docs, feeds, tickets and API sources</div></div></div></div><div class="p-5 rounded-2xl bg-gradient-to-br from-purple-500/10 to-indigo-500/10 border border-purple-500/30 space-y-4"><div class="text-sm font-extrabold text-white">Best first step</div><p class="text-xs text-slate-300 leading-relaxed">Use the free plan to test source quality and answer accuracy before buying AI credits or larger source limits. It currently includes one bot, 50 source pages and 100 monthly AI credits.</p><a data-cta="affiliate" data-tool-id="docsbot" href="https://docsbot.ai?via=31kq9q" target="_blank" rel="sponsored noopener noreferrer" class="block w-full px-5 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center hover:brightness-110 transition-all">Start DocsBot Free via Verified Affiliate Link →</a><p class="text-[11px] text-slate-400 leading-relaxed"><strong class="text-slate-300">Affiliate disclosure:</strong> COSHUMA may earn a commission if you buy through this verified affiliate link, at no extra cost to you.</p></div></div>
+      </section>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
-          <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=docsbot.ai&sz=128" alt="DocsBot logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
-            <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Autonomous AI Agents</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">DocsBot</h1>
-            </div>
-          </div>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5"><div><h2 class="text-2xl font-black text-white">DocsBot pricing in 2026</h2><p class="text-sm text-slate-400 mt-2">The current official USD pricing page lists Free at $0, Personal at $49/month, Standard at $149/month and Business at $499/month. Annual plans advertise two months free.</p></div><div class="grid grid-cols-1 md:grid-cols-4 gap-4"><article class="p-4 rounded-2xl bg-[#181a29] border border-emerald-500/25"><div class="text-xs font-bold text-emerald-400">FREE</div><div class="font-black text-white text-lg mt-2">$0</div><p class="text-xs text-slate-400 mt-2">1 bot · 50 source pages · 100 monthly AI credits · basic sources.</p></article><article class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-xs font-bold text-slate-300">PERSONAL</div><div class="font-black text-white text-lg mt-2">$49/mo</div><p class="text-xs text-slate-400 mt-2">1 bot · 5k pages · 5k AI credits · actions, scheduling, Zapier, Slack and basic analytics.</p></article><article class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30"><div class="text-xs font-bold text-purple-300">STANDARD</div><div class="font-black text-white text-lg mt-2">$149/mo</div><p class="text-xs text-slate-400 mt-2">3 bots · 15k pages · 15k credits · 5 users · web search, escalation and deeper analytics.</p></article><article class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30"><div class="text-xs font-bold text-blue-300">BUSINESS</div><div class="font-black text-white text-lg mt-2">$499/mo</div><p class="text-xs text-slate-400 mt-2">10 bots · 100k pages · 60k credits · 10 users · unbranded widgets, PII redaction and priority support.</p></article></div></section>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
-        </div>
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-5"><div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-4"><h2 class="text-xl font-black text-white">Where DocsBot is strongest</h2><ul class="text-sm text-slate-300 space-y-2.5"><li>✓ Customer-support agents grounded in product documentation</li><li>✓ Website, PDF, Office, help-desk and API knowledge sources</li><li>✓ Lead forms, scheduling and workflow actions on paid tiers</li><li>✓ Question/conversation analytics for finding content gaps</li><li>✓ MCP and agent workflows for supported automation use cases</li></ul></div><div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-4"><h2 class="text-xl font-black text-white">What to check before upgrading</h2><ul class="text-sm text-slate-300 space-y-2.5"><li>• AI-credit use varies by model and action complexity</li><li>• The free bot has only 50 source pages and 100 monthly credits</li><li>• Paid-plan limits differ substantially in bots, pages, actions and users</li><li>• When monthly AI credits run out, the bot stops responding unless capacity is increased or resets</li><li>• Auto-add credits is optional and can increase paid spend, so enable it only deliberately</li></ul></div></section>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">Deploy custom AI agents trained on your unique business knowledge for superior automated support and enhanced team productivity.</p>
-        </div>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-4"><h2 class="text-2xl font-black text-white">Verified COSHUMA affiliate terms</h2><p class="text-sm text-slate-300 leading-relaxed">DocsBot's partner welcome email directly supplied COSHUMA's unique referral URL and states a 25% commission when someone signs up for a paid account through that link. The dashboard/login URL in the same email is not used as a revenue CTA.</p></section>
 
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Custom AI agent creation</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Train on business knowledge</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Automated customer support</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Boost team productivity</div>
-          </div>
-        </div>
-
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to DocsBot</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/carv.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=carv.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Carv</span></div><span class="text-[10px] font-extrabold text-emerald-400">Custom enterprise pricing</span></a>
-<a href="/tool/liftmycv.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=liftmycv.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">LiftmyCV</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
-
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://docsbot.ai/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official DocsBot Site</span><span>→</span></a>
-        </div>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of DocsBot?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim DocsBot Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/docsbot.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="DocsBot Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
-      </div>
+      <section class="p-7 rounded-3xl bg-gradient-to-r from-purple-500/10 to-indigo-500/10 border border-purple-500/30 text-center space-y-4"><h2 class="text-2xl md:text-3xl font-black text-white">Test answer quality before buying capacity</h2><p class="text-sm text-slate-300 max-w-2xl mx-auto">The free tier is enough to validate whether your documents produce useful answers before paying for larger source and AI-credit limits.</p><a data-cta="affiliate" data-tool-id="docsbot" href="https://docsbot.ai?via=31kq9q" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white hover:brightness-110 transition-all">Start DocsBot Free via Verified Affiliate Link →</a><div class="text-[11px] text-slate-400">Unique affiliate URL verified from DocsBot's partner welcome email to COSHUMA on September 1, 2026.</div></section>
     </main>
-
-    <!-- Footer -->
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
-    </footer>
+    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS decision guides.</div></footer>
   </body>
 </html>
-

--- a/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
+++ b/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
@@ -9,6 +9,7 @@ const verified = {
   vidiq: 'https://vidiq.com/coshuma',
   cartstack: 'http://www.cartstack.com/?afmc=wb',
   'customgpt-ai': 'https://customgpt.ai/?fpr=sangkwon-3b18de',
+  docsbot: 'https://docsbot.ai?via=31kq9q',
 };
 
 for (const file of ['data/tools.json', 'data/tools.next.json']) {


### PR DESCRIPTION
## Summary
- publishes the exact DocsBot referral URL supplied directly to COSHUMA by the DocsBot Partner Team
- replaces the generic DocsBot page with a current buyer-intent landing covering the free plan, paid tiers, AI-credit limits, support-agent use cases and upgrade cautions
- adds DocsBot to the verified affiliate sync map

## Evidence
- DocsBot partner welcome email to support@coshuma.com on 2026-09-01: `https://docsbot.ai?via=31kq9q`
- email explicitly states 25% commission for paid accounts referred through the unique link
- official pricing page currently lists Free $0, Personal $49/month, Standard $149/month, Business $499/month and two months free on annual plans

## Safety
- dashboard/login URL from the email is not used as a revenue link
- exact referral URL is preserved
- no paid action, auto-add credits, subscription or ad spend