### PR TITLE
Optimize Rytr buyer-intent affiliate landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/rytr.html
+++ b/projects/GlobalSaaSHub/public/tool/rytr.html
@@ -3,29 +3,26 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Rytr Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Rytr is an AI-powered writing assistant that helps you generate high-quality content for various needs in just seconds. From blog posts to emails, cre... Discover features, pricing (See official pricing), and official links for Rytr on GlobalSaaSHub." />
+    <title>Rytr Pricing, Free Plan & Best Fit (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Rytr pricing and buyer guide for 2026: compare the Free, Unlimited and Premium plans, writing limits, tone matching, plagiarism checks, languages and best-fit use cases." />
     <link rel="canonical" href="https://coshuma.com/tool/rytr.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/tool/rytr.html" />
-    <meta property="og:title" content="Rytr Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Rytr is an AI-powered writing assistant that helps you generate high-quality content for various needs in just seconds. From blog posts to emails, cre... Check rating, pricing, and features." />
+    <meta property="og:title" content="Rytr Pricing, Free Plan & Best Fit (2026)" />
+    <meta property="og:description" content="Compare Rytr's Free, Unlimited and Premium plans, writing limits, tone matching and plagiarism checks before choosing a plan." />
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Rytr",
-      "operatingSystem": "Web",
-      "applicationCategory": "Email & Outreach",
-      "description": "Rytr is an AI-powered writing assistant that helps you generate high-quality content for various needs in just seconds. From blog posts to emails, create compelling copy quickly and efficiently with intelligent AI suggestions."
+      "operatingSystem": "Web, Browser Extension",
+      "applicationCategory": "BusinessApplication",
+      "url": "https://coshuma.com/tool/rytr.html",
+      "description": "AI writing assistant for drafting, editing and improving marketing, business and general-purpose content."
     }
     </script>
 
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,133 +33,136 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
     <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
+      <article class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
+        <section class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=rytr.me&sz=128" alt="Rytr logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=rytr.me&sz=128" alt="Rytr logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Email & Outreach</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Rytr</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">AI Writing Assistant</div>
+              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Rytr Pricing & Best-Fit Guide</h1>
+              <p class="text-slate-400 text-sm mt-2">Checked against Rytr's official pricing and product pages on September 2, 2026.</p>
             </div>
           </div>
+        </section>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
-        </div>
-
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">Rytr is an AI-powered writing assistant that helps you generate high-quality content for various needs in just seconds. From blog posts to emails, create compelling copy quickly and efficiently with intelligent AI suggestions.</p>
-        </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI content generation</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Supports 30+ languages</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> 50+ use cases & templates</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Plagiarism checker</div>
-          </div>
-        </div>
-
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Rytr</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/convertkit.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=kit.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Kit (formerly ConvertKit)</span></div><span class="text-[10px] font-extrabold text-emerald-400">Free plan; Creator plan from $33/month for 1,000 subscribers</span></a>
-<a href="/tool/aweber.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=aweber.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">AWeber</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/moosend.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=moosend.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Moosend</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
-
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <section class="rounded-2xl bg-gradient-to-br from-purple-500/10 to-indigo-500/5 border border-purple-500/20 p-6 space-y-4">
           <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
+            <h2 class="text-2xl font-black text-white">Quick verdict</h2>
+            <p class="text-slate-300 leading-relaxed mt-2">Rytr is strongest for individuals and freelancers who want a low-cost AI writing assistant for short-form marketing copy, emails, rewrites and everyday drafting. The free plan is useful for light testing, Unlimited is the value option for one main writing voice, and Premium is the better fit when you manage multiple brands or need broader language support.</p>
           </div>
-          <a data-cta="official" href="https://rytr.me/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Rytr Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://rytr.me?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Rytr via Verified Affiliate Link</span><span>→</span></a>
-        </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <a data-cta="affiliate" data-tool-id="rytr" href="https://rytr.me?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Check Rytr via verified affiliate link →</a>
+            <a data-cta="official" href="https://rytr.me/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">View official pricing →</a>
+          </div>
+          <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission if you purchase through the verified affiliate link above, at no additional cost to you. Pricing and plan terms can change, so confirm the checkout page before paying.</p>
+        </section>
 
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Rytr?</span>
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">Current Rytr pricing</h2>
+          <p class="text-slate-300 text-sm leading-relaxed">Rytr's official pricing page currently shows the following annual-effective prices, with annual billing advertised as two months free / about 20% savings. Monthly billing is available separately and can be cancelled at any time.</p>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+              <div class="text-xs uppercase tracking-wider text-slate-400 font-bold">Free</div>
+              <div class="text-2xl font-black text-emerald-400 mt-1">$0/month</div>
+              <ul class="mt-4 space-y-2 text-sm text-slate-300">
+                <li>• 10K characters per month</li>
+                <li>• 40+ use cases</li>
+                <li>• 20+ preset tones</li>
+                <li>• Chrome extension</li>
+                <li>• No credit card required</li>
+              </ul>
             </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
