### PR TITLE
Optimize Merlin buyer-intent affiliate landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/merlin.html
+++ b/projects/GlobalSaaSHub/public/tool/merlin.html
@@ -3,29 +3,34 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Merlin Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Merlin is an AI productivity tool designed to supercharge your daily tasks, offering powerful summarization, content generation, and seamless workflow... Discover features, pricing (See official pricing), and official links for Merlin on GlobalSaaSHub." />
+    <title>Merlin AI Pricing, Free Plan & Review (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Merlin AI pricing, free plan, browser-extension features and best-fit guidance for 2026. Compare Free vs Pro and start with COSHUMA's verified Merlin affiliate link." />
     <link rel="canonical" href="https://coshuma.com/tool/merlin.html" />
-    
-    <!-- Open Graph SEO Tags -->
+
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/merlin.html" />
-    <meta property="og:title" content="Merlin Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Merlin is an AI productivity tool designed to supercharge your daily tasks, offering powerful summarization, content generation, and seamless workflow... Check rating, pricing, and features." />
+    <meta property="og:title" content="Merlin AI Pricing, Free Plan & Review (2026)" />
+    <meta property="og:description" content="Current Merlin Free and Pro plan guidance, AI-model access, browser tools and a verified affiliate CTA." />
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
-      "name": "Merlin",
-      "operatingSystem": "Web",
-      "applicationCategory": "Workflow Automation",
-      "description": "Merlin is an AI productivity tool designed to supercharge your daily tasks, offering powerful summarization, content generation, and seamless workflow automation features. Boost your efficiency and creativity with intelligent AI assistance across various applications."
+      "name": "Merlin AI",
+      "url": "https://www.getmerlin.in/",
+      "operatingSystem": "Web, Chrome, Mobile",
+      "applicationCategory": "ProductivityApplication",
+      "description": "AI productivity assistant with multi-model chat, summarization, research, image generation and browser-extension workflows.",
+      "offers": {
+        "@type": "AggregateOffer",
+        "priceCurrency": "USD",
+        "lowPrice": "0",
+        "highPrice": "19",
+        "offerCount": "2"
+      }
     }
     </script>
 
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,134 +41,95 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div><span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span></a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
     <main class="max-w-4xl mx-auto px-4 py-12 w-full">
       <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
         <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=getmerlin.in&sz=128" alt="Merlin logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=getmerlin.in&sz=128" alt="Merlin AI logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Workflow Automation</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Merlin</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">AI Productivity</div>
+              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Merlin AI</h1>
+              <p class="text-slate-400 text-sm mt-2">One assistant for chat, research, summarization, creation and browser workflows.</p>
             </div>
           </div>
-
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
+          <div class="flex items-center gap-2 bg-emerald-500/10 border border-emerald-500/20 text-emerald-300 px-4 py-2 rounded-xl text-sm font-bold">Verified affiliate link</div>
         </div>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">Merlin is an AI productivity tool designed to supercharge your daily tasks, offering powerful summarization, content generation, and seamless workflow automation features. Boost your efficiency and creativity with intelligent AI assistance across various applications.</p>
