### PR TITLE
Optimize VidIQ buyer-intent affiliate landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/vidiq.html
+++ b/projects/GlobalSaaSHub/public/tool/vidiq.html
@@ -3,29 +3,33 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>VidIQ Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="VidIQ is an essential AI-powered toolkit for YouTube creators, providing robust features for keyword research, video analytics, optimization, and comp... Discover features, pricing (Free plan available), and official links for VidIQ on GlobalSaaSHub." />
+    <title>VidIQ Pricing: Free, Boost & Max + YouTube Growth Review (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Compare VidIQ Free, Boost and Max for YouTube keyword research, AI Coach, thumbnails, competitor tracking and channel growth. See current 2026 pricing and start with the verified partner link." />
     <link rel="canonical" href="https://coshuma.com/tool/vidiq.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://coshuma.com/tool/vidiq.html" />
-    <meta property="og:title" content="VidIQ Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="VidIQ is an essential AI-powered toolkit for YouTube creators, providing robust features for keyword research, video analytics, optimization, and comp... Check rating, pricing, and features." />
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://coshuma.com/tool/vidiq.html" />
+    <meta property="og:title" content="VidIQ Pricing: Free, Boost & Max + YouTube Growth Review (2026)" />
+    <meta property="og:description" content="A practical 2026 guide to VidIQ Free, Boost and Max, including AI credits, keyword research, competitor tracking and verified pricing links." />
+
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "VidIQ",
-      "operatingSystem": "Web",
-      "applicationCategory": "Video & Shorts Gen",
-      "description": "VidIQ is an essential AI-powered toolkit for YouTube creators, providing robust features for keyword research, video analytics, optimization, and competitor analysis. It leverages AI for generating titles, content ideas, video scripts, and descriptions to boost channel growth."
+      "operatingSystem": "Web, Browser Extension",
+      "applicationCategory": "MultimediaApplication",
+      "url": "https://coshuma.com/tool/vidiq.html",
+      "description": "YouTube growth software for keyword research, competitor tracking, AI-assisted ideas, thumbnails, scripts and channel optimization.",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD",
+        "description": "Free plan available"
+      }
     }
     </script>
 
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,134 +40,117 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
+    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
+      <section class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-7">
+        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=vidiq.com&sz=128" alt="VidIQ logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=vidiq.com&sz=128" alt="VidIQ logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Video & Shorts Gen</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">VidIQ</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">YouTube Growth & SEO</div>
+              <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">VidIQ Pricing & Review (2026)</h1>
             </div>
           </div>
