### PR TITLE
Optimize Pictory buyer-intent affiliate landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/pictory.html
+++ b/projects/GlobalSaaSHub/public/tool/pictory.html
@@ -3,29 +3,27 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Pictory Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="An AI-powered video creation tool that automatically transforms text into engaging videos, making it easy for marketers and content creators to produc... Discover features, pricing (See official pricing), and official links for Pictory on GlobalSaaSHub." />
+    <title>Pictory Pricing, Free Trial & AI Video Review (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Compare Pictory Starter, Professional and Team pricing for AI video creation. See current monthly and annual pricing, core features, free-trial access and the verified COSHUMA partner route." />
     <link rel="canonical" href="https://coshuma.com/tool/pictory.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://coshuma.com/tool/pictory.html" />
-    <meta property="og:title" content="Pictory Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="An AI-powered video creation tool that automatically transforms text into engaging videos, making it easy for marketers and content creators to produc... Check rating, pricing, and features." />
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://coshuma.com/tool/pictory.html" />
+    <meta property="og:title" content="Pictory Pricing, Free Trial & AI Video Review (2026)" />
+    <meta property="og:description" content="A practical Pictory plan guide for creators and teams comparing Starter, Professional and Team plans for script-to-video, captions, AI voices, avatars and content repurposing." />
+
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Pictory",
       "operatingSystem": "Web",
-      "applicationCategory": "Video & Shorts Gen",
-      "description": "An AI-powered video creation tool that automatically transforms text into engaging videos, making it easy for marketers and content creators to produce compelling video content quickly."
+      "applicationCategory": "MultimediaApplication",
+      "url": "https://coshuma.com/tool/pictory.html",
+      "description": "AI video creation software for turning scripts, URLs, documents and long-form content into edited videos, clips and captioned social content."
     }
     </script>
 
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,134 +34,129 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
+    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
+      <section class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-7">
+        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=pictory.ai&sz=128" alt="Pictory logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=pictory.ai&sz=128" alt="Pictory logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Video & Shorts Gen</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Pictory</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">AI Video Creation</div>
+              <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Pictory Pricing & Review (2026)</h1>
             </div>
           </div>
