### PR TITLE
Fix ChatBot vs GoHighLevel buyer-intent SEO landing

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/chatbot-vs-gohighlevel.html
+++ b/projects/GlobalSaaSHub/public/compare/chatbot-vs-gohighlevel.html
@@ -1,172 +1,134 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ChatBot vs GoHighLevel Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of ChatBot vs GoHighLevel. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ChatBot vs GoHighLevel: AI Support vs Agency CRM (2026) | GlobalSaaSHub</title>
+  <meta name="description" content="Compare ChatBot vs GoHighLevel for AI customer support, CRM, funnels and agency automation. See current pricing signals, free-trial differences and best-fit use cases." />
+  <link rel="canonical" href="https://coshuma.com/compare/chatbot-vs-gohighlevel.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/chatbot-vs-gohighlevel.html" />
+  <meta property="og:title" content="ChatBot vs GoHighLevel: AI Support vs Agency CRM (2026)" />
+  <meta property="og:description" content="Choose between ChatBot for AI-first support workflows and GoHighLevel for broader CRM, funnel and agency automation." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"WebPage",
+    "name":"ChatBot vs GoHighLevel: AI Support vs Agency CRM",
+    "url":"https://coshuma.com/compare/chatbot-vs-gohighlevel.html",
+    "description":"Compare ChatBot and GoHighLevel by customer-support focus, CRM and agency workflows, pricing signals and best-fit use cases.",
+    "isPartOf":{"@type":"WebSite","name":"GlobalSaaSHub","url":"https://coshuma.com/"},
+    "about":[
+      {"@type":"SoftwareApplication","name":"ChatBot","url":"https://coshuma.com/tool/chatbot.html"},
+      {"@type":"SoftwareApplication","name":"GoHighLevel","url":"https://coshuma.com/tool/gohighlevel.html"}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="/affiliate-attribution.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen flex flex-col justify-between">
+<header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+  <div class="max-w-6xl mx-auto flex items-center justify-between">
+    <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div><span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span></a>
+    <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
+  </div>
+</header>
+<main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
+  <section class="text-center space-y-4">
+    <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Customer Support vs Agency Platform</div>
+    <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">ChatBot vs GoHighLevel</h1>
+    <p class="text-slate-300 max-w-2xl mx-auto leading-relaxed">ChatBot is centered on AI customer conversations, inbox and support automation. GoHighLevel is a broader CRM, lead-nurture, funnel and client-account platform built heavily around agency workflows.</p>
+  </section>
 
-    <link rel="canonical" href="https://coshuma.com/compare/chatbot-vs-gohighlevel.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/chatbot-vs-gohighlevel.html" />
-    <meta property="og:title" content="ChatBot vs GoHighLevel Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare ChatBot and GoHighLevel by pricing, features, and verified public information." />
-
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "ChatBot vs GoHighLevel Comparison",
-      "url": "https://coshuma.com/compare/chatbot-vs-gohighlevel.html",
-      "description": "Compare ChatBot and GoHighLevel by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "ChatBot", "url": "https://coshuma.com/tool/chatbot.html"},
-        {"@type": "SoftwareApplication", "name": "GoHighLevel", "url": "https://coshuma.com/tool/gohighlevel.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+  <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-5">
+    <h2 class="text-2xl font-black text-white">Quick decision</h2>
+    <div class="grid md:grid-cols-2 gap-4">
+      <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/20 space-y-2">
+        <h3 class="font-bold text-purple-300">Choose ChatBot if support automation is the main job</h3>
+        <p class="text-sm text-slate-300 leading-relaxed">Best fit when your priority is an AI Agent, shared inbox, ticketing, live chat, human takeover and customer-support workflows without adopting a full agency CRM stack.</p>
       </div>
-    </header>
-
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">ChatBot vs GoHighLevel</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Chatbots & Support tool.
-        </p>
+      <div class="p-5 rounded-2xl bg-blue-500/5 border border-blue-500/20 space-y-2">
+        <h3 class="font-bold text-blue-300">Choose GoHighLevel if you need the broader revenue stack</h3>
+        <p class="text-sm text-slate-300 leading-relaxed">Best fit when you need CRM pipelines, lead capture, booking, funnels, automated email/SMS, client sub-accounts and agency-oriented management in one platform.</p>
       </div>
+    </div>
+  </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose ChatBot if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose GoHighLevel if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
+  <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
+    <h2 class="text-2xl font-black text-white">Pricing signals checked September 2, 2026</h2>
+    <div class="grid md:grid-cols-2 gap-4 text-sm">
+      <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-3">
+        <h3 class="font-bold text-purple-300">ChatBot</h3>
+        <p class="text-slate-300"><strong>Essential:</strong> $19/user/month billed yearly or $25 billed monthly.</p>
+        <p class="text-slate-300"><strong>Growth:</strong> $79/user/month billed yearly or $99 billed monthly.</p>
+        <p class="text-slate-300"><strong>Enterprise:</strong> custom pricing.</p>
+        <p class="text-xs text-slate-500">The official pricing page advertises a 14-day free trial with no credit card required. There is no permanent free tier on the current public pricing page.</p>
       </div>
-
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/chatbot.html" class="hover:text-purple-300">ChatBot</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/gohighlevel.html" class="hover:text-blue-300">GoHighLevel</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">ChatBot Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Create AI chatbots</div>
-<div>✓ Automate customer service</div>
-<div>✓ Lead generation automation</div>
-<div>✓ No-code builder</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">GoHighLevel Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ CRM & Pipeline</div>
-<div>✓ Automated SMS/Email</div>
-<div>✓ Sales Funnels</div>
-<div>✓ AI Chatbots</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://chatbot.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get ChatBot →</a>
-          <a href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get GoHighLevel →</a>
-        </div>
+      <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-3">
+        <h3 class="font-bold text-blue-300">GoHighLevel</h3>
+        <p class="text-slate-300"><strong>Starter:</strong> $97/month, including up to three sub-accounts.</p>
+        <p class="text-slate-300"><strong>Unlimited:</strong> $297/month with unlimited sub-accounts and API access.</p>
+        <p class="text-slate-300"><strong>Agency Pro / SaaS Pro:</strong> $497/month on current official plan routes that list the SaaS tier.</p>
+        <p class="text-xs text-slate-500">Standard official pricing routes advertise a 14-day trial, while some official promotional routes display 30 days. Confirm the exact trial shown after clicking.</p>
       </div>
-    </main>
+    </div>
+  </section>
 
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
+  <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+    <h2 class="text-2xl font-black text-white">Feature comparison</h2>
+    <div class="grid md:grid-cols-2 gap-4 text-sm">
+      <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/20 space-y-3">
+        <h3 class="font-bold text-purple-300">ChatBot strengths</h3>
+        <div class="text-slate-300">✓ AI Agent for customer conversations</div>
+        <div class="text-slate-300">✓ Shared inbox and ticketing</div>
+        <div class="text-slate-300">✓ Live chat and human takeover</div>
+        <div class="text-slate-300">✓ Workflow automation and proactive campaigns</div>
+        <div class="text-slate-300">✓ Website chat plus supported messaging channels</div>
       </div>
-    </footer>
-  </body>
+      <div class="p-5 rounded-2xl bg-blue-500/5 border border-blue-500/20 space-y-3">
+        <h3 class="font-bold text-blue-300">GoHighLevel strengths</h3>
+        <div class="text-slate-300">✓ CRM and sales pipelines</div>
+        <div class="text-slate-300">✓ Booking, funnels and website builder</div>
+        <div class="text-slate-300">✓ Automated email and SMS workflows</div>
+        <div class="text-slate-300">✓ Client sub-accounts for agencies</div>
+        <div class="text-slate-300">✓ SaaS-mode options on higher-tier plans</div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-6 rounded-3xl bg-[#131520] border border-amber-500/20 space-y-4">
+    <h2 class="text-2xl font-black text-white">The main difference is scope</h2>
+    <p class="text-sm text-slate-300 leading-relaxed">ChatBot is the more focused purchase when AI support and live customer conversations are the problem to solve. GoHighLevel costs more at the entry level but covers a much wider lead-to-client workflow. Do not choose GoHighLevel only for chatbot functionality if you will not use its CRM, funnels, automations or account structure.</p>
+  </section>
+
+  <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+    <h2 class="text-2xl font-black text-white">Check the current plans</h2>
+    <div class="grid md:grid-cols-2 gap-4">
+      <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/25 space-y-4">
+        <h3 class="font-bold text-white">ChatBot</h3>
+        <p class="text-sm text-slate-300">Use ChatBot's official pricing page to verify the current seat and AI-resolution cost for your support volume.</p>
+        <a href="https://www.chatbot.com/pricing/" target="_blank" rel="noopener noreferrer" class="block px-5 py-3 rounded-xl bg-purple-600 hover:bg-purple-500 text-white text-center font-extrabold text-sm">Check ChatBot Pricing →</a>
+        <a href="/tool/chatbot.html" class="block text-center text-xs font-bold text-purple-300 hover:text-purple-200">Read the ChatBot overview</a>
+      </div>
+      <div class="p-5 rounded-2xl bg-blue-500/5 border border-blue-500/25 space-y-4">
+        <h3 class="font-bold text-white">GoHighLevel</h3>
+        <p class="text-sm text-slate-300">GlobalSaaSHub has a verified customer-facing HighLevel partner route. Use the detailed guide to compare the plan structure before subscribing.</p>
+        <a data-cta="affiliate" data-tool-id="gohighlevel" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="block px-5 py-3 rounded-xl bg-blue-600 hover:bg-blue-500 text-white text-center font-extrabold text-sm">Check GoHighLevel Plans →</a>
+        <a href="/tool/gohighlevel.html" class="block text-center text-xs font-bold text-blue-300 hover:text-blue-200">Read the full GoHighLevel pricing guide</a>
+      </div>
+    </div>
+    <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: GlobalSaaSHub may earn a commission if you purchase GoHighLevel through the verified partner link above, at no additional cost to you. ChatBot is linked through its official pricing page here. Final prices, taxes, discounts and eligibility are controlled by each vendor.</p>
+  </section>
+
+  <section class="p-5 rounded-2xl bg-[#10121b] border border-[#222538] text-xs text-slate-500 leading-relaxed">
+    <strong class="text-slate-300">Evidence note:</strong> Pricing and plan claims on this page were checked against current official ChatBot and HighLevel pages on September 2, 2026. HighLevel currently exposes both standard 14-day and promotional 30-day trial routes, so this page does not promise a single trial duration. This comparison does not claim hands-on testing where none was performed.
+  </section>
+</main>
+<footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div></footer>
+</body>
 </html>


### PR DESCRIPTION
SEO/revenue-focused cleanup for another high-intent comparison that still exposed programmatic placeholders.

Changes:
- removes `Not rated`, `See official pricing` and unsupported `Winner` positioning
- reframes the decision around AI support vs broader CRM/agency automation
- adds current official ChatBot pricing signals and current HighLevel $97/$297/$497 plan structure
- preserves ChatBot as a normal official link and the exact verified HighLevel customer partner route
- adds affiliate attribution metadata only to the verified HighLevel CTA
- keeps canonical, OG, JSON-LD and internal links aligned

Evidence checked Sep 2, 2026 against current official ChatBot and HighLevel pricing pages. No paid action or unverified affiliate URL is introduced.