### PR TITLE
Optimize Sudowrite buyer-intent affiliate landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/sudowrite.html
+++ b/projects/GlobalSaaSHub/public/tool/sudowrite.html
@@ -3,29 +3,34 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Sudowrite Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="An innovative AI writing tool specifically designed to assist fiction writers in brainstorming, drafting, and refining their stories and novels.... Discover features, pricing (See official pricing), and official links for Sudowrite on GlobalSaaSHub." />
+    <title>Sudowrite Pricing, Free Trial & AI Fiction Writing Review (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Sudowrite pricing, free trial, features and best-fit guidance for fiction writers in 2026. Compare Hobby & Student, Professional and Max plans, then start through COSHUMA's verified affiliate link." />
     <link rel="canonical" href="https://coshuma.com/tool/sudowrite.html" />
-    
-    <!-- Open Graph SEO Tags -->
+
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/sudowrite.html" />
-    <meta property="og:title" content="Sudowrite Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="An innovative AI writing tool specifically designed to assist fiction writers in brainstorming, drafting, and refining their stories and novels.... Check rating, pricing, and features." />
+    <meta property="og:title" content="Sudowrite Pricing, Free Trial & AI Fiction Writing Review (2026)" />
+    <meta property="og:description" content="Current Sudowrite plan guidance, fiction-writing features, free-trial details and a verified affiliate CTA." />
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Sudowrite",
+      "url": "https://www.sudowrite.com/",
       "operatingSystem": "Web",
-      "applicationCategory": "AI Copywriting",
-      "description": "An innovative AI writing tool specifically designed to assist fiction writers in brainstorming, drafting, and refining their stories and novels."
+      "applicationCategory": "WritingApplication",
+      "description": "AI writing software built for fiction authors, with drafting, rewriting, brainstorming, sensory description and story-planning tools.",
+      "offers": {
+        "@type": "AggregateOffer",
+        "priceCurrency": "USD",
+        "lowPrice": "10",
+        "highPrice": "59",
+        "offerCount": "3"
+      }
     }
     </script>
 
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,134 +41,159 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
     <main class="max-w-4xl mx-auto px-4 py-12 w-full">
       <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
         <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=sudowrite.com&sz=128" alt="Sudowrite logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=sudowrite.com&sz=128" alt="Sudowrite logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>✍️</text></svg>'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>AI Copywriting</span>
-              </div>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">AI Fiction Writing</div>
               <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Sudowrite</h1>
+              <p class="text-slate-400 text-sm mt-2">Purpose-built AI writing partner for novelists and fiction writers.</p>
             </div>
           </div>
+          <div class="flex items-center gap-2 bg-emerald-500/10 border border-emerald-500/20 text-emerald-300 px-4 py-2 rounded-xl text-sm font-bold">Verified affiliate link</div>
+        </div>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
+        <div class="p-6 rounded-2xl bg-gradient-to-br from-purple-500/10 to-indigo-500/10 border border-purple-500/30 space-y-4">
+          <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div>
+              <div class="text-xs uppercase font-bold text-purple-300 tracking-wider">Best first step</div>
+              <h2 class="text-2xl font-extrabold text-white mt-1">Try Sudowrite before choosing a plan</h2>
+              <p class="text-sm text-slate-300 mt-2 leading-relaxed">Sudowrite currently offers a free trial with no credit card required. Test the fiction-specific workflow first, then choose a plan based mainly on how many AI credits you need each month.</p>
+            </div>
+            <a data-cta="affiliate" data-tool-id="sudowrite" href="https://www.sudowrite.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="shrink-0 px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start Sudowrite Free Trial →</a>
           </div>
+          <p class="text-[11px] text-slate-400">Affiliate disclosure: COSHUMA may earn a commission if you subscribe through this verified partner link, at no extra cost to you.</p>
         </div>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">An innovative AI writing tool specifically designed to assist fiction writers in brainstorming, drafting, and refining their stories and novels.</p>