+            <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/30">
+              <div class="text-xs uppercase tracking-wider text-purple-300 font-bold">Unlimited</div>
+              <div class="text-2xl font-black text-emerald-400 mt-1">$7.50/month*</div>
+              <ul class="mt-4 space-y-2 text-sm text-slate-300">
+                <li>• Unlimited AI generation</li>
+                <li>• 1 personalised tone match</li>
+                <li>• 50 plagiarism checks/month</li>
+                <li>• Higher input limits than Free</li>
+              </ul>
+            </div>
+            <div class="p-5 rounded-2xl bg-indigo-500/5 border border-indigo-500/30">
+              <div class="text-xs uppercase tracking-wider text-indigo-300 font-bold">Premium</div>
+              <div class="text-2xl font-black text-emerald-400 mt-1">$24.16/month*</div>
+              <ul class="mt-4 space-y-2 text-sm text-slate-300">
+                <li>• Unlimited AI generation</li>
+                <li>• Multiple personalised tone matches</li>
+                <li>• 100 plagiarism checks/month</li>
+                <li>• 35+ languages on the pricing page</li>
+                <li>• Higher character input limits</li>
+              </ul>
+            </div>
           </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Rytr Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/rytr.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Rytr Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
+          <p class="text-[11px] text-slate-500">*Annual-effective price shown on Rytr's official pricing page when yearly billing is selected. Check the live pricing page for current monthly billing amounts.</p>
+        </section>
 
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">What Rytr is good at</h2>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">Fast everyday drafting:</strong> emails, replies, captions, calls to action, SEO metadata and short marketing copy.</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">Editing and rewriting:</strong> text expansion, correction, tone changes, autocomplete and content improvement.</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">Voice matching:</strong> paid tiers can mirror a personalised writing voice, with Premium aimed at multiple brands or clients.</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">Write where you work:</strong> Rytr promotes a Chrome extension for generating and editing content across browser-based workflows.</div>
+          </div>
+        </section>
 
-      </div>
+        <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
+            <h3 class="text-base font-bold text-emerald-400">Choose Rytr if...</h3>
+            <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+              <li>You want a permanent free tier before paying.</li>
+              <li>You mostly create short-form business or marketing copy.</li>
+              <li>You want unlimited generation at a relatively low annual-effective price.</li>
+              <li>You need plagiarism checks and personal tone matching in one writing tool.</li>
+            </ul>
+          </div>
+          <div class="p-5 rounded-2xl bg-amber-500/5 border border-amber-500/20 space-y-2">
+            <h3 class="text-base font-bold text-amber-300">Consider an alternative if...</h3>
+            <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+              <li>Your main workflow is long-form SEO research and optimization rather than general drafting.</li>
+              <li>You are primarily writing fiction and want story-specific planning tools.</li>
+              <li>You need a WordPress-focused AI content workflow.</li>
+              <li>You need heavy team collaboration and content operations beyond a writing assistant.</li>
+            </ul>
+          </div>
+        </section>
+
+        <section class="space-y-4 pt-4 border-t border-[#222538]">
+          <h2 class="text-xl font-bold text-white">Best alternatives on COSHUMA</h2>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <a href="/tool/sudowrite.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">Sudowrite</div><div class="text-xs text-slate-400 mt-1">Better fit for fiction and creative-writing workflows.</div></a>
+            <a href="/tool/frase.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">Frase</div><div class="text-xs text-slate-400 mt-1">Better fit for SEO research, briefs and optimized content.</div></a>
+            <a href="/tool/getgenie.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">GetGenie</div><div class="text-xs text-slate-400 mt-1">Better fit for WordPress-centered AI content workflows.</div></a>
+          </div>
+        </section>
+
+        <section class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] space-y-4">
+          <h2 class="text-xl font-bold text-white">Bottom line</h2>
+          <p class="text-slate-300 leading-relaxed">Start on Free if you only need occasional drafts or want to test Rytr's workflow. Unlimited is the simplest value choice for a single writer who wants unrestricted generation, while Premium makes more sense for freelancers or marketers handling several brands, more languages and more plagiarism checks.</p>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <a data-cta="affiliate" data-tool-id="rytr" href="https://rytr.me?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Try Rytr via verified affiliate link →</a>
+            <a href="/tool/sudowrite.html" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Compare a creative-writing alternative →</a>
+          </div>
+        </section>
+      </article>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
+
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
Revenue-first, zero-cost conversion update for an already verified Rytr affiliate route.

Changes:
- replaces generic `Not yet editorially rated`, `Editorial review in progress` and `See official pricing` placeholders with a buyer-intent 2026 pricing guide
- preserves the exact verified customer-facing affiliate URL `https://rytr.me?via=sangkwon`
- adds above-the-fold and closing affiliate CTAs with `data-cta="affiliate"` and `data-tool-id="rytr"`
- adds the existing `/affiliate-attribution.js` helper so UTM traffic and affiliate clicks can be measured on this static page
- adds current Free / Unlimited / Premium plan guidance and annual-effective pricing from Rytr's official pricing page checked Sep 2, 2026
- replaces irrelevant email-marketing alternatives with Sudowrite, Frase and GetGenie internal routes that better match writing-content intent
- adds explicit affiliate disclosure and avoids ratings or unsupported superiority claims

Official evidence checked Sep 2, 2026:
- https://rytr.me/pricing
- https://rytr.me/
- https://rytr.me/products/my-voice

No paid services, new affiliate application, guessed tracking URL or commission claim is introduced.