### PR TITLE
Optimize BoldDesk buyer-intent affiliate landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/bolddesk.html
+++ b/projects/GlobalSaaSHub/public/tool/bolddesk.html
@@ -3,29 +3,26 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>BoldDesk Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="A comprehensive help desk solution designed for startups, offering a free plan to manage customer inquiries efficiently and streamline support operati... Discover features, pricing (See official pricing), and official links for BoldDesk on GlobalSaaSHub." />
+    <title>BoldDesk Pricing, Free Trial & Best Fit (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="BoldDesk pricing and buyer guide for 2026: review current team-size pricing, the 15-day free trial, all-inclusive support features, AI support tools and best-fit use cases." />
     <link rel="canonical" href="https://coshuma.com/tool/bolddesk.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/tool/bolddesk.html" />
-    <meta property="og:title" content="BoldDesk Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="A comprehensive help desk solution designed for startups, offering a free plan to manage customer inquiries efficiently and streamline support operati... Check rating, pricing, and features." />
+    <meta property="og:title" content="BoldDesk Pricing, Free Trial & Best Fit (2026)" />
+    <meta property="og:description" content="Compare BoldDesk's current team-size pricing, 15-day free trial, all-inclusive help desk features and best-fit use cases before choosing it." />
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "BoldDesk",
       "operatingSystem": "Web",
-      "applicationCategory": "Workflow Automation",
-      "description": "A comprehensive help desk solution designed for startups, offering a free plan to manage customer inquiries efficiently and streamline support operations."
+      "applicationCategory": "BusinessApplication",
+      "url": "https://coshuma.com/tool/bolddesk.html",
+      "description": "AI-powered customer support software combining ticketing, live chat, omnichannel support, automation, knowledge base, reporting, AI Agent and AI Copilot capabilities."
     }
     </script>
 
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,134 +33,119 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
     <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
+      <article class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
+        <section class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=bolddesk.com&sz=128" alt="BoldDesk logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=bolddesk.com&sz=128" alt="BoldDesk logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Workflow Automation</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">BoldDesk</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">Customer Support & Help Desk</div>
+              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">BoldDesk Pricing & Best-Fit Guide</h1>
+              <p class="text-slate-400 text-sm mt-2">Checked against BoldDesk's official pricing, product and affiliate pages on September 2, 2026.</p>
             </div>
           </div>
+        </section>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
-        </div>
-
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">A comprehensive help desk solution designed for startups, offering a free plan to manage customer inquiries efficiently and streamline support operations.</p>
-        </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Ticket Management System</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Self-Service Portal (Knowledge Base)</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Automated Workflow Rules</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Reporting & Analytics</div>
-          </div>
-        </div>
-
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to BoldDesk</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/notion-ai.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=notion.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Notion AI</span></div><span class="text-[10px] font-extrabold text-emerald-400">Free trial; Business plan with Notion AI at $20/user/month</span></a>
-<a href="/tool/socialchamp-io.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=socialchamp.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Social Champ</span></div><span class="text-[10px] font-extrabold text-emerald-400">Free plan; paid plans from $4/month billed annually</span></a>
-<a href="/tool/boldsign.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=boldsign.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">BoldSign</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
-
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <section class="rounded-2xl bg-gradient-to-br from-purple-500/10 to-indigo-500/5 border border-purple-500/20 p-6 space-y-4">
           <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
+            <h2 class="text-2xl font-black text-white">Quick verdict</h2>
+            <p class="text-slate-300 leading-relaxed mt-2">BoldDesk is a strong fit for support teams that want ticketing, live chat, omnichannel support, automation, knowledge base, reporting and AI capabilities in one platform instead of paying separately to unlock feature tiers. Its current public pricing starts at $99 per month for 5 agents when billed yearly, and the standard trial is 15 days with no credit card required.</p>
           </div>
-          <a data-cta="official" href="https://www.bolddesk.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official BoldDesk Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://www.bolddesk.com/?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit BoldDesk via Verified Affiliate Link</span><span>→</span></a>
-        </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <a data-cta="affiliate" data-tool-id="bolddesk" href="https://www.bolddesk.com/?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Try BoldDesk via verified affiliate link →</a>
+            <a data-cta="official" href="https://www.bolddesk.com/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">View official pricing →</a>
+          </div>
+          <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission if you purchase through the verified affiliate link above, at no additional cost to you. BoldDesk's official affiliate page currently states 30% commission on eligible referred sales for the first 12 months and a 90-day cookie period. Pricing and program terms can change, so confirm the live vendor pages before paying.</p>
+        </section>
 
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of BoldDesk?</span>
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">Current BoldDesk pricing</h2>
+          <p class="text-slate-300 text-sm leading-relaxed">BoldDesk currently presents one all-inclusive product priced by team size. The figures below are the public prices shown on the official pricing page when checked on September 2, 2026.</p>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+              <div class="text-xs uppercase tracking-wider text-slate-400 font-bold">5 agents</div>
+              <div class="text-2xl font-black text-emerald-400 mt-1">$99/month yearly</div>
+              <p class="text-xs text-slate-400 mt-1">$1,188 billed yearly; about $20 per agent.</p>
+              <div class="text-lg font-bold text-white mt-4">$124/month monthly</div>
+              <p class="text-xs text-slate-400 mt-1">Billed monthly; about $24.80 per agent.</p>
             </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