+          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-3 py-1.5 rounded-md">Official pricing checked Sep 2, 2026</span>
+        </div>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
+        <p class="text-slate-300 text-base md:text-lg leading-relaxed">
+          Pictory is aimed at creators, marketers and teams that want to turn scripts, webpages, documents or existing long-form media into polished videos without a traditional editing workflow. Its live pricing page currently offers Starter, Professional, Team and Enterprise plans, with a free-trial option shown alongside the paid plans.
+        </p>
+
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs uppercase tracking-wider text-slate-400 font-bold">Starter</div>
+            <div class="text-2xl font-black text-white mt-1">$29/mo</div>
+            <div class="text-xs text-emerald-300 font-bold mt-1">$25/mo billed annually</div>
+            <div class="text-xs text-slate-400 mt-2">1 user, 200 monthly video minutes, 5 GB storage, 1 brand kit, 60 minutes of ElevenLabs AI voices and basic AI tools.</div>
+          </div>
+          <div class="p-4 rounded-2xl bg-purple-500/10 border border-purple-500/30">
+            <div class="text-xs uppercase tracking-wider text-purple-300 font-bold">Professional</div>
+            <div class="text-2xl font-black text-white mt-1">$59/mo</div>
+            <div class="text-xs text-emerald-300 font-bold mt-1">$35/mo billed annually</div>
+            <div class="text-xs text-slate-300 mt-2">1 user, 600 monthly video minutes, 20 GB storage, 5 brand kits, custom avatars, voice cloning and advanced AI tools.</div>
+          </div>
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs uppercase tracking-wider text-slate-400 font-bold">Team</div>
+            <div class="text-2xl font-black text-white mt-1">$199/mo</div>
+            <div class="text-xs text-emerald-300 font-bold mt-1">$119/mo billed annually</div>
+            <div class="text-xs text-slate-400 mt-2">3+ users, 1,800 monthly video minutes, 100 GB storage, 10 brand kits, team workspace, onboarding and team training.</div>
           </div>
         </div>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">An AI-powered video creation tool that automatically transforms text into engaging videos, making it easy for marketers and content creators to produce compelling video content quickly.</p>
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a data-cta="affiliate" data-tool-id="pictory" href="https://pictory.ai?fpr=sangkwon-an23" target="_blank" rel="sponsored noopener noreferrer" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start Pictory via COSHUMA →</a>
+          <a href="/compare/outlierkit-vs-pictory.html" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-[#181a29] border border-[#30344c] text-white text-center hover:border-purple-500/50 transition-all">Compare OutlierKit vs Pictory →</a>
         </div>
+        <p class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: the primary Pictory button uses COSHUMA's verified partner URL. GlobalSaaSHub may earn a commission if you purchase after using it, at no extra cost to you. Final prices, promotions, taxes and plan limits are controlled by Pictory.</p>
+      </section>
 
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Text-to-video conversion</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Automatic subtitling & captions</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Stock media library access</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Short video highlight reels</div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">Which Pictory plan makes sense?</h2>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-2">
+            <h3 class="font-bold text-emerald-300">Starter: simple solo production</h3>
+            <p class="text-slate-300 leading-relaxed">Best when you mainly need script-to-video, automatic captions, stock media and straightforward branded videos without the higher-end avatar and voice-cloning tools.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/30 space-y-2">
+            <h3 class="font-bold text-purple-300">Professional: heavier creator workflow</h3>
+            <p class="text-slate-300 leading-relaxed">The stronger fit for frequent content production because the live plan adds substantially more video minutes and storage plus custom avatars, voice cloning, advanced AI tools and long-video summarization.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-2">
+            <h3 class="font-bold text-blue-300">Team: shared production</h3>
+            <p class="text-slate-300 leading-relaxed">Useful when multiple people need a shared workspace, much larger video quotas, more storage and brand kits, plus onboarding and team training.</p>
           </div>
         </div>
+      </section>
 
-        <!-- Pros & Cons Section -->
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">What Pictory can do</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-slate-300">
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Turn ideas, scripts, URLs, documents, PDFs and PowerPoints into video</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Add automatic subtitles, captions, highlights and B-roll</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Use integrated stock media from Getty Images and Storyblocks</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Use ElevenLabs AI voices, with allowances varying by plan</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Access custom avatars and voice cloning on Professional and above</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Create social clips and repurpose long-form video content</div>
+        </div>
+      </section>
+
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">Pictory vs creator-growth tools</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
+          <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/20">
+            <h3 class="font-bold text-purple-300 mb-2">Choose Pictory if...</h3>
+            <p class="text-sm text-slate-300 leading-relaxed">Your bottleneck is producing the video itself: turning source material into edited footage, captions, voiceover, B-roll, clips or avatar-led content.</p>
           </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
+          <div class="p-5 rounded-2xl bg-blue-500/5 border border-blue-500/20">
+            <h3 class="font-bold text-blue-300 mb-2">Choose OutlierKit or TubeBuddy if...</h3>
+            <p class="text-sm text-slate-300 leading-relaxed">Your bigger problem is finding topics, analyzing YouTube opportunities or optimizing an existing channel rather than generating finished videos. Those tools solve a different stage of the creator workflow.</p>
           </div>
         </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Pictory</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/tubebuddy.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=tubebuddy.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">TubeBuddy</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/outlierkit.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=outlierkit.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">OutlierKit</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/fliki.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=fliki.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Fliki</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
+        <div class="flex flex-wrap gap-3">
+          <a href="/compare/outlierkit-vs-pictory.html" class="inline-flex px-5 py-3 rounded-xl bg-[#181a29] border border-[#30344c] font-bold text-sm text-white hover:border-purple-500/50 transition-all">OutlierKit vs Pictory →</a>
+          <a href="/compare/tubebuddy-vs-pictory.html" class="inline-flex px-5 py-3 rounded-xl bg-[#181a29] border border-[#30344c] font-bold text-sm text-white hover:border-purple-500/50 transition-all">TubeBuddy vs Pictory →</a>
         </div>
+      </section>
 
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://pictory.ai/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Pictory Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://pictory.ai?fpr=sangkwon-an23" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Pictory via Verified Affiliate Link</span><span>→</span></a>
-        </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-amber-500/20 space-y-4">
+        <h2 class="text-2xl font-black text-white">Pricing note before you pay</h2>
+        <p class="text-sm text-slate-300 leading-relaxed">Pictory's live pricing page currently displays promotional annual pricing and says annual plans can save up to 40%. Promotions can change, so compare the annual and monthly toggles and confirm the final checkout amount before purchasing. Enterprise pricing is custom.</p>
+        <p class="text-xs text-slate-500">The live pricing page shows a free-trial option for Starter, Professional and Team. Trial terms can change, so confirm the current eligibility and billing terms on Pictory before starting.</p>
+      </section>
 
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Pictory?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Pictory Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/pictory.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Pictory Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4 text-center">
+        <h2 class="text-2xl font-black text-white">Best next step: test the workflow before committing</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto leading-relaxed">If your goal is to turn written or long-form content into publishable video faster, use the current free-trial path first and check whether Pictory's automated scene selection, captions, stock media and voice workflow fit your content style.</p>
+        <a data-cta="affiliate" data-tool-id="pictory" href="https://pictory.ai?fpr=sangkwon-an23" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Try Pictory via COSHUMA →</a>
+        <p class="text-[10px] text-slate-500">Verified partner URL: pictory.ai?fpr=sangkwon-an23. No purchase is required to use this comparison page.</p>
+      </section>
 
-
-      </div>
+      <section class="p-5 rounded-2xl bg-[#10121b] border border-[#222538] text-xs text-slate-500 leading-relaxed">
+        <strong class="text-slate-300">Source note:</strong> pricing and plan details were checked against Pictory's official pricing page on September 2, 2026. Current official pages also list script/URL/document/PDF/PPT-to-video creation, automatic captions, highlights, stock media, ElevenLabs voices, custom avatars, voice cloning, team collaboration and API options. This page does not claim hands-on testing where none was performed.
+      </section>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
Revenue-focused, zero-cost update for the already verified Pictory affiliate funnel.

Changes:
- replaces generic/not-rated copy with a current buyer-intent Pictory plan guide
- preserves the verified customer-facing affiliate URL `https://pictory.ai?fpr=sangkwon-an23`
- moves affiliate CTAs above the fold and into the closing decision section with `data-cta="affiliate"` and `data-tool-id="pictory"`
- adds current Starter / Professional / Team monthly and annual pricing from Pictory's live official pricing page checked Sep 2, 2026
- adds plan-selection guidance for video minutes, storage, brand kits, ElevenLabs voices, avatars, voice cloning, team collaboration and free-trial positioning
- adds internal comparison paths to OutlierKit and TubeBuddy for creator-intent traffic
- adds explicit affiliate disclosure and source transparency

Evidence checked Sep 2, 2026:
- repository marks Pictory `affiliate_verified: true` and `approved_tracking` with the exact tracking URL above
- Pictory official live pricing: Starter $29 monthly / $25 annual-effective, Professional $59 / $35, Team $199 / $119; Enterprise custom; free-trial buttons are shown on paid plans
- Pictory official product navigation documents script, URL, document, PDF, PPT and audio-to-video workflows plus captions, highlights, avatars, voice cloning and API
- Pictory's current partner signup page states a 40% one-time commission on the referred customer's first payment; this commission claim is not used as customer-facing sales copy

No paid services, ad spend, guessed tracking URLs or unsupported revenue claims are introduced.