### PR TITLE
Improve homepage crawl discovery for buyer-intent guides

### DIFF
--- a/projects/GlobalSaaSHub/index.html
+++ b/projects/GlobalSaaSHub/index.html
@@ -23,14 +23,14 @@
     <meta name="google-site-verification" content="google0f306d6dc6fa9ff6" />
     <title>GlobalSaaSHub | Premier AI & B2B SaaS Tool Directory</title>
 
-    <meta name="description" content="Discover top-tier AI software, workflow automation, and productivity tools for professionals and teams." />
+    <meta name="description" content="Compare AI and SaaS tools by pricing, features, alternatives, and best-fit use cases. Explore buyer-focused reviews and side-by-side software comparisons." />
     <link rel="canonical" href="https://coshuma.com/" />
     
     <!-- Open Graph SEO Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/" />
     <meta property="og:title" content="GlobalSaaSHub | Premier AI & B2B SaaS Tool Directory" />
-    <meta property="og:description" content="Discover top-tier AI software, workflow automation, and productivity tools for professionals and teams." />
+    <meta property="og:description" content="Compare AI and SaaS tools by pricing, features, alternatives, and best-fit use cases. Explore buyer-focused reviews and side-by-side software comparisons." />
 
     <!-- JSON-LD Structured Data for Google Indexing -->
     <script type="application/ld+json">
@@ -39,7 +39,7 @@
       "@type": "WebSite",
       "name": "GlobalSaaSHub",
       "url": "https://coshuma.com/",
-      "description": "Discover top-tier AI software, workflow automation, and productivity tools for professionals and teams."
+      "description": "Compare AI and SaaS tools by pricing, features, alternatives, and best-fit use cases. Explore buyer-focused reviews and side-by-side software comparisons."
     }
     </script>
 
@@ -50,26 +50,34 @@
   </head>
   <body style="background-color: #090a0f; color: #ffffff; margin: 0; padding: 0;">
     <div id="root">
-      {/* Static Fallback Content for AI Crawlers & Bots (ChatGPT Bot, Googlebot, Perplexity) */}
-      <div style="padding: 40px; max-w: 800px; margin: 0 auto; text-align: center;">
-        <h1 style="font-size: 28px; font-weight: 800; color: #a855f7;">GlobalSaaSHub - Premier AI & B2B SaaS Directory</h1>
+      <!-- Static fallback content for search and AI crawlers before the app hydrates. -->
+      <div style="padding: 40px; max-width: 800px; margin: 0 auto; text-align: center;">
+        <h1 style="font-size: 28px; font-weight: 800; color: #a855f7;">GlobalSaaSHub - AI & SaaS Pricing, Reviews and Comparisons</h1>
         <p style="font-size: 14px; color: #94a3b8; line-height: 1.6;">
-          Discover top-tier AI software, productivity tools, workflow automation, and developer APIs to scale your business. Browse 151 curated SaaS profiles with clearly sourced pricing where available and side-by-side comparisons of up to 3 direct competitors.
+          Compare AI software, productivity tools, workflow automation, creator platforms and business SaaS by pricing, features, alternatives and best-fit use cases. Use the buyer guides below to reach detailed reviews and side-by-side comparisons without relying on client-side JavaScript.
         </p>
-        <nav aria-label="Featured software guides" style="margin-top: 20px; font-size: 13px; line-height: 2;">
-          <a href="/tool/taskade.html">Taskade review</a> ·
-          <a href="/tool/systeme-io.html">Systeme.io review</a> ·
-          <a href="/tool/fliki.html">Fliki review</a> ·
-          <a href="/tool/castmagic.html">Castmagic review</a> ·
-          <a href="/tool/vidiq.html">vidIQ review</a><br />
+        <nav aria-label="Featured software buyer guides" style="margin-top: 20px; font-size: 13px; line-height: 2;">
+          <strong>Popular pricing and review guides:</strong><br />
+          <a href="/tool/descript.html">Descript pricing & review</a> ·
+          <a href="/tool/elevenlabs.html">ElevenLabs pricing & review</a> ·
+          <a href="/tool/gohighlevel.html">GoHighLevel pricing & review</a> ·
+          <a href="/tool/pictory.html">Pictory pricing & review</a><br />
+          <a href="/tool/fireflies-ai.html">Fireflies.ai pricing & review</a> ·
+          <a href="/tool/vista-social.html">Vista Social pricing & review</a> ·
+          <a href="/tool/systeme-io.html">Systeme.io pricing & review</a> ·
+          <a href="/tool/taskade.html">Taskade pricing & review</a><br />
+          <a href="/tool/vidiq.html">vidIQ pricing & review</a> ·
+          <a href="/tool/tubebuddy.html">TubeBuddy pricing & review</a> ·
+          <a href="/tool/castmagic.html">Castmagic pricing & review</a> ·
+          <a href="/tool/fliki.html">Fliki pricing & review</a><br />
+          <strong>Side-by-side comparisons:</strong><br />
           <a href="/compare/vidiq-vs-tubebuddy.html">vidIQ vs TubeBuddy</a> ·
+          <a href="/compare/descript-vs-tubebuddy.html">Descript vs TubeBuddy</a> ·
           <a href="/compare/castmagic-vs-tubebuddy.html">Castmagic vs TubeBuddy</a> ·
           <a href="/compare/systeme-io-vs-privy.html">Systeme.io vs Privy</a>
         </nav>
-
       </div>
     </div>
     <script type="module" src="/src/main.jsx"></script>
   </body>
-
 </html>


### PR DESCRIPTION
SEO/revenue-focused no-cost cleanup:
- remove the crawl-visible JSX-style fallback comment from raw HTML
- strengthen homepage meta/OG/JSON-LD description around pricing, comparisons, alternatives, and buyer intent
- expose verified existing high-intent tool and compare pages in the static no-JS fallback so crawlers can discover them directly

This addresses a concrete crawl-quality issue observed on the public homepage and strengthens internal discovery while Search Console validation is still in progress for discovered-but-not-indexed pages.