### PR TITLE
Optimize HighLevel buyer-intent affiliate landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/gohighlevel.html
+++ b/projects/GlobalSaaSHub/public/tool/gohighlevel.html
@@ -3,29 +3,27 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>GoHighLevel Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="An all-in-one sales, marketing, and CRM platform designed specifically for agencies and businesses to automate client acquisition and retention.... Discover features, pricing (See official pricing), and official links for GoHighLevel on GlobalSaaSHub." />
+    <title>GoHighLevel Pricing: Starter vs Unlimited vs Agency Pro (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Compare HighLevel Starter, Unlimited and Agency Pro pricing, trial access, sub-account limits, CRM, funnels, automations and SaaS-mode features. Includes COSHUMA's verified partner route." />
     <link rel="canonical" href="https://coshuma.com/tool/gohighlevel.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://coshuma.com/tool/gohighlevel.html" />
-    <meta property="og:title" content="GoHighLevel Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="An all-in-one sales, marketing, and CRM platform designed specifically for agencies and businesses to automate client acquisition and retention.... Check rating, pricing, and features." />
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://coshuma.com/tool/gohighlevel.html" />
+    <meta property="og:title" content="GoHighLevel Pricing: Starter vs Unlimited vs Agency Pro (2026)" />
+    <meta property="og:description" content="A practical HighLevel pricing and plan guide for freelancers, agencies and SaaS operators." />
+
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
-      "name": "GoHighLevel",
-      "operatingSystem": "Web",
-      "applicationCategory": "Chatbots & Support",
-      "description": "An all-in-one sales, marketing, and CRM platform designed specifically for agencies and businesses to automate client acquisition and retention."
+      "name": "HighLevel",
+      "operatingSystem": "Web, Mobile",
+      "applicationCategory": "BusinessApplication",
+      "url": "https://coshuma.com/tool/gohighlevel.html",
+      "description": "All-in-one CRM, marketing automation, funnels, scheduling and agency client-management platform."
     }
     </script>
 
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,134 +34,123 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
+    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
+      <section class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-7">
+        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=gohighlevel.com&sz=128" alt="GoHighLevel logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=gohighlevel.com&sz=128" alt="HighLevel logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Chatbots & Support</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">GoHighLevel</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">Agency CRM & Automation</div>
+              <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">GoHighLevel Pricing & Review (2026)</h1>
             </div>
           </div>