+            <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/30">
+              <div class="text-xs uppercase tracking-wider text-purple-300 font-bold">25 agents</div>
+              <div class="text-2xl font-black text-emerald-400 mt-1">$349/month yearly</div>
+              <p class="text-xs text-slate-400 mt-1">$4,188 billed yearly; about $14 per agent.</p>
+              <div class="text-lg font-bold text-white mt-4">$436/month monthly</div>
+              <p class="text-xs text-slate-400 mt-1">Billed monthly; about $17.44 per agent.</p>
+            </div>
           </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim BoldDesk Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/bolddesk.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="BoldDesk Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">Free trial:</strong> BoldDesk's official pricing page says the standard trial lasts 15 days and gives access to the platform's features, with no credit card required to start.</div>
+          <p class="text-[11px] text-slate-500">Larger team sizes have separate published prices. Check the live BoldDesk pricing page for the exact agent count you need and for any limited-time AI-credit offer.</p>
+        </section>
 
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">What you get in the platform</h2>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">Ticketing & omnichannel:</strong> email ticketing, live chat and support across channels such as WhatsApp, SMS and social messaging.</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">Automation:</strong> workflow automation, routing, SLA management and support processes in the same platform.</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">Self service:</strong> knowledge base and customer portal tools for reducing repetitive agent work.</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">AI support:</strong> BoldDesk advertises AI Agent, AI Copilot and AI Actions alongside its core help desk features.</div>
+          </div>
+        </section>
 
-      </div>
+        <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
+            <h3 class="text-base font-bold text-emerald-400">Choose BoldDesk if...</h3>
+            <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+              <li>You want core help desk and omnichannel features in one product.</li>
+              <li>You prefer published team-size pricing instead of feature-gated plan tiers.</li>
+              <li>You are evaluating a Zendesk or Freshdesk replacement and value migration support.</li>
+              <li>You want to test the full support workflow before entering payment details.</li>
+            </ul>
+          </div>
+          <div class="p-5 rounded-2xl bg-amber-500/5 border border-amber-500/20 space-y-2">
+            <h3 class="text-base font-bold text-amber-300">Check carefully before buying if...</h3>
+            <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+              <li>Your team has fewer than five agents and you need the lowest possible entry price.</li>
+              <li>Your AI usage will be heavy and AI-credit or add-on costs materially affect your budget.</li>
+              <li>You need a specific integration or compliance requirement that must be validated before migration.</li>
+              <li>You are relying on a startup or nonprofit promotion rather than standard public pricing.</li>
+            </ul>
+          </div>
+        </section>
+
+        <section class="space-y-4 pt-4 border-t border-[#222538]">
+          <h2 class="text-xl font-bold text-white">Useful alternatives on COSHUMA</h2>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <a href="/tool/helpdesk.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">HelpDesk</div><div class="text-xs text-slate-400 mt-1">Compare another dedicated ticketing and support platform.</div></a>
+            <a href="/tool/tidio.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">Tidio</div><div class="text-xs text-slate-400 mt-1">Compare a support platform centered on live chat and automation.</div></a>
+            <a href="/tool/livechat.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">LiveChat</div><div class="text-xs text-slate-400 mt-1">Compare a mature live-chat-focused support option.</div></a>
+          </div>
+        </section>
+
+        <section class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] space-y-4">
+          <h2 class="text-xl font-bold text-white">Bottom line</h2>
+          <p class="text-slate-300 leading-relaxed">BoldDesk makes the most sense for teams that want an all-in-one support stack and can use its team-size pricing efficiently. Start with the 15-day free trial, test the channels and automation your team actually needs, then compare the live annual and monthly totals for your agent count before committing.</p>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <a data-cta="affiliate" data-tool-id="bolddesk" href="https://www.bolddesk.com/?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start BoldDesk via verified affiliate link →</a>
+            <a data-cta="official" href="https://www.bolddesk.com/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Recheck live pricing →</a>
+          </div>
+        </section>
+      </article>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
+
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>
-


### PR DESCRIPTION
## Revenue-focused change
- Replaces placeholder/review-in-progress copy with a buyer-intent BoldDesk pricing guide.
- Uses current official BoldDesk pricing and 15-day trial facts checked on 2026-09-02.
- Preserves the exact verified affiliate route: `https://www.bolddesk.com/?via=sangkwon`.
- Adds prominent `data-cta="affiliate"` / `data-tool-id="bolddesk"` CTAs and loads `/affiliate-attribution.js` for source-tagged click attribution.
- Adds explicit affiliate disclosure and current public BoldDesk affiliate terms (30% for 12 months; 90-day cookie), with a recheck-before-purchase note.

Official evidence used: BoldDesk pricing page, BoldDesk product page, BoldDesk affiliate program page.

No paid service or subscription added.