+        <div class="p-6 rounded-2xl bg-gradient-to-br from-purple-500/10 to-indigo-500/10 border border-purple-500/30 space-y-4">
+          <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div>
+              <div class="text-xs uppercase font-bold text-purple-300 tracking-wider">Start with the free plan</div>
+              <h2 class="text-2xl font-extrabold text-white mt-1">See if Merlin fits your daily workflow before paying</h2>
+              <p class="text-sm text-slate-300 mt-2 leading-relaxed">Merlin currently has a $0 plan with limited AI-model, image-generation, tool and Chrome-extension access. Upgrade only if you need materially higher usage and premium models.</p>
+            </div>
+            <a data-cta="affiliate" data-tool-id="merlin" href="https://www.getmerlin.in/chat?ref=yjeyytn" target="_blank" rel="sponsored noopener noreferrer" class="shrink-0 px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Try Merlin Free →</a>
+          </div>
+          <p class="text-[11px] text-slate-400">Affiliate disclosure: COSHUMA may earn a commission if you later purchase through this verified referral link, at no extra cost to you.</p>
         </div>
 
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI-powered summarization</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Intelligent content generation</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Workflow automation capabilities</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Cross-platform integration</div>
+        <section class="space-y-3">
+          <h2 class="text-xl font-bold text-white">What Merlin AI does</h2>
+          <p class="text-slate-300 leading-relaxed">Merlin combines access to multiple AI models with browser and productivity tools. The strongest use case is reducing context switching: summarize a page or YouTube video, ask questions about current content, draft replies, research topics, generate images, and continue the same work across web, extension and mobile.</p>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-2">
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white text-sm">Multi-model AI chat</div><p class="text-xs text-slate-400 mt-1">Access a mix of OpenAI, Anthropic, Google and other models depending on plan and usage limits.</p></div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white text-sm">Browser assistant</div><p class="text-xs text-slate-400 mt-1">Summarize pages and YouTube videos, write in Gmail, post on LinkedIn/X and ask about the page you are viewing.</p></div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white text-sm">Research & creation</div><p class="text-xs text-slate-400 mt-1">Use live search, file uploads, writing tools and image/video generation from one subscription.</p></div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white text-sm">Cross-device workflow</div><p class="text-xs text-slate-400 mt-1">Sync usage across Merlin's web app, Chrome extension and mobile experience.</p></div>
           </div>
-        </div>
+        </section>
 
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
+        <section class="space-y-4">
+          <div class="flex items-end justify-between gap-4"><div><h2 class="text-xl font-bold text-white">Merlin pricing in 2026</h2><p class="text-sm text-slate-400 mt-1">The official pricing page currently emphasizes Free and Pro for individual users.</p></div><span class="text-[11px] text-slate-500">Checked Sep. 2, 2026</span></div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+              <div class="text-sm font-extrabold text-white">Free</div><div class="text-2xl font-black text-emerald-400 mt-2">$0</div>
+              <ul class="text-xs text-slate-300 mt-4 space-y-2"><li>• Limited Basic and Plus-level model access</li><li>• Basic image generation</li><li>• Limited access to 70+ AI tools</li><li>• Limited Chrome-extension features</li><li>• Cross-device sync</li></ul>
+            </div>
+            <div class="p-5 rounded-2xl bg-purple-500/10 border border-purple-500/30">
+              <div class="text-xs font-bold text-purple-300 uppercase tracking-wide">For heavier daily use</div><div class="text-sm font-extrabold text-white mt-1">Pro</div><div class="text-2xl font-black text-emerald-400 mt-2">$19/mo</div><div class="text-xs text-slate-500">current annual-plan effective price; final checkout may vary by billing option</div>
+              <ul class="text-xs text-slate-300 mt-4 space-y-2"><li>• Much higher usage on premium models</li><li>• Access to additional/exclusive models</li><li>• Advanced image and video generation</li><li>• Expanded browser-extension and research usage</li><li>• Priority support</li></ul>
+            </div>
           </div>
+          <p class="text-[11px] text-slate-500">Merlin applies combined fair-usage limits across features, so heavy use of one feature can reduce availability elsewhere. Confirm live plan terms at checkout before purchasing.</p>
+        </section>
 
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
+        <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2"><h3 class="text-sm font-bold text-emerald-400">Good fit if you...</h3><ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside"><li>Want one subscription for several AI models and utilities.</li><li>Frequently summarize webpages, videos or documents.</li><li>Want AI inside browser workflows instead of a separate chat tab.</li><li>Need a usable free plan before deciding to upgrade.</li></ul></div>
+          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2"><h3 class="text-sm font-bold text-rose-400">Consider another tool if...</h3><ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside"><li>You need guaranteed fixed usage with no fair-use pooling.</li><li>Your company requires a single-model vendor rather than a multi-model wrapper.</li><li>You only need one specialized workflow such as help desk, SEO or fiction writing.</li></ul></div>
+        </section>
 
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Merlin</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
+        <section class="space-y-4 pt-4 border-t border-[#222538]">
+          <h2 class="text-xl font-bold text-white">Related alternatives</h2>
           <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/notion-ai.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=notion.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Notion AI</span></div><span class="text-[10px] font-extrabold text-emerald-400">Free trial; Business plan with Notion AI at $20/user/month</span></a>
