### PR TITLE
Fix Descript vs TubeBuddy buyer-intent SEO landing

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/descript-vs-tubebuddy.html
+++ b/projects/GlobalSaaSHub/public/compare/descript-vs-tubebuddy.html
@@ -1,172 +1,126 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Descript vs TubeBuddy Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Descript vs TubeBuddy. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Descript vs TubeBuddy: Video Editing vs YouTube SEO (2026) | GlobalSaaSHub</title>
+  <meta name="description" content="Compare Descript vs TubeBuddy for creators: text-based video editing, transcription and AI clips vs YouTube SEO, keyword research and channel optimization. See pricing signals and best-fit use cases." />
+  <link rel="canonical" href="https://coshuma.com/compare/descript-vs-tubebuddy.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/descript-vs-tubebuddy.html" />
+  <meta property="og:title" content="Descript vs TubeBuddy: Video Editing vs YouTube SEO (2026)" />
+  <meta property="og:description" content="A buyer-focused comparison of Descript for editing and repurposing versus TubeBuddy for YouTube SEO and channel growth workflows." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"WebPage",
+    "name":"Descript vs TubeBuddy: Video Editing vs YouTube SEO",
+    "url":"https://coshuma.com/compare/descript-vs-tubebuddy.html",
+    "description":"Compare Descript for text-based video and audio editing with TubeBuddy for YouTube SEO, keyword research and channel optimization.",
+    "isPartOf":{"@type":"WebSite","name":"GlobalSaaSHub","url":"https://coshuma.com/"},
+    "about":[
+      {"@type":"SoftwareApplication","name":"Descript","url":"https://coshuma.com/tool/descript.html"},
+      {"@type":"SoftwareApplication","name":"TubeBuddy","url":"https://coshuma.com/tool/tubebuddy.html"}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="/affiliate-attribution.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen flex flex-col justify-between">
+<header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+  <div class="max-w-6xl mx-auto flex items-center justify-between">
+    <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div><span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span></a>
+    <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
+  </div>
+</header>
+<main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
+  <section class="text-center space-y-4">
+    <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Creator Software Comparison</div>
+    <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Descript vs TubeBuddy</h1>
+    <p class="text-slate-300 max-w-2xl mx-auto leading-relaxed">These tools solve different parts of a creator workflow. Descript is primarily for editing, transcription and repurposing. TubeBuddy is primarily for YouTube SEO, keyword research, testing and channel optimization.</p>
+  </section>
 
-    <link rel="canonical" href="https://coshuma.com/compare/descript-vs-tubebuddy.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/descript-vs-tubebuddy.html" />
-    <meta property="og:title" content="Descript vs TubeBuddy Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Descript and TubeBuddy by pricing, features, and verified public information." />
-
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "Descript vs TubeBuddy Comparison",
-      "url": "https://coshuma.com/compare/descript-vs-tubebuddy.html",
-      "description": "Compare Descript and TubeBuddy by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "Descript", "url": "https://coshuma.com/tool/descript.html"},
-        {"@type": "SoftwareApplication", "name": "TubeBuddy", "url": "https://coshuma.com/tool/tubebuddy.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+  <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-5">
+    <h2 class="text-2xl font-black text-white">Quick decision</h2>
+    <div class="grid md:grid-cols-2 gap-4">
+      <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/20 space-y-2">
+        <h3 class="font-bold text-purple-300">Choose Descript if editing is the bottleneck</h3>
+        <p class="text-sm text-slate-300 leading-relaxed">Best fit when you want to edit audio or video through text, transcribe recordings, clean audio, remove filler words, create clips and use AI-assisted editing in one workspace.</p>
       </div>
-    </header>
-
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Descript vs TubeBuddy</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Video & Shorts Gen tool.
-        </p>
+      <div class="p-5 rounded-2xl bg-blue-500/5 border border-blue-500/20 space-y-2">
+        <h3 class="font-bold text-blue-300">Choose TubeBuddy if YouTube discovery is the bottleneck</h3>
+        <p class="text-sm text-slate-300 leading-relaxed">Best fit when you want YouTube keyword research, SEO guidance, title and tag optimization, thumbnail testing, analytics and channel-management utilities.</p>
       </div>
+    </div>
+  </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Descript if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose TubeBuddy if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
+  <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
+    <h2 class="text-2xl font-black text-white">Descript vs TubeBuddy at a glance</h2>
+    <div class="grid grid-cols-3 gap-3 text-sm">
+      <div class="font-bold text-slate-400">Decision factor</div><div class="font-bold text-purple-300">Descript</div><div class="font-bold text-blue-300">TubeBuddy</div>
+      <div class="text-slate-400">Primary job</div><div class="text-slate-200">Edit and repurpose audio/video</div><div class="text-slate-200">Optimize and manage YouTube content</div>
+      <div class="text-slate-400">Free entry</div><div class="text-slate-200">Free plan available</div><div class="text-slate-200">Free access; paid upgrades available</div>
+      <div class="text-slate-400">Paid plan signal</div><div class="text-slate-200">Hobbyist $16–$24/person/mo; Creator $24–$35/person/mo depending on billing cycle</div><div class="text-slate-200">Pro, Legend and Enterprise structure; confirm live checkout pricing for the channel you license</div>
+      <div class="text-slate-400">Strongest fit</div><div class="text-slate-200">Podcasts, interviews, screen recordings, clips</div><div class="text-slate-200">YouTube SEO, testing, research, repetitive channel workflows</div>
+    </div>
+    <p class="text-xs text-slate-500">Descript pricing was cross-checked against current official Descript pages on September 2, 2026. TubeBuddy's current GlobalSaaSHub buyer guide reflects the live Pro/Legend/Enterprise plan structure and directs buyers to the live checkout for final numeric pricing.</p>
+  </section>
+
+  <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+    <h2 class="text-2xl font-black text-white">Feature comparison</h2>
+    <div class="grid md:grid-cols-2 gap-4 text-sm">
+      <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-3">
+        <h3 class="font-bold text-purple-300">Descript strengths</h3>
+        <div class="text-slate-300">✓ Text-based video and audio editing</div>
+        <div class="text-slate-300">✓ Automatic transcription</div>
+        <div class="text-slate-300">✓ Studio Sound and filler-word cleanup</div>
+        <div class="text-slate-300">✓ AI-assisted editing with Underlord</div>
+        <div class="text-slate-300">✓ Short-form clip and caption workflows</div>
       </div>
-
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/descript.html" class="hover:text-purple-300">Descript</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/tubebuddy.html" class="hover:text-blue-300">TubeBuddy</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Descript Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ AI transcription</div>
-<div>✓ Text-based video editing</div>
-<div>✓ Podcast production tools</div>
-<div>✓ Screen recording functionality</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">TubeBuddy Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Video SEO optimization</div>
-<div>✓ Keyword research tools</div>
-<div>✓ Bulk processing features</div>
-<div>✓ Channel health reports</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://get.descript.com/ole5fu20j5sq" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Descript →</a>
-          <a href="https://www.tubebuddy.com/pricing?a=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get TubeBuddy →</a>
-        </div>
+      <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-3">
+        <h3 class="font-bold text-blue-300">TubeBuddy strengths</h3>
+        <div class="text-slate-300">✓ YouTube keyword research</div>
+        <div class="text-slate-300">✓ SEO Studio and metadata optimization</div>
+        <div class="text-slate-300">✓ Thumbnail and metadata testing</div>
+        <div class="text-slate-300">✓ Channel and niche analysis</div>
+        <div class="text-slate-300">✓ Bulk and creator productivity workflows</div>
       </div>
-    </main>
+    </div>
+  </section>
 
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
+  <section class="p-6 rounded-3xl bg-[#131520] border border-amber-500/20 space-y-4">
+    <h2 class="text-2xl font-black text-white">They are not direct substitutes</h2>
+    <p class="text-sm text-slate-300 leading-relaxed">If you publish on YouTube, using one does not necessarily replace the other. Descript can handle the production and repurposing stage, while TubeBuddy can support research, optimization and channel-management work after or before editing. If you only need one, choose based on where your current workflow loses the most time.</p>
+  </section>
+
+  <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+    <h2 class="text-2xl font-black text-white">Check the current plans</h2>
+    <div class="grid md:grid-cols-2 gap-4">
+      <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/25 space-y-4">
+        <h3 class="font-bold text-white">Descript</h3>
+        <p class="text-sm text-slate-300">Start with the free plan if you want to test text-based editing before paying.</p>
+        <a data-cta="affiliate" data-tool-id="descript" href="https://get.descript.com/ole5fu20j5sq" target="_blank" rel="sponsored noopener noreferrer" class="block px-5 py-3 rounded-xl bg-purple-600 hover:bg-purple-500 text-white text-center font-extrabold text-sm">Start Descript Free →</a>
+        <a href="/tool/descript.html" class="block text-center text-xs font-bold text-purple-300 hover:text-purple-200">Read the full Descript pricing guide</a>
       </div>
-    </footer>
-  </body>
+      <div class="p-5 rounded-2xl bg-blue-500/5 border border-blue-500/25 space-y-4">
+        <h3 class="font-bold text-white">TubeBuddy</h3>
+        <p class="text-sm text-slate-300">Use the live pricing route to see the current plan and discount state for the YouTube channel you intend to license.</p>
+        <a data-cta="affiliate" data-tool-id="tubebuddy" href="https://www.tubebuddy.com/pricing?a=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="block px-5 py-3 rounded-xl bg-blue-600 hover:bg-blue-500 text-white text-center font-extrabold text-sm">Check TubeBuddy Plans →</a>
+        <a href="/tool/tubebuddy.html" class="block text-center text-xs font-bold text-blue-300 hover:text-blue-200">Read the full TubeBuddy pricing guide</a>
+      </div>
+    </div>
+    <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: GlobalSaaSHub may earn a commission if you purchase through selected verified partner links, at no additional cost to you. Final prices, taxes, discounts and eligibility are controlled by each vendor.</p>
+  </section>
+
+  <section class="p-5 rounded-2xl bg-[#10121b] border border-[#222538] text-xs text-slate-500 leading-relaxed">
+    <strong class="text-slate-300">Evidence note:</strong> Descript plan amounts and limits were checked against current official Descript pages on September 2, 2026. TubeBuddy feature and plan guidance is aligned with the current dedicated GlobalSaaSHub TubeBuddy buyer guide, which was checked against TubeBuddy official sources on September 2, 2026. This comparison does not claim hands-on testing where none was performed.
+  </section>
+</main>
+<footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div></footer>
+</body>
 </html>


### PR DESCRIPTION
Replace a low-trust programmatic comparison that exposed `Not rated` / `See official pricing` placeholders with a focused buyer guide:
- clarify that Descript and TubeBuddy solve different creator workflow stages
- replace placeholder meta/body copy with search-intent terms around video editing vs YouTube SEO
- add current Descript pricing signals and cautious TubeBuddy live-pricing guidance
- preserve the existing verified affiliate destinations
- add affiliate attribution hooks and stronger internal links to both pricing guides
- keep canonical, OG and JSON-LD aligned