### PR TITLE
Optimize Vista Social buyer-intent affiliate landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/vista-social.html
+++ b/projects/GlobalSaaSHub/public/tool/vista-social.html
@@ -3,29 +3,26 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vista Social Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Vista Social is an AI-powered platform for comprehensive social media management, offering tools for publishing, engagement, analytics, and team colla... Discover features, pricing (See official pricing), and official links for Vista Social on GlobalSaaSHub." />
+    <title>Vista Social Pricing: Professional vs Advanced vs Scale (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Compare Vista Social Professional, Advanced and Scale pricing, profile limits, 14-day no-card trial, AI social workflows, and the verified COSHUMA referral offer." />
     <link rel="canonical" href="https://coshuma.com/tool/vista-social.html" />
-    
-    <!-- Open Graph SEO Tags -->
+
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/vista-social.html" />
-    <meta property="og:title" content="Vista Social Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Vista Social is an AI-powered platform for comprehensive social media management, offering tools for publishing, engagement, analytics, and team colla... Check rating, pricing, and features." />
+    <meta property="og:title" content="Vista Social Pricing: Professional vs Advanced vs Scale (2026)" />
+    <meta property="og:description" content="Current Vista Social pricing, plan-fit guidance, 14-day no-card trial and verified COSHUMA referral route." />
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Vista Social",
       "operatingSystem": "Web",
-      "applicationCategory": "Workflow Automation",
-      "description": "Vista Social is an AI-powered platform for comprehensive social media management, offering tools for publishing, engagement, analytics, and team collaboration."
+      "applicationCategory": "Social Media Management Software",
+      "description": "Social media management software for publishing, engagement, analytics, listening, automations and team workflows."
     }
     </script>
 
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,136 +33,132 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
     <main class="max-w-4xl mx-auto px-4 py-12 w-full">
       <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
         <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=vistasocial.com&sz=128" alt="Vista Social logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=vistasocial.com&sz=128" alt="Vista Social logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.style.display='none'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Workflow Automation</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Vista Social</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">Social Media Management</div>
+              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Vista Social Pricing & Plan Guide</h1>
             </div>
           </div>
+          <div class="bg-emerald-500/10 border border-emerald-500/20 text-emerald-300 px-4 py-2 rounded-xl text-sm font-bold">14-day trial • no card</div>
+        </div>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
+        <div class="p-6 rounded-2xl bg-gradient-to-br from-purple-500/10 to-cyan-500/5 border border-purple-500/30 space-y-4">
+          <div class="text-xs uppercase tracking-wider font-bold text-purple-300">Fast decision</div>
+          <h2 class="text-2xl font-black text-white">Start on Professional unless you already need agency workflows or higher profile capacity.</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">Vista Social's live pricing page currently lists Professional at <strong class="text-white">$79/month</strong>, Advanced at <strong class="text-white">$149/month</strong>, and Scale at <strong class="text-white">$349/month</strong>. All three public plans advertise a 14-day free trial with no credit card required.</p>
+          <div class="flex flex-col sm:flex-row gap-3 pt-1">
+            <a data-cta="affiliate" data-tool-id="vista-social" href="https://vistasocial.com?fpr=sangkwon14" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center border border-purple-500 hover:bg-purple-500 transition-all">Start the 14-Day Vista Social Trial →</a>
+            <a data-cta="official" href="https://vistasocial.com/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Check Live Pricing</a>
           </div>
+          <p class="text-[11px] text-slate-400 leading-relaxed">Referral note: Vista Social's official affiliate support page says users who register through an affiliate link receive 10% off their first year. Confirm the discount shown at checkout before paying.</p>
         </div>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">Vista Social is an AI-powered platform for comprehensive social media management, offering tools for publishing, engagement, analytics, and team collaboration.</p>