-        </div>
+        <section class="space-y-3">
+          <h2 class="text-xl font-bold text-white">What Sudowrite is best for</h2>
+          <p class="text-slate-300 text-base leading-relaxed">Sudowrite is designed specifically for fiction rather than general business copy. It helps writers move from ideas and outlines into scenes and chapters, then refine prose without forcing a generic marketing-writing workflow.</p>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 pt-2">
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white text-sm">Novel drafting</div><p class="text-xs text-slate-400 mt-1">Generate scenes and longer draft sections from structured story context.</p></div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white text-sm">Revision & style</div><p class="text-xs text-slate-400 mt-1">Rewrite passages, expand moments and improve flow or tone.</p></div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white text-sm">Story development</div><p class="text-xs text-slate-400 mt-1">Brainstorm characters, plot turns, worldbuilding and sensory detail.</p></div>
+          </div>
+        </section>
 
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
+        <section class="space-y-4">
+          <div class="flex items-end justify-between gap-4">
+            <div>
+              <h2 class="text-xl font-bold text-white">Sudowrite pricing in 2026</h2>
+              <p class="text-sm text-slate-400 mt-1">All three plans include the core feature set; the main differences are monthly credits and rollover behavior.</p>
+            </div>
+            <span class="text-[11px] text-slate-500">Checked Sep. 2, 2026</span>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+              <div class="text-sm font-extrabold text-white">Hobby & Student</div>
+              <div class="text-2xl font-black text-emerald-400 mt-2">$10/mo</div>
+              <div class="text-xs text-slate-500">annual billing · $19 monthly</div>
+              <ul class="text-xs text-slate-300 mt-4 space-y-2"><li>• 225,000 credits/month</li><li>• Best for lighter or occasional fiction work</li><li>• Full feature access</li></ul>
+            </div>
+            <div class="p-5 rounded-2xl bg-purple-500/10 border border-purple-500/30">
+              <div class="text-xs font-bold text-purple-300 uppercase tracking-wide">Most useful for active novelists</div>
+              <div class="text-sm font-extrabold text-white mt-1">Professional</div>
+              <div class="text-2xl font-black text-emerald-400 mt-2">$22/mo</div>
+              <div class="text-xs text-slate-500">annual billing · $29 monthly</div>
+              <ul class="text-xs text-slate-300 mt-4 space-y-2"><li>• 1,000,000 credits/month</li><li>• Better fit for a novel or screenplay workflow</li><li>• Includes Feedback access</li></ul>
+            </div>
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+              <div class="text-sm font-extrabold text-white">Max</div>
+              <div class="text-2xl font-black text-emerald-400 mt-2">$44/mo</div>
+              <div class="text-xs text-slate-500">annual billing · $59 monthly</div>
+              <ul class="text-xs text-slate-300 mt-4 space-y-2"><li>• 2,000,000 credits/month</li><li>• Unused credits roll over for 12 months</li><li>• Built for frequent, high-volume writers</li></ul>
+            </div>
+          </div>
+          <p class="text-[11px] text-slate-500">Prices above reflect Sudowrite's current official plan documentation and may change. Confirm the final amount and billing cycle on Sudowrite before subscribing.</p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">Core fiction-writing features</h2>
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI story generation</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Brainstorming tools</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Character development</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Rewrite & expand text</div>
+            <div class="flex items-start gap-2.5 p-3 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span><span><strong class="text-white">Write:</strong> Auto or Guided generation for what comes next.</span></div>
+            <div class="flex items-start gap-2.5 p-3 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span><span><strong class="text-white">Describe:</strong> Sensory detail for sight, sound, smell, touch and taste.</span></div>
+            <div class="flex items-start gap-2.5 p-3 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span><span><strong class="text-white">Rewrite:</strong> Improve phrasing, flow or tone in an existing passage.</span></div>
+            <div class="flex items-start gap-2.5 p-3 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span><span><strong class="text-white">Brainstorm:</strong> Generate ideas for plots, names, characters and worldbuilding.</span></div>
+            <div class="flex items-start gap-2.5 p-3 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span><span><strong class="text-white">First Draft & Draft:</strong> Create longer scenes or chapter-length material from notes and structured scenes.</span></div>
+            <div class="flex items-start gap-2.5 p-3 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span><span><strong class="text-white">Chat & Story Bible:</strong> Work with characters, synopsis, outline and worldbuilding context.</span></div>
           </div>
-        </div>
+        </section>
 
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
+            <h3 class="text-sm font-bold text-emerald-400">Good fit if you...</h3>
             <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
+              <li>Write novels, screenplays, short stories or fan fiction.</li>
+              <li>Want AI tools shaped around story structure instead of ad copy.</li>
+              <li>Need help getting unstuck, expanding scenes or revising prose.</li>
+              <li>Prefer testing the product before entering payment details.</li>
             </ul>
           </div>
-
           <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
