### PR TITLE
Optimize TubeBuddy buyer-intent affiliate landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/tubebuddy.html
+++ b/projects/GlobalSaaSHub/public/tool/tubebuddy.html
@@ -3,29 +3,27 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>TubeBuddy Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="An essential browser extension and mobile app for YouTube creators, TubeBuddy helps optimize and grow YouTube channels through advanced analytics, SEO... Discover features, pricing (See official pricing), and official links for TubeBuddy on GlobalSaaSHub." />
+    <title>TubeBuddy Pricing, Pro vs Legend & YouTube SEO Review (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Compare TubeBuddy Pro, Legend and Enterprise for YouTube SEO, keyword research, A/B testing, Shorts linking, analytics and bulk channel workflows. Use the verified COSHUMA partner link and confirm live pricing at checkout." />
     <link rel="canonical" href="https://coshuma.com/tool/tubebuddy.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://coshuma.com/tool/tubebuddy.html" />
-    <meta property="og:title" content="TubeBuddy Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="An essential browser extension and mobile app for YouTube creators, TubeBuddy helps optimize and grow YouTube channels through advanced analytics, SEO... Check rating, pricing, and features." />
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://coshuma.com/tool/tubebuddy.html" />
+    <meta property="og:title" content="TubeBuddy Pricing, Pro vs Legend & YouTube SEO Review (2026)" />
+    <meta property="og:description" content="A practical TubeBuddy plan guide for creators comparing Pro, Legend and Enterprise, with verified partner access and current feature guidance." />
+
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "TubeBuddy",
-      "operatingSystem": "Web",
-      "applicationCategory": "Video & Shorts Gen",
-      "description": "An essential browser extension and mobile app for YouTube creators, TubeBuddy helps optimize and grow YouTube channels through advanced analytics, SEO tools, and productivity features."
+      "operatingSystem": "Web, Browser Extension",
+      "applicationCategory": "MultimediaApplication",
+      "url": "https://coshuma.com/tool/tubebuddy.html",
+      "description": "YouTube creator software for keyword research, SEO optimization, A/B testing, analytics, Shorts linking and channel productivity workflows."
     }
     </script>
 
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,134 +34,123 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
+    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
+      <section class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-7">
+        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=tubebuddy.com&sz=128" alt="TubeBuddy logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=tubebuddy.com&sz=128" alt="TubeBuddy logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Video & Shorts Gen</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">TubeBuddy</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">YouTube SEO & Growth</div>
+              <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">TubeBuddy Pricing & Review (2026)</h1>
             </div>
           </div>