-        </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI-powered social media management</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Content publishing and scheduling</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Engagement tracking and analytics</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Team collaboration workflows</div>
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">Vista Social plans: which one fits?</h2>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-3">
+              <h3 class="text-lg font-extrabold text-white">Professional</h3>
+              <div class="text-2xl font-black text-emerald-400">$79/mo</div>
+              <div class="text-xs text-slate-400">$758/year on the current yearly plan</div>
+              <ul class="text-sm text-slate-300 space-y-2">
+                <li>• 15 social profiles</li>
+                <li>• Publishing, engagement and reports</li>
+                <li>• Ask Vista AI and DM automations</li>
+                <li>• Best for solo pros and small teams</li>
+              </ul>
+            </div>
+            <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/30 space-y-3">
+              <div class="text-[10px] uppercase font-black text-purple-300 tracking-wider">Most popular</div>
+              <h3 class="text-lg font-extrabold text-white">Advanced</h3>
+              <div class="text-2xl font-black text-emerald-400">$149/mo</div>
+              <div class="text-xs text-slate-400">$1,430/year on the current yearly plan</div>
+              <ul class="text-sm text-slate-300 space-y-2">
+                <li>• 30 social profiles</li>
+                <li>• Advanced approvals and smart scheduling</li>
+                <li>• Custom reporting</li>
+                <li>• Zapier, Make and MCP integrations</li>
+              </ul>
+            </div>
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-3">
+              <h3 class="text-lg font-extrabold text-white">Scale</h3>
+              <div class="text-2xl font-black text-emerald-400">$349/mo</div>
+              <div class="text-xs text-slate-400">$3,638/year on the current yearly plan</div>
+              <ul class="text-sm text-slate-300 space-y-2">
+                <li>• 70 social profiles</li>
+                <li>• White-label dashboard and reports</li>
+                <li>• Client profile connection</li>
+                <li>• Higher-capacity agency workflows</li>
+              </ul>
+            </div>
           </div>
-        </div>
+          <p class="text-xs text-amber-300/90 leading-relaxed">Seat-count caution: Vista Social's live pricing page currently shows inconsistent included-user counts between its plan table/cards and FAQ copy. Use the live checkout or sales confirmation for the exact number of included users before buying.</p>
+        </section>
 
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
+        <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-3">
+            <h2 class="text-lg font-bold text-emerald-300">Good fit if you need</h2>
+            <ul class="text-sm text-slate-300 space-y-2">
+              <li>• Multi-network scheduling from one workspace</li>
+              <li>• Shared inbox, comments, reviews and team approvals</li>
+              <li>• Reporting for clients or internal teams</li>
+              <li>• AI-assisted captions, replies and social workflows</li>
+              <li>• DM automations, link-in-bio pages and integrations</li>
             </ul>
           </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
+          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-3">
+            <h2 class="text-lg font-bold text-rose-300">Check before upgrading</h2>
+            <ul class="text-sm text-slate-300 space-y-2">
+              <li>• Cross-web/social listening is an optional paid add-on.</li>
+              <li>• X (Twitter) integration is listed as a separate paid add-on.</li>
+              <li>• Employee Advocacy beyond the free starter allowance costs extra.</li>
+              <li>• Enterprise pricing is custom and requires sales contact.</li>
             </ul>
           </div>
-        </div>
+        </section>
 
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Vista Social</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
+        <section class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-3">
+          <h2 class="text-xl font-bold text-white">Current add-on costs worth noticing</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">The live pricing page currently lists cross-social/web/news Listening from <strong class="text-white">$75/month</strong>, X integration at <strong class="text-white">$29/month</strong>, and Employee Advocacy from <strong class="text-white">$199/month for 25 employees</strong>. These can materially change the total cost for larger teams, so compare the base plan with the exact workflow you need.</p>
+        </section>
+
+        <section class="space-y-4 pt-2 border-t border-[#222538]">
+          <h2 class="text-xl font-bold text-white">Alternative paths</h2>
           <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/notion-ai.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=notion.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Notion AI</span></div><span class="text-[10px] font-extrabold text-emerald-400">Free trial; Business plan with Notion AI at $20/user/month</span></a>
