### PR TITLE
Optimize Make.com buyer-intent affiliate landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/make-com.html
+++ b/projects/GlobalSaaSHub/public/tool/make-com.html
@@ -3,29 +3,30 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Make.com Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="A visual automation platform that lets you design, build, and automate anything—from simple tasks to complex workflows—in minutes without coding.... Discover features, pricing (See official pricing), and official links for Make.com on GlobalSaaSHub." />
+    <title>Make.com Pricing, Free Plan & Automation Review (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Compare Make.com Free, Core, Pro and Teams plans for 2026, see who each plan fits, and start with the verified COSHUMA affiliate link." />
     <link rel="canonical" href="https://coshuma.com/tool/make-com.html" />
-    
-    <!-- Open Graph SEO Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/make-com.html" />
-    <meta property="og:title" content="Make.com Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="A visual automation platform that lets you design, build, and automate anything—from simple tasks to complex workflows—in minutes without coding.... Check rating, pricing, and features." />
-
-    <!-- JSON-LD Structured Data for Google Indexing -->
+    <meta property="og:title" content="Make.com Pricing, Free Plan & Automation Review (2026)" />
+    <meta property="og:description" content="Current Make.com plan guidance, automation features, buying considerations and a verified partner CTA." />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Make.com",
       "operatingSystem": "Web",
-      "applicationCategory": "Coding & Dev Tools",
-      "description": "A visual automation platform that lets you design, build, and automate anything—from simple tasks to complex workflows—in minutes without coding."
+      "applicationCategory": "BusinessApplication",
+      "description": "Visual workflow automation platform for connecting apps, APIs and AI services.",
+      "offers": {
+        "@type": "AggregateOffer",
+        "lowPrice": "0",
+        "highPrice": "38",
+        "priceCurrency": "USD",
+        "offerCount": "4"
+      }
     }
     </script>
-
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,134 +37,104 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
     <main class="max-w-4xl mx-auto px-4 py-12 w-full">
       <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
         <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=make.com&sz=128" alt="Make.com logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=make.com&sz=128" alt="Make.com logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Coding & Dev Tools</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Make.com</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">Workflow Automation</div>
+              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Make.com Pricing & Review (2026)</h1>
+              <p class="text-sm text-slate-400 mt-2">Best for visual no-code automation, multi-step workflows and AI-powered scenarios.</p>
             </div>
           </div>
+        </div>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
+        <div class="p-5 rounded-2xl bg-purple-500/10 border border-purple-500/25 space-y-3">
+          <div class="text-xs uppercase tracking-wider font-extrabold text-purple-300">Quick recommendation</div>
+          <p class="text-slate-200 leading-relaxed">Start on the <strong>Free plan</strong> if you are testing a few workflows. Move to <strong>Core</strong> when you need minute-level scheduling and unlimited active scenarios, <strong>Pro</strong> for priority execution and advanced controls, or <strong>Teams</strong> for shared team roles and templates.</p>
+          <a data-cta="affiliate" data-tool-id="make-com" href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex items-center justify-center px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start Make.com Free via Verified Partner Link →</a>
+          <p class="text-[11px] text-slate-400">Affiliate disclosure: COSHUMA may earn a commission if you become a paying customer through this verified link, at no extra cost to you.</p>
+        </div>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">Current Make.com pricing</h2>
+          <p class="text-sm text-slate-400">Pricing checked against Make's official pricing page on September 2, 2026. Paid prices below are the displayed monthly prices for 10,000 credits/month; final pricing can vary by credit volume, billing term and region.</p>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-emerald-400 font-extrabold">Free — $0/mo</div><p class="text-sm text-slate-300 mt-2">Up to 1,000 credits/month, visual workflow builder, 3,000+ apps, routers and filters. Best for learning and light automations.</p></div>
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-emerald-400 font-extrabold">Core — $12/mo</div><p class="text-sm text-slate-300 mt-2">Shown for 10,000 credits/month. Adds unlimited active scenarios, minute-level scheduling, more data transfer and Make API access.</p></div>
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-emerald-400 font-extrabold">Pro — $21/mo</div><p class="text-sm text-slate-300 mt-2">Shown for 10,000 credits/month. Adds priority scenario execution, custom variables and full-text execution-log search.</p></div>
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-emerald-400 font-extrabold">Teams — $38/mo</div><p class="text-sm text-slate-300 mt-2">Shown for 10,000 credits/month. Adds teams, team roles and shared scenario templates. Enterprise uses custom pricing.</p></div>
           </div>
