### PR TITLE
Optimize Castmagic buyer-intent affiliate funnel

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/castmagic-vs-tubebuddy.html
+++ b/projects/GlobalSaaSHub/public/compare/castmagic-vs-tubebuddy.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Castmagic vs TubeBuddy Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Castmagic vs TubeBuddy. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
-
+    <title>Castmagic vs TubeBuddy: Content Repurposing vs YouTube SEO (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Compare Castmagic vs TubeBuddy by job-to-be-done, pricing structure, content repurposing, YouTube SEO, A/B testing and workflow fit. Both routes use verified COSHUMA partner links." />
     <link rel="canonical" href="https://coshuma.com/compare/castmagic-vs-tubebuddy.html" />
+
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/compare/castmagic-vs-tubebuddy.html" />
-    <meta property="og:title" content="Castmagic vs TubeBuddy Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Castmagic and TubeBuddy by pricing, features, and verified public information." />
+    <meta property="og:title" content="Castmagic vs TubeBuddy: Which Creator Tool Solves Your Bottleneck?" />
+    <meta property="og:description" content="Castmagic repurposes recordings into content; TubeBuddy optimizes YouTube publishing and growth. Compare the two before paying." />
 
     <script type="application/ld+json">
     {
@@ -18,19 +18,15 @@
       "@type": "WebPage",
       "name": "Castmagic vs TubeBuddy Comparison",
       "url": "https://coshuma.com/compare/castmagic-vs-tubebuddy.html",
-      "description": "Compare Castmagic and TubeBuddy by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
+      "description": "Decision guide comparing Castmagic content repurposing with TubeBuddy YouTube SEO and channel optimization.",
+      "isPartOf": {"@type": "WebSite", "name": "GlobalSaaSHub", "url": "https://coshuma.com/"},
       "about": [
         {"@type": "SoftwareApplication", "name": "Castmagic", "url": "https://coshuma.com/tool/castmagic.html"},
         {"@type": "SoftwareApplication", "name": "TubeBuddy", "url": "https://coshuma.com/tool/tubebuddy.html"}
       ]
     }
     </script>
-    
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -47,126 +43,90 @@
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
     <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
+      <section class="text-center space-y-4">
+        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Creator Workflow Comparison</div>
         <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Castmagic vs TubeBuddy</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Video & Shorts Gen tool.
-        </p>
-      </div>
+        <p class="text-slate-300 text-base max-w-2xl mx-auto leading-relaxed">These tools overlap around creators, but they solve different bottlenecks. Castmagic turns recordings into more content. TubeBuddy helps optimize and operate a YouTube channel.</p>
+        <span class="inline-flex text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-3 py-1.5 rounded-md">Official sources checked Sep 2, 2026</span>
+      </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Castmagic if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-5">
+        <h2 class="text-2xl font-black text-white">Quick answer</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/20 space-y-3">
+            <h3 class="text-lg font-black text-purple-300">Choose Castmagic when the recording is already made</h3>
+            <p class="text-sm text-slate-300 leading-relaxed">Best fit for podcasts, interviews, webinars, meetings and long-form video that need to become transcripts, summaries, blogs, newsletters, social posts, scripts and clips.</p>
+            <a href="/tool/castmagic.html" class="text-xs font-bold text-purple-300 hover:text-purple-200">See Castmagic pricing and plan guide →</a>
           </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose TubeBuddy if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
+          <div class="p-5 rounded-2xl bg-blue-500/5 border border-blue-500/20 space-y-3">
+            <h3 class="text-lg font-black text-blue-300">Choose TubeBuddy when YouTube growth is the bottleneck</h3>
+            <p class="text-sm text-slate-300 leading-relaxed">Best fit for keyword research, SEO Studio, title and tag optimization, thumbnail and metadata testing, channel analytics, Shorts linking and bulk YouTube workflows.</p>
+            <a href="/tool/tubebuddy.html" class="text-xs font-bold text-blue-300 hover:text-blue-200">See TubeBuddy plan guide →</a>
           </div>
         </div>
-      </div>
+      </section>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/castmagic.html" class="hover:text-purple-300">Castmagic</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/tubebuddy.html" class="hover:text-blue-300">TubeBuddy</a>
-          </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
+        <h2 class="text-2xl font-black text-white">Side-by-side buying decision</h2>
+        <div class="overflow-x-auto">
+          <table class="w-full min-w-[680px] text-sm border-separate border-spacing-y-2">
+            <thead>
+              <tr class="text-left text-xs uppercase tracking-wider text-slate-400">
+                <th class="p-3">Decision factor</th>
+                <th class="p-3 text-purple-300">Castmagic</th>
+                <th class="p-3 text-blue-300">TubeBuddy</th>
+              </tr>
+            </thead>
+            <tbody class="text-slate-300">
+              <tr class="bg-[#181a29]"><td class="p-3 font-bold text-white">Primary job</td><td class="p-3">Repurpose audio/video into many content assets</td><td class="p-3">Optimize YouTube publishing and channel growth</td></tr>
+              <tr class="bg-[#181a29]"><td class="p-3 font-bold text-white">Best input</td><td class="p-3">Podcast, webinar, interview, meeting or video recording</td><td class="p-3">An active YouTube channel and its existing/new videos</td></tr>
+              <tr class="bg-[#181a29]"><td class="p-3 font-bold text-white">Strongest outputs</td><td class="p-3">Transcripts, summaries, articles, newsletters, social posts, scripts, clips</td><td class="p-3">Keywords, SEO guidance, tests, analytics, channel workflow tools</td></tr>
+              <tr class="bg-[#181a29]"><td class="p-3 font-bold text-white">Current plan structure</td><td class="p-3">Hobby, Starter, Team, plus Business & Scale</td><td class="p-3">Pro, Legend and Enterprise</td></tr>
+              <tr class="bg-[#181a29]"><td class="p-3 font-bold text-white">Public price visibility</td><td class="p-3">Annual view currently displays $19/$48/$139 monthly equivalents*</td><td class="p-3">Live numeric Pro/Legend pricing is not stable in every public session; verify at checkout</td></tr>
+              <tr class="bg-[#181a29]"><td class="p-3 font-bold text-white">API</td><td class="p-3">Starter and Team list API access; Hobby does not</td><td class="p-3">Not the central reason to buy; product is centered on YouTube creator workflows</td></tr>
+              <tr class="bg-[#181a29]"><td class="p-3 font-bold text-white">Best buyer</td><td class="p-3">Content teams, podcasters, agencies, long-form creators</td><td class="p-3">YouTubers, channel managers, brands operating YouTube</td></tr>
+            </tbody>
+          </table>
         </div>
+        <p class="text-[11px] text-slate-500">*Castmagic's official annual-billing view also separately displays $239/yr, $579/yr and $1,669/yr and states a 30% annual saving. Confirm the final checkout amount before purchase.</p>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
+          <h2 class="text-xl font-black text-white">Castmagic purchase path</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">Start by testing one real piece of long-form media. If the transcript and repurposed outputs remove repeated writing/editing work, pick the plan based mainly on transcription library hours, spaces, storage and whether you need API access.</p>
+          <a data-cta="affiliate" data-tool-id="castmagic" href="https://castmagic.io?fpr=sangkwon-an54" target="_blank" rel="sponsored noopener noreferrer" class="block w-full px-5 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center transition-all">Try Castmagic via COSHUMA →</a>
         </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See website for details</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
+        <div class="p-6 rounded-3xl bg-[#131520] border border-blue-500/30 space-y-4">
+          <h2 class="text-xl font-black text-white">TubeBuddy purchase path</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">Start with the YouTube problem you are trying to fix: discovery, SEO, testing, analytics or repetitive channel work. Check the live plan tied to the channel you intend to license because public numeric pricing can vary by session and eligibility.</p>
+          <a data-cta="affiliate" data-tool-id="tubebuddy" href="https://www.tubebuddy.com/pricing?a=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="block w-full px-5 py-3.5 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center transition-all">Check TubeBuddy via COSHUMA →</a>
         </div>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Castmagic Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ AI-powered content repurposing</div>
-<div>✓ Transforms audio & video files</div>
-<div>✓ Generates blog posts & social content</div>
-<div>✓ Automates content workflows</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">TubeBuddy Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Video SEO optimization</div>
-<div>✓ Keyword research tools</div>
-<div>✓ Bulk processing features</div>
-<div>✓ Channel health reports</div>
-            </div>
-          </div>
-        </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-amber-500/20 space-y-4">
+        <h2 class="text-2xl font-black text-white">When using both can make sense</h2>
+        <p class="text-sm text-slate-300 leading-relaxed">A creator can use Castmagic after recording to turn one long video into multiple written and short-form assets, then use TubeBuddy for the YouTube-specific side of packaging, optimization, testing and channel operations. That combination only makes economic sense if both workflows are frequent enough to justify two subscriptions.</p>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://castmagic.io?fpr=sangkwon-an54" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Castmagic →</a>
-          <a href="https://www.tubebuddy.com/pricing?a=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get TubeBuddy →</a>
-        </div>
-      </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-4">
+        <h2 class="text-2xl font-black text-white">What this comparison does not claim</h2>
+        <p class="text-sm text-slate-300 leading-relaxed">There is no fabricated winner score here. The better choice depends on the job. Castmagic is the stronger match for content repurposing from source media; TubeBuddy is the stronger match for YouTube-specific optimization and channel workflow.</p>
+        <p class="text-xs text-slate-500">Affiliate disclosure: both primary product buttons use verified COSHUMA partner URLs. GlobalSaaSHub may earn a commission if you purchase after using them, at no extra cost to you. This does not change the decision criteria above.</p>
+      </section>
+
+      <section class="p-5 rounded-2xl bg-[#10121b] border border-[#222538] text-xs text-slate-500 leading-relaxed">
+        <strong class="text-slate-300">Source note:</strong> Castmagic pricing and capabilities were checked against Castmagic's official pricing and product pages on September 2, 2026. TubeBuddy plan structure and feature positioning were checked against its official pricing and product documentation, as reflected in the current GlobalSaaSHub TubeBuddy guide. Castmagic's partner URL was separately verified from its FirstPromoter welcome email; TubeBuddy's partner route is the existing verified COSHUMA pricing URL. No hands-on performance claim is made where no hands-on test was performed.
+      </section>
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
   </body>
 </html>

--- a/projects/GlobalSaaSHub/public/tool/castmagic.html
+++ b/projects/GlobalSaaSHub/public/tool/castmagic.html
@@ -3,29 +3,27 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Castmagic Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Castmagic is an AI-powered content workflow tool that transforms audio and video files into various scalable content formats. It helps professionals a... Discover features, pricing (See website for details), and official links for Castmagic on GlobalSaaSHub." />
+    <title>Castmagic Pricing: Hobby vs Starter vs Team (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Compare Castmagic Hobby, Starter and Team pricing, transcription hours, storage, API access and content-repurposing workflows. Includes COSHUMA's verified Castmagic partner route." />
     <link rel="canonical" href="https://coshuma.com/tool/castmagic.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://coshuma.com/tool/castmagic.html" />
-    <meta property="og:title" content="Castmagic Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Castmagic is an AI-powered content workflow tool that transforms audio and video files into various scalable content formats. It helps professionals a... Check rating, pricing, and features." />
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://coshuma.com/tool/castmagic.html" />
+    <meta property="og:title" content="Castmagic Pricing: Hobby vs Starter vs Team (2026)" />
+    <meta property="og:description" content="A practical Castmagic plan guide for podcasters, YouTubers, agencies and content teams turning recordings into reusable content." />
+
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Castmagic",
       "operatingSystem": "Web",
-      "applicationCategory": "Video & Shorts Gen",
-      "description": "Castmagic is an AI-powered content workflow tool that transforms audio and video files into various scalable content formats. It helps professionals and creators automate the repurposing of their media into blog posts, social content, and more."
+      "applicationCategory": "MultimediaApplication",
+      "url": "https://coshuma.com/tool/castmagic.html",
+      "description": "AI content-repurposing software that turns audio and video into transcripts, summaries, articles, social posts, newsletters, clips and other reusable content assets."
     }
     </script>
 
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,134 +34,124 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
+    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
+      <section class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-7">
+        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=castmagic.io&sz=128" alt="Castmagic logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=castmagic.io&sz=128" alt="Castmagic logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Video & Shorts Gen</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Castmagic</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">AI Content Repurposing</div>
+              <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Castmagic Pricing & Review (2026)</h1>
             </div>
           </div>
+          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-3 py-1.5 rounded-md">Official sources checked Sep 2, 2026</span>
+        </div>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
+        <p class="text-slate-300 text-base md:text-lg leading-relaxed">
+          Castmagic is built for turning long-form audio and video into reusable content. Upload or import a recording, then generate transcripts, summaries, show notes, articles, newsletters, social posts, scripts and clips from the same source instead of rewriting each asset manually.
+        </p>
+
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs uppercase tracking-wider text-slate-400 font-bold">Hobby</div>
+            <div class="text-2xl font-black text-white mt-1">$19/mo*</div>
+            <div class="text-xs text-slate-400 mt-2">30 library transcription hours, up to 3 spaces and 50GB storage. Best for a solo creator testing a repeatable repurposing workflow.</div>
+          </div>
+          <div class="p-4 rounded-2xl bg-purple-500/10 border border-purple-500/30">
+            <div class="text-xs uppercase tracking-wider text-purple-300 font-bold">Starter</div>
+            <div class="text-2xl font-black text-white mt-1">$48/mo*</div>
+            <div class="text-xs text-slate-300 mt-2">100 transcription hours, up to 10 spaces, 250GB storage and API access. Better for a growing creator or content operation.</div>
+          </div>
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs uppercase tracking-wider text-slate-400 font-bold">Team</div>
+            <div class="text-2xl font-black text-white mt-1">$139/mo*</div>
+            <div class="text-xs text-slate-400 mt-2">400 transcription hours, up to 25 spaces, 1TB storage, API access and priority support for heavier team workflows.</div>
           </div>
         </div>
+        <p class="text-[11px] text-slate-500">*Castmagic's live pricing page currently shows these monthly equivalents on the annual-billing view and says annual billing saves 30%. It separately displays $239/yr, $579/yr and $1,669/yr. Confirm the final amount shown at checkout before paying.</p>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">Castmagic is an AI-powered content workflow tool that transforms audio and video files into various scalable content formats. It helps professionals and creators automate the repurposing of their media into blog posts, social content, and more.</p>
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a data-cta="affiliate" data-tool-id="castmagic" href="https://castmagic.io?fpr=sangkwon-an54" target="_blank" rel="sponsored noopener noreferrer" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Try Castmagic via COSHUMA →</a>
+          <a href="/compare/castmagic-vs-tubebuddy.html" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-[#181a29] border border-[#30344c] text-white text-center hover:border-purple-500/50 transition-all">Castmagic vs TubeBuddy →</a>
         </div>
+        <p class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: the primary Castmagic button uses COSHUMA's verified partner URL. GlobalSaaSHub may earn a commission if you become a paying customer after using it, at no extra cost to you. Final prices, taxes, plan terms and eligibility are controlled by Castmagic.</p>
+      </section>
 
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI-powered content repurposing</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Transforms audio & video files</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Generates blog posts & social content</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Automates content workflows</div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">Which Castmagic plan should you choose?</h2>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-2">
+            <h3 class="font-bold text-emerald-300">Hobby for a solo creator</h3>
+            <p class="text-slate-300 leading-relaxed">Choose Hobby when one person mainly needs transcription plus repeatable AI outputs from podcasts, interviews or videos and 30 accumulated library hours are enough.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/30 space-y-2">
+            <h3 class="font-bold text-purple-300">Starter for regular production</h3>
+            <p class="text-slate-300 leading-relaxed">Starter is the practical step up when you need more recording capacity, more spaces and storage, or API access for a more connected publishing workflow.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-2">
+            <h3 class="font-bold text-blue-300">Team for agencies and media teams</h3>
+            <p class="text-slate-300 leading-relaxed">Team makes more sense when several people collaborate across brands or clients and the economics depend on a much larger media library, more spaces and priority support.</p>
           </div>
         </div>
+      </section>
 
-        <!-- Pros & Cons Section -->
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">What Castmagic can generate from one recording</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-slate-300">
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Timestamped transcripts, summaries and takeaways</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Blog posts, articles and newsletters</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ LinkedIn posts, social captions, threads and quote assets</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ YouTube descriptions, video scripts and highlight clips</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Brand-voice prompts and reusable content templates</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ YouTube, TikTok, Instagram, Zoom, Drive, RSS and other import workflows</div>
+        </div>
+      </section>
+
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">Castmagic vs TubeBuddy: do not buy the wrong type of tool</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See website for details)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
+          <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/20">
+            <h3 class="font-bold text-purple-300 mb-2">Choose Castmagic if...</h3>
+            <p class="text-sm text-slate-300 leading-relaxed">Your bottleneck happens after recording: transcription, repurposing, writing, clipping and turning one long-form asset into many publishable assets.</p>
           </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
+          <div class="p-5 rounded-2xl bg-blue-500/5 border border-blue-500/20">
+            <h3 class="font-bold text-blue-300 mb-2">Choose TubeBuddy if...</h3>
+            <p class="text-sm text-slate-300 leading-relaxed">Your bottleneck is specifically YouTube growth: keywords, SEO Studio, thumbnail or metadata testing, channel analytics and repeated YouTube publishing tasks.</p>
           </div>
         </div>
+        <a href="/compare/castmagic-vs-tubebuddy.html" class="inline-flex px-5 py-3 rounded-xl bg-[#181a29] border border-[#30344c] font-bold text-sm text-white hover:border-purple-500/50 transition-all">See the full Castmagic vs TubeBuddy comparison →</a>
+      </section>
 
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Castmagic</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/tubebuddy.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=tubebuddy.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">TubeBuddy</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/outlierkit.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=outlierkit.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">OutlierKit</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/pictory.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=pictory.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Pictory</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-amber-500/20 space-y-4">
+        <h2 class="text-2xl font-black text-white">Before paying</h2>
+        <p class="text-sm text-slate-300 leading-relaxed">Base the plan on the amount of source media you need to keep and process, not on the number of AI outputs alone. Castmagic currently lists unlimited re-generations and unlimited media clipping across Hobby, Starter and Team, while transcription library hours, spaces, storage, API access and support level are the bigger plan separators.</p>
+        <p class="text-xs text-slate-500">Castmagic also lists a Business & Scale offer from $699/month for custom volume, additional seats and storage, dedicated support and enterprise-level requirements.</p>
+      </section>
 
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See website for details</div>
-          </div>
-          <a data-cta="official" href="https://www.castmagic.io/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Castmagic Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://castmagic.io?fpr=sangkwon-an54" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Castmagic via Verified Affiliate Link</span><span>→</span></a>
-        </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4 text-center">
+        <h2 class="text-2xl font-black text-white">Best next step: test the workflow with a real recording</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto leading-relaxed">Use a podcast, webinar, interview or YouTube video you already own and judge whether the transcript plus downstream content outputs save enough editing and writing time to justify the plan you are considering.</p>
+        <a data-cta="affiliate" data-tool-id="castmagic" href="https://castmagic.io?fpr=sangkwon-an54" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Open Castmagic via COSHUMA →</a>
+        <p class="text-[10px] text-slate-500">Verified partner URL: castmagic.io?fpr=sangkwon-an54.</p>
+      </section>
 
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Castmagic?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Castmagic Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/castmagic.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Castmagic Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
-      </div>
+      <section class="p-5 rounded-2xl bg-[#10121b] border border-[#222538] text-xs text-slate-500 leading-relaxed">
+        <strong class="text-slate-300">Source note:</strong> pricing, transcription-hour limits, storage, spaces, supported languages, integrations and API availability were checked against Castmagic's official pricing page on September 2, 2026. The COSHUMA referral route was separately verified from Castmagic's FirstPromoter welcome email, which supplied the unique customer-facing link and described a 30% recurring commission with a 90-day cookie window. This page does not claim hands-on testing where none was performed.
+      </section>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
Improves Castmagic monetization without changing the verified tracking route.

- Replaces generic/unrated Castmagic copy with current buyer-intent pricing and plan guidance from official Castmagic sources checked 2026-09-02.
- Keeps the verified customer-facing referral URL `https://castmagic.io?fpr=sangkwon-an54` and adds explicit affiliate CTA metadata/disclosure.
- Reworks Castmagic vs TubeBuddy into a job-to-be-done comparison instead of fabricated/unrated winner language.
- Adds stronger internal paths between the detailed review and comparison page.

Affiliate terms were separately verified from Castmagic's FirstPromoter welcome email (30% recurring commission, 90-day cookie). No new paid services or unverified tracking URLs are introduced.