### PR TITLE
Optimize Fireflies buyer-intent affiliate landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/fireflies-ai.html
+++ b/projects/GlobalSaaSHub/public/tool/fireflies-ai.html
@@ -3,29 +3,27 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Fireflies.ai Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="AI voice assistant and meeting note-taker that transcribes, summarizes, and analyzes conversations.... Discover features, pricing (See official pricing), and official links for Fireflies.ai on GlobalSaaSHub." />
+    <title>Fireflies.ai Pricing: Free vs Pro vs Business (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Compare Fireflies.ai Free, Pro, Business and Enterprise pricing, storage, AI summaries, video recording and conversation intelligence. Includes COSHUMA's verified Fireflies partner route." />
     <link rel="canonical" href="https://coshuma.com/tool/fireflies-ai.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://coshuma.com/tool/fireflies-ai.html" />
-    <meta property="og:title" content="Fireflies.ai Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="AI voice assistant and meeting note-taker that transcribes, summarizes, and analyzes conversations.... Check rating, pricing, and features." />
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://coshuma.com/tool/fireflies-ai.html" />
+    <meta property="og:title" content="Fireflies.ai Pricing: Free vs Pro vs Business (2026)" />
+    <meta property="og:description" content="A practical Fireflies.ai plan guide for individuals and teams comparing meeting transcription, summaries, storage, recordings and analytics." />
+
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Fireflies.ai",
-      "operatingSystem": "Web",
-      "applicationCategory": "Workflow Automation",
-      "description": "AI voice assistant and meeting note-taker that transcribes, summarizes, and analyzes conversations."
+      "operatingSystem": "Web, Mobile, Desktop",
+      "applicationCategory": "BusinessApplication",
+      "url": "https://coshuma.com/tool/fireflies-ai.html",
+      "description": "AI meeting assistant for transcription, summaries, meeting search, recordings, integrations and conversation intelligence."
     }
     </script>
 
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,134 +34,118 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
+    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
+      <section class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-7">
+        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=fireflies.ai&sz=128" alt="Fireflies.ai logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=fireflies.ai&sz=128" alt="Fireflies.ai logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Workflow Automation</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Fireflies.ai</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">AI Meeting Assistant</div>
+              <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Fireflies.ai Pricing & Review (2026)</h1>
             </div>
           </div>
-
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
+          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-3 py-1.5 rounded-md">Official sources checked Sep 2, 2026</span>
         </div>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">AI voice assistant and meeting note-taker that transcribes, summarizes, and analyzes conversations.</p>
-        </div>
+        <p class="text-slate-300 text-base md:text-lg leading-relaxed">
+          Fireflies.ai records and transcribes meetings, produces AI summaries, lets teams search past conversations and adds deeper recording, analytics and administrative controls on paid plans. The key buying decision is usually not whether transcription exists, but how much storage, recording, analytics and team control you need.
+        </p>
 
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Automated Meeting Transcription</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI Conversation Intelligence</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> CRM Integrations</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Custom Topic Tracker</div>
+        <div class="grid grid-cols-1 md:grid-cols-4 gap-3">
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs uppercase tracking-wider text-slate-400 font-bold">Free</div>
+            <div class="text-2xl font-black text-white mt-1">$0</div>
+            <div class="text-xs text-slate-400 mt-2">Unlimited transcription*, limited AI summaries, 400 minutes of storage per team and 20 AI credits.</div>
           </div>
-        </div>
-
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs uppercase tracking-wider text-slate-400 font-bold">Pro</div>
+            <div class="text-2xl font-black text-white mt-1">$10/seat/mo</div>
+            <div class="text-xs text-slate-400 mt-2">Annual billing. $18 monthly. Adds unlimited AI summaries, 8,000 storage minutes per seat, video recording and unlimited integrations.</div>
           </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
+          <div class="p-4 rounded-2xl bg-purple-500/10 border border-purple-500/30">
+            <div class="text-xs uppercase tracking-wider text-purple-300 font-bold">Business</div>
+            <div class="text-2xl font-black text-white mt-1">$19/seat/mo</div>
+            <div class="text-xs text-slate-300 mt-2">Annual billing. $29 monthly. Adds unlimited storage, conversation intelligence, team analytics and broader admin features.</div>
+          </div>
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs uppercase tracking-wider text-slate-400 font-bold">Enterprise</div>
+            <div class="text-2xl font-black text-white mt-1">$39/seat/mo</div>
+            <div class="text-xs text-slate-400 mt-2">Annual only. Adds enterprise controls including SSO, SCIM, HIPAA support options, custom retention and dedicated account management.</div>
           </div>
         </div>