-<a href="/tool/bolddesk.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=bolddesk.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">BoldDesk</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/socialchamp-io.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=socialchamp.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Social Champ</span></div><span class="text-[10px] font-extrabold text-emerald-400">Free plan; paid plans from $4/month billed annually</span></a>
+            <a href="/tool/socialchamp-io.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="text-sm font-bold text-white">Social Champ</div><div class="text-xs text-slate-400 mt-1">Consider for a lower-cost social scheduling starting point.</div></a>
+            <a href="/compare/vista-social-vs-bolddesk.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="text-sm font-bold text-white">Vista Social vs BoldDesk</div><div class="text-xs text-slate-400 mt-1">Compare social engagement workflows with a support-desk alternative.</div></a>
+            <a href="/tool/make-com.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="text-sm font-bold text-white">Make.com</div><div class="text-xs text-slate-400 mt-1">Useful when workflow automation matters more than native social management.</div></a>
           </div>
-        </div>
+        </section>
 
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <div class="flex flex-col sm:flex-row gap-2">
-            <a data-cta="official" href="https://vistasocial.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Vista Social Site</span><span>→</span></a>
-            <a data-cta="affiliate" href="https://vistasocial.com?fpr=sangkwon14" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center border border-purple-500 hover:bg-purple-500 transition-all flex items-center justify-center gap-2"><span>Try Vista Social</span><span>→</span></a>
-          </div>
-        </div>
+        <section class="p-6 rounded-2xl bg-purple-500/10 border border-purple-500/30 space-y-4">
+          <h2 class="text-xl font-black text-white">Bottom line</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">Professional is the cleanest trial starting point for most small teams. Advanced is the more relevant step for agencies that need stronger approval, reporting and integration workflows. Scale is aimed at higher-volume client management and white-label operations.</p>
+          <a data-cta="affiliate" data-tool-id="vista-social" href="https://vistasocial.com?fpr=sangkwon14" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-6 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center border border-purple-500 hover:bg-purple-500 transition-all">Try Vista Social Through COSHUMA →</a>
+          <p class="text-[11px] text-slate-400 leading-relaxed"><strong class="text-slate-300">Affiliate disclosure:</strong> COSHUMA may earn a commission if you sign up or purchase through the partner link, at no additional cost beyond the offer shown by Vista Social. Pricing and offer details were checked against Vista Social's official pricing and affiliate documentation on September 2, 2026.</p>
+        </section>
 
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Vista Social?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Vista Social Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/vista-social.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Vista Social Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
+        <section class="p-5 rounded-2xl bg-[#0b0c10] border border-[#222538] text-xs text-slate-400 leading-relaxed">
+          <strong class="text-slate-300">Source transparency:</strong> Plan prices, trial terms, profile capacities and add-on prices come from Vista Social's official pricing page. Affiliate duration, referral discount and payout rules are documented by Vista Social's official affiliate pages. COSHUMA does not claim personal hands-on testing unless explicitly stated.
+        </section>
       </div>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
Revenue-first, zero-cost update for an already verified Vista Social partner route.

Changes:
- replaces generic/unrated copy with current Professional vs Advanced vs Scale plan guidance
- preserves the verified customer-facing referral URL `https://vistasocial.com?fpr=sangkwon14`
- moves affiliate CTAs above the fold and into the closing decision section with `data-cta="affiliate"` and `data-tool-id="vista-social"`
- adds current official $79 / $149 / $349 monthly pricing, yearly totals, 14-day no-card trial and profile capacities
- surfaces the official affiliate support note that referred users receive 10% off their first year, while telling visitors to confirm the discount at checkout
- adds current add-on cost cautions for Listening, X integration and Employee Advocacy
- explicitly flags Vista Social's current included-user-count inconsistency between pricing-page sections instead of guessing
- adds stronger internal routes to Social Champ, Make.com and an existing comparison page

Evidence checked Sep 2, 2026:
- repository data marks `https://vistasocial.com?fpr=sangkwon14` as verified `approved_tracking`
- Vista Social official pricing page lists Professional $79/month, Advanced $149/month, Scale $349/month, 14-day no-card trials, and yearly billing savings
- Vista Social official affiliate documentation lists a 20% starting commission for up to 12 months and says referred users receive 10% off their first year

No paid services, ad spend, guessed tracking URLs, fabricated ratings, or unsupported revenue claims are introduced.