-        </div>
+        </section>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">A visual automation platform that lets you design, build, and automate anything—from simple tasks to complex workflows—in minutes without coding.</p>
-        </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">What you can automate</h2>
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Visual Drag & Drop</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> 3000+ Integrations</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Advanced Branching</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> JSON Parsing</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-200"><strong class="text-purple-300">App workflows:</strong> connect CRM, email, spreadsheets, databases, forms and thousands of other apps.</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-200"><strong class="text-purple-300">AI workflows:</strong> connect AI services, Make AI features and custom provider connections on paid plans.</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-200"><strong class="text-purple-300">Logic & routing:</strong> use filters, routers, branching and data transformation for multi-step processes.</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-200"><strong class="text-purple-300">APIs:</strong> paid plans can use Make API access while advanced workflows can connect external services and custom apps.</div>
           </div>
-        </div>
+        </section>
 
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
+            <h3 class="text-sm font-bold text-emerald-400">Best reasons to choose Make</h3>
+            <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+              <li>Free plan has no time limit.</li>
+              <li>Visual builder makes multi-step logic easier to inspect.</li>
+              <li>Large app ecosystem and strong API/AI flexibility.</li>
+              <li>Pricing scales by credit volume instead of forcing one fixed usage level.</li>
             </ul>
           </div>
-
           <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
+            <h3 class="text-sm font-bold text-rose-400">Check before upgrading</h3>
+            <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+              <li>Every module action consumes credits, so complex scenarios can use more than expected.</li>
+              <li>Extra credits cost more than credits included in your plan.</li>
+              <li>Some higher-volume or security needs may push you toward Pro, Teams or Enterprise.</li>
             </ul>
           </div>
-        </div>
+        </section>
 
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Make.com</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
+        <section class="space-y-4 pt-4 border-t border-[#222538]">
+          <h2 class="text-xl font-bold text-white">Make.com vs alternatives</h2>
           <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/unbounce.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=unbounce.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Unbounce</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/jotform.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=jotform.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Jotform</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/webflow.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=webflow.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Webflow</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
+            <a href="/compare/n8n-vs-make-com.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-slate-200">n8n vs Make.com</div><div class="text-xs text-slate-400 mt-1">Compare visual automation with a more technical/self-hostable option.</div></a>
+            <a href="/tool/gumloop.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-slate-200">Gumloop</div><div class="text-xs text-slate-400 mt-1">Explore an AI-first workflow automation alternative.</div></a>
+            <a href="/tool/jotform.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-slate-200">Jotform</div><div class="text-xs text-slate-400 mt-1">Useful when form-driven workflows are the main requirement.</div></a>
           </div>
-        </div>
+        </section>
 
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
+        <section class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] space-y-4">
+          <h2 class="text-xl font-bold text-white">Who should start with Make.com?</h2>
+          <p class="text-slate-300 leading-relaxed">Make is a strong fit for creators, operations teams, marketers, agencies and small businesses that want to automate repetitive work without writing a full integration from scratch. The Free plan is enough to validate a workflow before committing to a paid tier.</p>
+          <div class="flex flex-col sm:flex-row gap-3">
+            <a data-cta="affiliate" data-tool-id="make-com" href="https://www.make.com/en?pc=coshuma&affiliatesource=coshuma-tool" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Try Make.com Free →</a>
+            <a data-cta="official" href="https://www.make.com/en/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-bold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Check Official Pricing</a>
           </div>
-          <a data-cta="official" href="https://www.make.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Make.com Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Make.com via Verified Affiliate Link</span><span>→</span></a>
-        </div>
+          <p class="text-[11px] text-slate-500">COSHUMA uses the verified partner code <code>pc=coshuma</code>. The source-tagged CTA follows Make's documented affiliate-source parameter format for attribution.</p>
+        </section>
 
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Make.com?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Make.com Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/make-com.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Make.com Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
+        <section class="p-5 rounded-2xl bg-[#0b0c10] border border-[#222538] text-xs text-slate-400 leading-relaxed">
+          <strong class="text-slate-300">Editorial note:</strong> This page is based on Make's current public pricing and help documentation. COSHUMA does not claim hands-on testing where it has not been independently verified. Always confirm final pricing and limits on Make before purchasing.
+        </section>
       </div>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
Refresh the Make.com tool page using current official pricing and affiliate-program documentation. Keeps the verified `pc=coshuma` partner CTA, adds plan-selection guidance, direct automation use cases, a buyer-intent n8n comparison path, affiliate disclosure, and a documented `affiliatesource` attribution parameter on the secondary CTA. No paid services or new dependencies.