+        <p class="text-[11px] text-slate-500">*Fireflies applies usage and upload-rate rules even where transcription is described as unlimited. Its official help center documents upload limits and potential overage charges for certain externally uploaded sources.</p>
 
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Fireflies.ai</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/expandi.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=expandi.io&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Expandi</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/reditus.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=getreditus.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Reditus</span></div><span class="text-[10px] font-extrabold text-emerald-400">14-day free trial; Startup plan at $99/month (billed annually) or $149 monthly</span></a>
-<a href="/tool/joiin.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=joiin.co&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Joiin</span></div><span class="text-[10px] font-extrabold text-emerald-400">Starting at $23/month (billed annually, 1 company)</span></a>
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a data-cta="affiliate" data-tool-id="fireflies-ai" href="https://fireflies.ai/?fpr=sangkwon53" target="_blank" rel="sponsored noopener noreferrer" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start with Fireflies via COSHUMA →</a>
+          <a href="https://fireflies.ai/pricing" target="_blank" rel="noopener noreferrer" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-[#181a29] border border-[#30344c] text-white text-center hover:border-purple-500/50 transition-all">Check Official Plan Details →</a>
+        </div>
+        <p class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: the primary Fireflies button uses COSHUMA's verified customer-facing referral URL. GlobalSaaSHub may earn a commission if you become a paying customer after using it, at no extra cost to you. Final pricing, taxes, eligibility, limits and billing terms are controlled by Fireflies.</p>
+      </section>
+
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">Which Fireflies plan should you choose?</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-2">
+            <h3 class="font-bold text-emerald-300">Free for individual evaluation</h3>
+            <p class="text-slate-300 leading-relaxed">Use Free if you mainly need live meeting transcription, basic search and a limited amount of stored meeting history while deciding whether Fireflies fits your call workflow.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-2">
+            <h3 class="font-bold text-blue-300">Pro for regular meeting capture</h3>
+            <p class="text-slate-300 leading-relaxed">Pro is the practical creator, consultant or small-team tier when unlimited AI summaries, video recording, downloads, personal/email assistants and broader integrations justify the per-seat cost.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/30 space-y-2">
+            <h3 class="font-bold text-purple-300">Business for team intelligence</h3>
+            <p class="text-slate-300 leading-relaxed">Business becomes more compelling when managers need unlimited storage, conversation intelligence, team analytics, user groups and more centralized controls rather than just personal meeting notes.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-2">
+            <h3 class="font-bold text-amber-300">Enterprise for compliance and governance</h3>
+            <p class="text-slate-300 leading-relaxed">Enterprise is aimed at larger organizations that need controls such as SSO, SCIM, private storage, custom data retention and a dedicated account-management relationship.</p>
           </div>
         </div>
+      </section>
 
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://fireflies.ai/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Fireflies.ai Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://fireflies.ai/?fpr=sangkwon53" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Fireflies.ai via Verified Affiliate Link</span><span>→</span></a>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">What you get before paying</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-slate-300">
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Zoom, Google Meet, Microsoft Teams and other meeting support</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Transcription in 100+ languages</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Real-time notes and live transcription</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Meeting search and AskFred AI assistant</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Audio/video upload plus web, mobile, desktop and Chrome access</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ API access listed on the Free plan</div>
         </div>
+      </section>
 
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Fireflies.ai?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Fireflies.ai Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/fireflies-ai.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Fireflies.ai Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-amber-500/20 space-y-4">
+        <h2 class="text-2xl font-black text-white">Watch the real operating cost</h2>
+        <p class="text-sm text-slate-300 leading-relaxed">The seat price is not always the full cost. Fireflies' official Business documentation says AI Credits can be purchased as add-ons for advanced AI-powered actions, and its storage/rate-limit guide documents paid overage for some uploaded media beyond monthly limits. Check the intended call volume and AI-credit usage before moving a large team.</p>
+        <p class="text-xs text-slate-500">For externally uploaded media, the official guide currently lists 3,000 minutes per source per month for individuals, scaling with team size and capped per source; overage is documented at $0.01/minute. Live meeting capture and some other recording routes are treated differently.</p>
+      </section>
 
+      <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4 text-center">
+        <h2 class="text-2xl font-black text-white">Best next step: start on Free and test your real meeting flow</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto leading-relaxed">Run Fireflies through meetings you actually attend, then upgrade only if storage, video recording, unlimited AI summaries, analytics or admin controls solve a real constraint. This avoids paying for team features before the workflow proves useful.</p>
+        <a data-cta="affiliate" data-tool-id="fireflies-ai" href="https://fireflies.ai/?fpr=sangkwon53" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Open Fireflies via COSHUMA →</a>
+        <p class="text-[10px] text-slate-500">Verified customer referral URL: fireflies.ai/?fpr=sangkwon53.</p>
+      </section>
 
-      </div>
+      <section class="p-5 rounded-2xl bg-[#10121b] border border-[#222538] text-xs text-slate-500 leading-relaxed">
+        <strong class="text-slate-300">Source note:</strong> pricing and plan features were checked against Fireflies' official pricing page and help-center pricing guidance on September 2, 2026. Storage and uploaded-media limits were cross-checked against Fireflies' official rate-limit documentation. Fireflies' public affiliate page currently advertises up to 30% recurring commission for 12 months and a 90-day referral window; COSHUMA's exact customer-facing referral URL was separately verified from the account's Fireflies FirstPromoter welcome email. This page does not assume COSHUMA's exact commission tier where the account-specific email did not state it, and it does not claim hands-on testing where none was performed.
+      </section>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
Improves the Fireflies revenue path without changing the verified customer referral URL.

- Replaces generic/unrated copy with current Free/Pro/Business/Enterprise pricing and plan guidance from Fireflies official sources checked 2026-09-02.
- Keeps the verified customer-facing URL `https://fireflies.ai/?fpr=sangkwon53` and adds explicit affiliate CTA metadata/disclosure.
- Adds storage, AI-credit and uploaded-media cost cautions from Fireflies official documentation.
- Uses the official program's public 'up to 30% recurring for 12 months / 90-day referral window' language without assuming COSHUMA's account-specific commission tier.

No paid services, fabricated review scores, or unverified tracking URLs are introduced.