### PR TITLE
Track YouTube-to-Descript affiliate attribution

### DIFF
--- a/projects/GlobalSaaSHub/public/affiliate-attribution.js
+++ b/projects/GlobalSaaSHub/public/affiliate-attribution.js
@@ -1,0 +1,63 @@
+(function () {
+  'use strict';
+
+  if (window.__coshumaStaticAttributionInitialized) return;
+  window.__coshumaStaticAttributionInitialized = true;
+
+  const measurementId = 'G-J7E0J89VCV';
+  const params = new URLSearchParams(window.location.search);
+  const campaign = {
+    utm_source: params.get('utm_source') || 'direct',
+    utm_medium: params.get('utm_medium') || 'none',
+    utm_campaign: params.get('utm_campaign') || 'none',
+    utm_content: params.get('utm_content') || 'none',
+    utm_term: params.get('utm_term') || 'none'
+  };
+
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = window.gtag || function gtag() {
+    window.dataLayer.push(arguments);
+  };
+
+  if (!document.querySelector('script[data-coshuma-ga4]')) {
+    const ga4Script = document.createElement('script');
+    ga4Script.async = true;
+    ga4Script.src = 'https://www.googletagmanager.com/gtag/js?id=' + encodeURIComponent(measurementId);
+    ga4Script.dataset.coshumaGa4 = 'true';
+    document.head.appendChild(ga4Script);
+  }
+
+  window.gtag('js', new Date());
+  window.gtag('config', measurementId, {
+    send_page_view: false,
+    cookie_domain: 'coshuma.com'
+  });
+
+  function toolIdFromPath() {
+    const match = window.location.pathname.match(/\/tool\/([^/.]+)\.html$/);
+    return match ? match[1] : 'unknown';
+  }
+
+  window.gtag('event', 'page_view', {
+    page_title: document.title,
+    page_location: window.location.href,
+    page_path: window.location.pathname + window.location.search,
+    tool_id: toolIdFromPath(),
+    ...campaign
+  });
+
+  document.addEventListener('click', function (event) {
+    const link = event.target.closest('a[data-cta="affiliate"]');
+    if (!link) return;
+
+    window.gtag('event', 'affiliate_click', {
+      tool_id: link.dataset.toolId || toolIdFromPath(),
+      link_url: link.href,
+      link_text: (link.textContent || '').trim().slice(0, 120),
+      page_location: window.location.href,
+      page_path: window.location.pathname + window.location.search,
+      ...campaign,
+      transport_type: 'beacon'
+    });
+  }, true);
+})();

--- a/projects/GlobalSaaSHub/public/tool/descript.html
+++ b/projects/GlobalSaaSHub/public/tool/descript.html
@@ -25,6 +25,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <script defer src="/affiliate-attribution.js"></script>
   <style>
     body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}
   </style>


### PR DESCRIPTION
Adds a lightweight static GA4 attribution helper and enables it on the Descript buyer-intent page, the first planned YouTube Shorts destination.

What this records on static SEO pages:
- UTM source / medium / campaign / content / term from the landing URL
- page_view with tool_id
- affiliate_click for links marked data-cta="affiliate"
- outbound link URL and CTA text

The GA4 measurement ID matches the existing production .env.production public identifier. No affiliate URL or pricing data is changed. This is intended to make YouTube Shorts traffic -> Descript landing -> verified affiliate CTA measurable before scaling Shorts production.