+          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-3 py-1.5 rounded-md">Pricing sources checked Sep 2, 2026</span>
+        </div>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
+        <p class="text-slate-300 text-base md:text-lg leading-relaxed">
+          VidIQ combines YouTube keyword research, competitor tracking, AI-assisted ideas, thumbnails, scripts and channel optimization. The easiest way to evaluate it is to start on the free plan, then upgrade only if you need more research depth, AI credits or multi-channel capacity.
+        </p>
+
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs uppercase tracking-wider text-slate-400 font-bold">Free</div>
+            <div class="text-2xl font-black text-white mt-1">$0</div>
+            <div class="text-xs text-slate-400 mt-2">150 AI credits/month, limited research and core creator tools.</div>
+          </div>
+          <div class="p-4 rounded-2xl bg-purple-500/10 border border-purple-500/30">
+            <div class="text-xs uppercase tracking-wider text-purple-300 font-bold">Boost</div>
+            <div class="text-2xl font-black text-white mt-1">$19/mo</div>
+            <div class="text-xs text-slate-300 mt-2">Or $199/year in VidIQ's U.S. pricing comparison; 2,000 AI credits for one channel.</div>
+          </div>
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs uppercase tracking-wider text-slate-400 font-bold">Max</div>
+            <div class="text-2xl font-black text-white mt-1">$49/mo</div>
+            <div class="text-xs text-slate-400 mt-2">Or $468/year in VidIQ's U.S. pricing comparison; 6,000 AI credits for one channel.</div>
           </div>
         </div>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">VidIQ is an essential AI-powered toolkit for YouTube creators, providing robust features for keyword research, video analytics, optimization, and competitor analysis. It leverages AI for generating titles, content ideas, video scripts, and descriptions to boost channel growth.</p>
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a data-cta="affiliate" data-tool-id="vidiq" href="https://vidiq.com/coshuma" target="_blank" rel="sponsored noopener noreferrer" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start VidIQ Free →</a>
+          <a href="/compare/vidiq-vs-tubebuddy.html" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-[#181a29] border border-[#30344c] text-white text-center hover:border-purple-500/50 transition-all">Compare VidIQ vs TubeBuddy →</a>
         </div>
+        <p class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: the VidIQ button uses a verified COSHUMA partner link. GlobalSaaSHub may earn a commission if you purchase after using it, at no extra cost to you. Prices and regional offers can change; confirm the final amount at checkout.</p>
+      </section>
 
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> YouTube keyword research</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI video optimization</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Competitor analysis</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI content generation (titles, scripts)</div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">Which VidIQ plan makes sense?</h2>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-2">
+            <h3 class="font-bold text-emerald-300">Start with Free</h3>
+            <p class="text-slate-300 leading-relaxed">Best if you are validating VidIQ before paying. Current official documentation lists 150 AI credits per month, 3 keyword results per search, up to 3 tracked competitors and 3 personalized daily ideas.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/30 space-y-2">
+            <h3 class="font-bold text-purple-300">Move to Boost when research limits slow you down</h3>
+            <p class="text-slate-300 leading-relaxed">Boost raises the monthly AI allowance to 2,000 credits for one channel and unlocks unlimited keyword research, unlimited Outliers research, 50 personalized daily ideas, up to 20 tracked competitors, Best Time to Post and subscriber analysis.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-2">
+            <h3 class="font-bold text-blue-300">Choose Max for heavier AI use</h3>
+            <p class="text-slate-300 leading-relaxed">Max starts at 6,000 AI credits for one channel and raises competitor tracking to up to 50. It is the better fit when AI Coach, thumbnails, clipping, scripts and other credit-using tools become part of your regular workflow.</p>
           </div>
         </div>
+      </section>
 
-        <!-- Pros & Cons Section -->
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">What you can do with VidIQ</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-slate-300">
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Research YouTube keywords and search opportunities</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Find outlier videos and niche trends worth testing</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Track competitors and channel performance signals</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Generate or improve titles, scripts and thumbnails with AI credits</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Use the browser extension inside the YouTube research workflow</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Check Shorts scorecards, optimization scores and real-time stats</div>
+        </div>
+      </section>
+
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">VidIQ vs TubeBuddy: quick choice</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (Free plan available)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
+          <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/20">
+            <h3 class="font-bold text-purple-300 mb-2">Pick VidIQ if...</h3>
+            <p class="text-sm text-slate-300 leading-relaxed">You want a YouTube growth workflow centered on data-backed ideas, outlier discovery, AI Coach, thumbnails, scripts and channel opportunity research.</p>
           </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
+          <div class="p-5 rounded-2xl bg-blue-500/5 border border-blue-500/20">
+            <h3 class="font-bold text-blue-300 mb-2">Compare TubeBuddy if...</h3>
+            <p class="text-sm text-slate-300 leading-relaxed">You care more about YouTube Studio productivity, SEO utilities and bulk channel-management workflows. Use the full comparison before choosing.</p>
           </div>
         </div>
+        <a href="/compare/vidiq-vs-tubebuddy.html" class="inline-flex px-5 py-3 rounded-xl bg-[#181a29] border border-[#30344c] font-bold text-sm text-white hover:border-purple-500/50 transition-all">See the VidIQ vs TubeBuddy comparison →</a>
+      </section>
 
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to VidIQ</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/tubebuddy.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=tubebuddy.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">TubeBuddy</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/outlierkit.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=outlierkit.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">OutlierKit</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/pictory.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=pictory.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Pictory</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4 text-center">
+        <h2 class="text-2xl font-black text-white">Best low-risk starting point: test the free plan</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto leading-relaxed">Use the free tier to see whether VidIQ's ideas, keyword data, competitor signals and AI workflow match the way you plan videos. Upgrade only when the free limits are clearly holding back your workflow.</p>
+        <a data-cta="affiliate" data-tool-id="vidiq" href="https://vidiq.com/coshuma" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Try VidIQ Free via COSHUMA →</a>
+        <p class="text-[10px] text-slate-500">Verified partner URL: vidiq.com/coshuma. Final pricing, taxes, discounts and regional availability are controlled by VidIQ.</p>
+      </section>
 
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">Free plan available</div>
-          </div>
-          <a data-cta="official" href="https://vidiq.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official VidIQ Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://vidiq.com/coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit VidIQ via Verified Affiliate Link</span><span>→</span></a>
-        </div>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of VidIQ?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim VidIQ Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/vidiq.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="VidIQ Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
-      </div>
+      <section class="p-5 rounded-2xl bg-[#10121b] border border-[#222538] text-xs text-slate-500 leading-relaxed">
+        <strong class="text-slate-300">Source note:</strong> pricing references are based on VidIQ's official 2026 plan/help pages and its official VidIQ-vs-TubeBuddy comparison, which states U.S. pricing checked August 7, 2026. Feature limits are based on VidIQ's May 6, 2026 plan-credit documentation. This page does not claim hands-on testing where none was performed.
+      </section>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
Revenue-focused, no-cost conversion update for the verified VidIQ partner funnel.

What changed:
- replaces generic/not-rated copy with a buyer-intent 2026 pricing and plan guide
- preserves the verified affiliate URL `https://vidiq.com/coshuma`
- adds prominent affiliate CTAs with `data-cta="affiliate"`, `data-tool-id="vidiq"` and sponsored rel attributes
- adds Free / Boost / Max decision guidance and a VidIQ-vs-TubeBuddy internal comparison path
- adds explicit affiliate disclosure and source transparency

Evidence checked before publishing:
- repository marks VidIQ as `affiliate_verified: true`, `affiliate_status: approved_tracking`
- VidIQ official plan/help documentation: Free 150 AI credits; Boost 2,000; Max 6,000 for one channel, plus plan feature limits
- VidIQ official comparison page states U.S. pricing checked Aug 7, 2026: Boost $19 monthly / $199 yearly; Max $49 monthly / $468 yearly

No paid services or ad spend used.