-<a href="/tool/bolddesk.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=bolddesk.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">BoldDesk</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/socialchamp-io.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=socialchamp.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Social Champ</span></div><span class="text-[10px] font-extrabold text-emerald-400">Free plan; paid plans from $4/month billed annually</span></a>
+            <a href="/tool/notion-ai.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="text-xs font-bold text-slate-200">Notion AI</div><div class="text-[10px] text-slate-500 mt-1">Best when AI lives inside a docs/workspace system</div></a>
+            <a href="/tool/bolddesk.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="text-xs font-bold text-slate-200">BoldDesk</div><div class="text-[10px] text-slate-500 mt-1">Better for customer-support workflows</div></a>
+            <a href="/tool/socialchamp-io.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="text-xs font-bold text-slate-200">Social Champ</div><div class="text-[10px] text-slate-500 mt-1">Better for dedicated social publishing and scheduling</div></a>
           </div>
+        </section>
+
+        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] space-y-4">
+          <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4"><div><div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Recommended action</div><div class="text-xl font-extrabold text-white mt-0.5">Use the free plan for real tasks first</div><p class="text-xs text-slate-400 mt-1">Upgrade only if the premium-model and higher-usage limits solve a recurring workflow problem.</p></div><a data-cta="affiliate" data-tool-id="merlin" href="https://www.getmerlin.in/chat?ref=yjeyytn" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start Merlin Free →</a></div>
+          <div class="text-[11px] text-slate-500">Prefer a non-affiliate path? <a href="https://www.getmerlin.in/" target="_blank" rel="noopener noreferrer" class="underline hover:text-slate-300">Visit Merlin directly</a>.</div>
         </div>
 
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://www.getmerlin.in/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Merlin Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://www.getmerlin.in/chat?ref=yjeyytn" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Merlin via Verified Affiliate Link</span><span>→</span></a>
-        </div>
+        <div class="p-5 rounded-2xl bg-[#0f111a] border border-[#222538] text-xs text-slate-400 leading-relaxed"><strong class="text-slate-300">Source note:</strong> Product and pricing details were checked against Merlin's official pricing pages on September 2, 2026. Affiliate attribution uses the exact unique referral URL supplied to COSHUMA in the Merlin Affiliate Program approval email.</div>
 
-        <!-- Claim Profile & Official Founder Badge Section -->
         <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Merlin?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Merlin Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/merlin.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Merlin Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
+          <div class="flex items-center justify-between"><div class="flex items-center gap-2 text-purple-300 font-bold text-sm"><span>🏆 Are you the founder of Merlin?</span></div><span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span></div>
+          <p class="text-xs text-slate-400 leading-relaxed">Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website.</p>
+          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.</div>
+          <div class="flex flex-col sm:flex-row items-center gap-3"><a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">⚡ Claim Merlin Profile ($49/yr)</a></div>
         </div>
-
-
       </div>
     </main>
 
-    <!-- Footer -->
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
-    </footer>
+    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div></footer>
   </body>
 </html>
-


### PR DESCRIPTION
## Summary
- moves Merlin's exact verified Tapfiliate referral URL above the fold and keeps a second closing affiliate CTA
- replaces generic editorial placeholders with current Free vs Pro decision guidance
- adds current official $0 Free plan and $19/month annual-effective Pro pricing with fair-usage caveat
- adds browser-extension, multi-model, research and creation use-case guidance
- adds affiliate disclosure and a source note

## Evidence
- Merlin Affiliate Program approval email supplies the exact unique referral URL `https://www.getmerlin.in/chat?ref=yjeyytn` and confirms 30% recurring commission under the program's stated conversion window
- Merlin official pricing pages checked 2026-09-02 show Free $0 and Pro $19/month on the annual plan, plus current feature/usage limits

## Safety
- exact account-specific affiliate URL preserved
- non-affiliate direct link remains available
- no paid action, guessed tracking URL, unsupported rating or revenue claim