+          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-3 py-1.5 rounded-md">Official sources checked Sep 2, 2026</span>
+        </div>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
+        <p class="text-slate-300 text-base md:text-lg leading-relaxed">
+          HighLevel combines CRM, pipelines, calendars, funnels, websites, marketing automation and client sub-accounts in one platform. It is mainly positioned for freelancers, agencies and service businesses that would otherwise stitch together several sales and marketing tools.
+        </p>
+
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs uppercase tracking-wider text-slate-400 font-bold">Starter</div>
+            <div class="text-2xl font-black text-white mt-1">$97/mo</div>
+            <div class="text-xs text-slate-400 mt-2">Unlimited contacts and users, core CRM and marketing tools, plus up to 3 sub-accounts.</div>
+          </div>
+          <div class="p-4 rounded-2xl bg-purple-500/10 border border-purple-500/30">
+            <div class="text-xs uppercase tracking-wider text-purple-300 font-bold">Unlimited</div>
+            <div class="text-2xl font-black text-white mt-1">$297/mo</div>
+            <div class="text-xs text-slate-300 mt-2">Everything in Starter plus unlimited sub-accounts, API access and branded desktop-app options.</div>
+          </div>
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs uppercase tracking-wider text-slate-400 font-bold">Agency Pro</div>
+            <div class="text-2xl font-black text-white mt-1">$497/mo</div>
+            <div class="text-xs text-slate-400 mt-2">Adds SaaS Mode and advanced rebilling/automation features for agencies packaging HighLevel as a recurring client product.</div>
           </div>
         </div>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">An all-in-one sales, marketing, and CRM platform designed specifically for agencies and businesses to automate client acquisition and retention.</p>
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a data-cta="affiliate" data-tool-id="gohighlevel" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start HighLevel via COSHUMA →</a>
+          <a href="/compare/text-vs-gohighlevel.html" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-[#181a29] border border-[#30344c] text-white text-center hover:border-purple-500/50 transition-all">Compare Text vs HighLevel →</a>
         </div>
+        <p class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: the primary HighLevel button uses COSHUMA's verified partner URL. GlobalSaaSHub may earn a commission if you become a paying customer after using it, at no extra cost to you. Final trial eligibility, prices, taxes, add-ons and usage charges are controlled by HighLevel.</p>
+      </section>
 
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> CRM & Pipeline</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Automated SMS/Email</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Sales Funnels</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI Chatbots</div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">Which HighLevel plan should you choose?</h2>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-2">
+            <h3 class="font-bold text-emerald-300">Starter for one business or a small client set</h3>
+            <p class="text-slate-300 leading-relaxed">The $97 plan is the sensible starting point when you need the core CRM, booking, pipeline, funnel, website and automation stack but do not need unlimited client sub-accounts.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/30 space-y-2">
+            <h3 class="font-bold text-purple-300">Unlimited for a growing agency</h3>
+            <p class="text-slate-300 leading-relaxed">The $297 plan is more appropriate when the economics depend on managing many client accounts because it removes the 3-sub-account cap and adds broader API and branding capabilities.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-2">
+            <h3 class="font-bold text-blue-300">Agency Pro for SaaS-style resale</h3>
+            <p class="text-slate-300 leading-relaxed">The $497 tier is aimed at agencies that want SaaS Mode, automated sub-account provisioning and markup/rebilling workflows rather than simply using HighLevel internally.</p>
           </div>
         </div>
+      </section>
 
-        <!-- Pros & Cons Section -->
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">What HighLevel can replace or consolidate</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-slate-300">
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ CRM, pipelines and lead follow-up workflows</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Appointment calendars and online booking</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Funnels, landing pages and website building</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Email, SMS and multi-step automation workflows</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Client sub-accounts and agency operations</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ SaaS-mode resale and rebilling on the Pro tier</div>
+        </div>
+      </section>
+
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">HighLevel vs a focused support platform</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
+          <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/20">
+            <h3 class="font-bold text-purple-300 mb-2">Choose HighLevel if...</h3>
+            <p class="text-sm text-slate-300 leading-relaxed">You want CRM, lead capture, funnels, scheduling, automations and multi-client agency operations in the same system.</p>
           </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
+          <div class="p-5 rounded-2xl bg-blue-500/5 border border-blue-500/20">
+            <h3 class="font-bold text-blue-300 mb-2">Choose Text if...</h3>
+            <p class="text-sm text-slate-300 leading-relaxed">Your main problem is customer support, live chat, help desk and AI service automation rather than a full agency sales-and-marketing stack.</p>
           </div>
         </div>
+        <a href="/compare/text-vs-gohighlevel.html" class="inline-flex px-5 py-3 rounded-xl bg-[#181a29] border border-[#30344c] font-bold text-sm text-white hover:border-purple-500/50 transition-all">See Text vs HighLevel →</a>
+      </section>
 
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to GoHighLevel</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/gallabox.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=gallabox.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Gallabox</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/livechat.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=livechat.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">LiveChat</span></div><span class="text-[10px] font-extrabold text-emerald-400">Check website for details.</span></a>
-<a href="/tool/helpdesk.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=helpdesk.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">HelpDesk</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-amber-500/20 space-y-4">
+        <h2 class="text-2xl font-black text-white">Trial and cost note</h2>
+        <p class="text-sm text-slate-300 leading-relaxed">HighLevel's standard public plan pages currently advertise a 14-day free trial with no contract and cancellation at any time. Some separate promotional pages advertise longer trial periods, so the exact offer can depend on the landing route. Confirm the trial shown after clicking before entering billing details.</p>
+        <p class="text-xs text-slate-500">Software subscription price is not necessarily the full operating cost. Phone, messaging, email, AI, app, marketplace and other usage-based or optional services can add cost depending on the setup.</p>
+      </section>
 
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://www.gohighlevel.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official GoHighLevel Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit GoHighLevel via Verified Affiliate Link</span><span>→</span></a>
-        </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4 text-center">
+        <h2 class="text-2xl font-black text-white">Best next step: map the plan to your number of client accounts</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto leading-relaxed">If you only need a few accounts, start by testing Starter. If unlimited client sub-accounts are central to the business model, compare Unlimited immediately. Only pay for Agency Pro when SaaS Mode and rebilling are part of the actual revenue plan.</p>
+        <a data-cta="affiliate" data-tool-id="gohighlevel" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">View HighLevel via COSHUMA →</a>
+        <p class="text-[10px] text-slate-500">Verified partner URL: gohighlevel.com/?fp_ref=sangkwon56.</p>
+      </section>
 
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of GoHighLevel?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim GoHighLevel Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/gohighlevel.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="GoHighLevel Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
-      </div>
+      <section class="p-5 rounded-2xl bg-[#10121b] border border-[#222538] text-xs text-slate-500 leading-relaxed">
+        <strong class="text-slate-300">Source note:</strong> plan pricing and feature positioning were checked against HighLevel's official public pricing and trial pages on September 2, 2026. The affiliate relationship was separately checked against HighLevel's official affiliate agreement and support portal, which currently describe a standard 40% direct-referral commission on qualifying recurring subscription products. This page does not claim hands-on testing where none was performed.
+      </section>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
Revenue-focused, zero-cost update for the verified HighLevel affiliate funnel.

Changes:
- replaces generic/not-rated copy with a current buyer-intent Starter vs Unlimited vs Agency Pro plan guide
- preserves the verified customer-facing partner URL `https://www.gohighlevel.com/?fp_ref=sangkwon56`
- moves affiliate CTAs above the fold and into the closing decision section with `data-cta="affiliate"` and `data-tool-id="gohighlevel"`
- adds current public $97 / $297 / $497 plan pricing and sub-account/SaaS-mode decision guidance
- adds a trial caveat because standard pricing pages advertise 14 days while separate official promotional routes can advertise longer periods
- adds a focused Text-vs-HighLevel comparison path
- adds explicit affiliate disclosure and usage/add-on cost caution

Evidence checked Sep 2, 2026:
- repository marks the exact HighLevel URL above as verified `approved_tracking`
- HighLevel official pricing pages list Starter $97/month, Unlimited $297/month and Agency Pro/SaaS Pro $497/month
- standard official plan pages advertise a 14-day free trial, no contracts and cancellation; separate official promo routes can display longer trial offers, so the page tells visitors to confirm the exact offer shown after clicking
- HighLevel's official affiliate agreement/support currently document a standard 40% direct-referral recurring commission on qualifying subscription products; this is used only as source validation and not as customer-facing hype

No paid services, ad spend, guessed tracking URLs or unsupported revenue claims are introduced.