### PR TITLE
Track YouTube Shorts attribution across priority affiliate landings

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/elevenlabs.html
+++ b/projects/GlobalSaaSHub/public/tool/elevenlabs.html
@@ -25,6 +25,7 @@
     </script>
 
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">

--- a/projects/GlobalSaaSHub/public/tool/gohighlevel.html
+++ b/projects/GlobalSaaSHub/public/tool/gohighlevel.html
@@ -25,6 +25,7 @@
     </script>
 
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">

--- a/projects/GlobalSaaSHub/public/tool/tubebuddy.html
+++ b/projects/GlobalSaaSHub/public/tool/tubebuddy.html
@@ -25,6 +25,7 @@
     </script>
 
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">

--- a/projects/GlobalSaaSHub/public/tool/vidiq.html
+++ b/projects/GlobalSaaSHub/public/tool/vidiq.html
@@ -31,6 +31,7 @@
     </script>
 
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
Revenue-first, zero-cost attribution expansion for the first COSHUMA Shorts funnel.

Changes:
- enables the existing `/affiliate-attribution.js` helper on ElevenLabs, VidIQ, TubeBuddy and GoHighLevel landing pages
- preserves all existing verified customer-facing affiliate URLs and buyer-intent copy
- records UTM source/medium/campaign and `affiliate_click` events when Shorts traffic reaches these static SEO pages
- completes tracking coverage for the initial five Shorts priorities: Descript was already enabled in PR #92; this PR adds the remaining four

No pricing, affiliate URL, commission claim, paid service or subscription is changed.