+          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-3 py-1.5 rounded-md">Official sources checked Sep 2, 2026</span>
+        </div>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
+        <p class="text-slate-300 text-base md:text-lg leading-relaxed">
+          TubeBuddy is built around the YouTube workflow: keyword research, SEO Studio, title and tag optimization, thumbnail testing, analytics, content strategy and bulk channel tools. Its current public pricing page centers on Pro, Legend and Enterprise. The page also offers annual billing with a stated 20% saving, while the final numeric price can depend on the channel and checkout state.
+        </p>
+
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs uppercase tracking-wider text-slate-400 font-bold">Pro</div>
+            <div class="text-xl font-black text-white mt-1">For individual creators</div>
+            <div class="text-xs text-slate-400 mt-2">Core SEO, basic video and thumbnail tools, title/tag optimization, content strategy, audience tools, Shorts linking and topical analysis.</div>
+          </div>
+          <div class="p-4 rounded-2xl bg-purple-500/10 border border-purple-500/30">
+            <div class="text-xs uppercase tracking-wider text-purple-300 font-bold">Legend</div>
+            <div class="text-xl font-black text-white mt-1">For scaling channels</div>
+            <div class="text-xs text-slate-300 mt-2">Adds deeper SEO access, advanced reporting, bulk processing, fuller audience tools and expanded content strategy features.</div>
+          </div>
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs uppercase tracking-wider text-slate-400 font-bold">Enterprise</div>
+            <div class="text-xl font-black text-white mt-1">Custom pricing</div>
+            <div class="text-xs text-slate-400 mt-2">For brands and teams managing multiple channels, with unlimited users, training, dedicated support and advanced analytics.</div>
           </div>
         </div>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">An essential browser extension and mobile app for YouTube creators, TubeBuddy helps optimize and grow YouTube channels through advanced analytics, SEO tools, and productivity features.</p>
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a data-cta="affiliate" data-tool-id="tubebuddy" href="https://www.tubebuddy.com/pricing?a=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Check TubeBuddy Plans via COSHUMA →</a>
+          <a href="/compare/vidiq-vs-tubebuddy.html" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-[#181a29] border border-[#30344c] text-white text-center hover:border-purple-500/50 transition-all">Compare VidIQ vs TubeBuddy →</a>
         </div>
+        <p class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: the TubeBuddy plan button uses COSHUMA's verified partner URL. GlobalSaaSHub may earn a commission if you purchase after using it, at no extra cost to you. Final prices, taxes, discounts and eligibility are controlled by TubeBuddy.</p>
+      </section>
 
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Video SEO optimization</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Keyword research tools</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Bulk processing features</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Channel health reports</div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">Which TubeBuddy plan should you choose?</h2>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-2">
+            <h3 class="font-bold text-emerald-300">Start with Pro if the workflow is the main need</h3>
+            <p class="text-slate-300 leading-relaxed">Pro is the lower-complexity creator tier. TubeBuddy currently lists limited Next Video Ideas, basic video and thumbnail tools, title and tag optimization, content strategy, audience tools, YouTube Shorts linking and Topical Analysis in the Pro package.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/30 space-y-2">
+            <h3 class="font-bold text-purple-300">Move to Legend for heavier optimization</h3>
+            <p class="text-slate-300 leading-relaxed">Legend is the stronger fit when full SEO access, advanced reporting, bulk processing, deeper audience analysis and repeated testing become part of a regular publishing workflow.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-2">
+            <h3 class="font-bold text-blue-300">Use Enterprise for multi-channel teams</h3>
+            <p class="text-slate-300 leading-relaxed">TubeBuddy positions Enterprise for creators, brands and teams managing multiple channels. Its public page lists custom pricing, unlimited users, 1:1 training, dedicated expert support and automated channel reviews.</p>
           </div>
         </div>
+      </section>
 
-        <!-- Pros & Cons Section -->
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">What TubeBuddy can help with</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-slate-300">
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Find YouTube keywords with Keyword Explorer</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Improve titles, tags and descriptions with SEO Studio</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Test thumbnails and metadata with A/B Testing</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Analyze channel and niche performance signals</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Use Suggested Shorts and YouTube Shorts linking workflows</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Speed up established channels with bulk editing and productivity tools</div>
+        </div>
+      </section>
+
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">TubeBuddy vs VidIQ: quick decision</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
+          <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/20">
+            <h3 class="font-bold text-purple-300 mb-2">Pick TubeBuddy if...</h3>
+            <p class="text-sm text-slate-300 leading-relaxed">You want YouTube Studio-oriented productivity, SEO utilities, metadata and thumbnail testing, channel analysis and bulk management features in one creator toolkit.</p>
           </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
+          <div class="p-5 rounded-2xl bg-blue-500/5 border border-blue-500/20">
+            <h3 class="font-bold text-blue-300 mb-2">Compare VidIQ if...</h3>
+            <p class="text-sm text-slate-300 leading-relaxed">You want a workflow that leans more heavily on AI credits, outlier discovery, AI Coach, competitor tracking and idea generation. Both products have verified COSHUMA partner routes.</p>
           </div>
         </div>
+        <a href="/compare/vidiq-vs-tubebuddy.html" class="inline-flex px-5 py-3 rounded-xl bg-[#181a29] border border-[#30344c] font-bold text-sm text-white hover:border-purple-500/50 transition-all">See the full VidIQ vs TubeBuddy comparison →</a>
+      </section>
 
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to TubeBuddy</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/outlierkit.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=outlierkit.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">OutlierKit</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/pictory.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=pictory.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Pictory</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/fliki.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=fliki.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Fliki</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-amber-500/20 space-y-4">
+        <h2 class="text-2xl font-black text-white">Pricing note before you upgrade</h2>
+        <p class="text-sm text-slate-300 leading-relaxed">TubeBuddy's live pricing page currently shows Pro, Legend and Enterprise and advertises a 20% saving for annual billing, but its server-rendered public page does not expose a stable numeric Pro or Legend price in every session. For accuracy, use the verified plan link, select the channel you intend to license and confirm the final amount before paying. TubeBuddy also states there are no contracts and you can cancel at any time.</p>
+        <p class="text-xs text-slate-500">For channels with fewer than 1,000 subscribers, TubeBuddy's help center currently documents a separate RisingStarBuddy coupon that can provide 50% off a Pro license. Eligibility and pricing can change, so verify it at checkout rather than assuming the discount applies.</p>
+      </section>
 
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://www.tubebuddy.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official TubeBuddy Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://www.tubebuddy.com/pricing?a=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit TubeBuddy via Verified Affiliate Link</span><span>→</span></a>
-        </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4 text-center">
+        <h2 class="text-2xl font-black text-white">Best next step: compare the live plan for your channel</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto leading-relaxed">If YouTube SEO, thumbnail testing or repetitive channel-management work is already taking time, check the live plan options for the exact channel you manage. If you are still deciding between research-first and workflow-first creator tools, read the VidIQ comparison before paying.</p>
+        <a data-cta="affiliate" data-tool-id="tubebuddy" href="https://www.tubebuddy.com/pricing?a=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">View TubeBuddy Plans via COSHUMA →</a>
+        <p class="text-[10px] text-slate-500">Verified partner URL: tubebuddy.com/pricing?a=coshuma. No purchase is required to use this comparison page.</p>
+      </section>
 
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of TubeBuddy?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim TubeBuddy Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/tubebuddy.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="TubeBuddy Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
-      </div>
+      <section class="p-5 rounded-2xl bg-[#10121b] border border-[#222538] text-xs text-slate-500 leading-relaxed">
+        <strong class="text-slate-300">Source note:</strong> plan structure and features were checked against TubeBuddy's official pricing page on September 2, 2026, including Pro, Legend, Enterprise, annual-billing savings, Shorts linking, SEO and bulk-processing feature tables. Additional feature details were cross-checked against TubeBuddy's official homepage, Keyword Explorer, A/B Testing and support documentation. This page does not claim hands-on testing where none was performed.
+      </section>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
Revenue-focused, zero-cost update for the verified TubeBuddy funnel.

What changed:
- replaces generic/not-rated copy with a current buyer-intent Pro vs Legend vs Enterprise guide
- preserves the verified customer-facing affiliate URL `https://www.tubebuddy.com/pricing?a=coshuma`
- moves verified affiliate CTAs above the fold and into the closing decision section with `data-cta="affiliate"` and `data-tool-id="tubebuddy"`
- adds current official plan positioning for YouTube SEO, Keyword Explorer, A/B testing, Shorts linking, analytics and bulk workflows
- links directly to the existing VidIQ vs TubeBuddy comparison for higher-intent visitors
- avoids hard-coding unstable numeric Pro/Legend prices because TubeBuddy's live public pricing page currently renders plan names and annual 20% savings but not a stable amount in every server-rendered session
- adds explicit affiliate disclosure and source transparency

Evidence checked Sep 2, 2026:
- repository verified partner URL and `approved_tracking` state
- TubeBuddy official pricing page: Pro, Legend, Enterprise, annual billing saves 20%, no contracts/cancel any time, plan feature table
- TubeBuddy official homepage/tool pages: Keyword Explorer, SEO Studio, A/B Testing, analytics, Shorts and creator workflow features
- TubeBuddy support: RisingStarBuddy coupon is documented for eligible channels under 1,000 subscribers; page tells users to verify eligibility at checkout

No paid services, subscriptions, ad spend, guessed tracking URLs or unsupported revenue claims are introduced.