### PR TITLE
Queue Omi approved referral link retrieval

### DIFF
--- a/projects/GlobalSaaSHub/data/browser_required_queue.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.json
@@ -26,5 +26,19 @@
       "Do not guess the Partner ID or construct a ?a= tracking parameter from documentation examples.",
       "Do not submit another Text Partner Program application."
     ]
+  },
+  {
+    "id": "omi-ai-affiliate-referral-link",
+    "priority": "high",
+    "status": "browser_required",
+    "cost": "0",
+    "verified_at": "2026-09-01T23:35:00+09:00",
+    "reason": "Omi AI's approval email verifies that the COSHUMA account is approved for referrals and can earn commissions, but the email supplies only a Get Started link that resolves to affiliate.basedhardware.com and does not expose a customer-facing unique referral URL.",
+    "next_action": "Reuse an already authenticated Omi/Based Hardware affiliate browser session, open the referral or link area, copy the exact customer-facing unique affiliate URL, verify its account-specific tracking identifier and final destination, then update only matching data records and eligible COSHUMA CTAs.",
+    "do_not": [
+      "Do not treat the affiliate.basedhardware.com dashboard/onboarding URL or its email tracking redirect as a revenue link.",
+      "Do not guess or construct a referral parameter.",
+      "Do not submit another Omi AI referral application."
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- records Omi AI as approved for referrals based on the approval email
- queues the one remaining browser-only step: obtain the actual customer-facing unique referral URL from the authenticated Omi/Based Hardware affiliate dashboard
- explicitly blocks use of the dashboard/onboarding URL or email redirect as a revenue link

## Evidence
- Omi AI approval email to support@coshuma.com on 2026-09-01 says the account is approved for referrals and can earn commissions
- the email only exposes a Get Started link to `affiliate.basedhardware.com`, not a verified customer-facing unique referral URL

## Safety
- no guessed referral parameter
- no duplicate application
- no paid action