+            <h3 class="text-sm font-bold text-rose-400">Consider another tool if...</h3>
             <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
+              <li>Your main use case is SEO, sales copy or business content.</li>
+              <li>You need a permanent free tier rather than a trial.</li>
+              <li>You prefer a flat unlimited-usage model instead of credit-based plans.</li>
             </ul>
           </div>
-        </div>
+        </section>
 
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Sudowrite</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
+        <section class="space-y-4 pt-4 border-t border-[#222538]">
+          <h2 class="text-xl font-bold text-white flex items-center justify-between"><span>Alternatives to Sudowrite</span><span class="text-xs font-semibold text-purple-400">Compare by use case</span></h2>
           <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/copy-ai.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=copy.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Copy.ai</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/jasper.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=jasper.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Jasper</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/writesonic.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=writesonic.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Writesonic</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
+            <a href="/tool/copy-ai.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="text-xs font-bold text-slate-200">Copy.ai</div><div class="text-[10px] text-slate-500 mt-1">Business and go-to-market copy</div></a>
+            <a href="/tool/jasper.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="text-xs font-bold text-slate-200">Jasper</div><div class="text-[10px] text-slate-500 mt-1">Marketing teams and brand content</div></a>
+            <a href="/tool/writesonic.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="text-xs font-bold text-slate-200">Writesonic</div><div class="text-[10px] text-slate-500 mt-1">SEO and general AI content workflows</div></a>
           </div>
+        </section>
+
+        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] space-y-4">
+          <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+            <div>
+              <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Recommended action</div>
+              <div class="text-xl font-extrabold text-white mt-0.5">Use the free trial to test your actual fiction workflow</div>
+              <p class="text-xs text-slate-400 mt-1">Then choose a plan based on how much drafting and rewriting you expect to do.</p>
+            </div>
+            <a data-cta="affiliate" data-tool-id="sudowrite" href="https://www.sudowrite.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Try Sudowrite Free →</a>
+          </div>
+          <div class="text-[11px] text-slate-500">Prefer a non-affiliate path? <a href="https://www.sudowrite.com/" target="_blank" rel="noopener noreferrer" class="underline hover:text-slate-300">Visit Sudowrite directly</a>.</div>
         </div>
 
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://www.sudowrite.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Sudowrite Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://www.sudowrite.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Sudowrite via Verified Affiliate Link</span><span>→</span></a>
+        <div class="p-5 rounded-2xl bg-[#0f111a] border border-[#222538] text-xs text-slate-400 leading-relaxed">
+          <strong class="text-slate-300">Source note:</strong> Pricing and product details were checked against Sudowrite's official pricing page and documentation on September 2, 2026. Affiliate attribution uses the exact partner URL supplied directly to COSHUMA by Sudowrite Partnerships.
         </div>
 
-        <!-- Claim Profile & Official Founder Badge Section -->
         <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
           <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Sudowrite?</span>
-            </div>
+            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm"><span>🏆 Are you the founder of Sudowrite?</span></div>
             <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
           </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Sudowrite Profile ($49/yr)
-            </a>
-          </div>
+          <p class="text-xs text-slate-400 leading-relaxed">Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website.</p>
+          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.</div>
+          <div class="flex flex-col sm:flex-row items-center gap-3"><a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">⚡ Claim Sudowrite Profile ($49/yr)</a></div>
           <div class="relative pt-2">
             <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
             <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/sudowrite.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Sudowrite Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
           </div>
         </div>
-
-
       </div>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
## Summary
- moves Sudowrite's exact verified partner URL above the fold and keeps a second closing affiliate CTA
- replaces generic editorial placeholders with current buyer-intent plan guidance
- adds current official Hobby & Student, Professional and Max pricing plus free-trial/no-card guidance
- adds fiction-specific feature and best-fit guidance using Sudowrite's official documentation
- adds clear affiliate disclosure and source note

## Evidence
- Sudowrite Partnerships email to support@coshuma.com supplies the exact affiliate URL `https://www.sudowrite.com?via=sangkwon`, 25% commission on payments for the first 12 months, and a 60-day cookie window
- Sudowrite official pricing/docs checked 2026-09-02: Hobby & Student $10 annual-effective / $19 monthly, Professional $22 / $29, Max $44 / $59; free trial requires no credit card

## Safety
- exact account-specific affiliate URL preserved
- non-affiliate direct link remains available
- no paid action, guessed tracking URL, unsupported rating or revenue claim