### PR TITLE
Queue Kittl approved tracking-link recovery

### DIFF
--- a/projects/GlobalSaaSHub/data/browser_required_queue.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.json
@@ -56,5 +56,19 @@
       "Do not bypass CAPTCHA, OTP, phone verification, legal consent or forced identity verification; request user intervention only for those mandatory steps.",
       "Do not purchase YouTube, design, editing or promotion services."
     ]
+  },
+  {
+    "id": "kittl-impact-approved-referral-link",
+    "priority": "high",
+    "status": "browser_required",
+    "cost": "0",
+    "verified_at": "2026-09-02T00:47:00+09:00",
+    "reason": "Kittl's Impact email explicitly welcomes COSHUMA to the Kittl Affiliate Program, while the repository still records Kittl as application_submitted with affiliate_url=null. The approval email provides brand/support resources but does not expose an account-specific customer referral URL, so no revenue URL can be safely published yet.",
+    "next_action": "Reuse an already authenticated Impact browser session, open the Kittl campaign/link-creation area, obtain the exact customer-facing tracking URL, verify its account-specific tracking identifier and destination, then update Kittl's affiliate status/data and eligible COSHUMA CTAs. Use Kittl's provided brand guidelines when preparing conversion content after the tracking URL is verified.",
+    "do_not": [
+      "Do not treat the Impact email redirect, notification-settings URL, Help Center or brand-guidelines URL as an affiliate/revenue link.",
+      "Do not guess or construct an Impact tracking URL or campaign parameter.",
+      "Do not submit another Kittl affiliate application because approval is already evidenced by the welcome email."
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- records Kittl as an approved browser-required revenue task based on the official Impact welcome email
- prevents the stale `application_submitted` repository state from causing a duplicate application
- requires recovery and verification of the actual customer-facing Impact tracking URL before any Kittl CTA is changed

## Evidence
- Kittl / Impact email to support@coshuma.com on 2026-09-01: “Welcome to the Kittl Affiliate Program”
- current repository data still has `affiliate_url=null` and `affiliate_status=application_submitted`
- the email contains brand/support resources but no account-specific customer referral link

## Safety
- no guessed Impact parameter
- no generic email/help/brand URL treated as revenue link
- no duplicate application
- no paid action