### PR TITLE
Optimize OutlierKit buyer-intent affiliate landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/outlierkit.html
+++ b/projects/GlobalSaaSHub/public/tool/outlierkit.html
@@ -3,29 +3,25 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>OutlierKit Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="An AI-powered platform designed for content creators, OutlierKit helps identify trending topics and viral video ideas, specifically for YouTube-focuse... Discover features, pricing (See official pricing), and official links for OutlierKit on GlobalSaaSHub." />
+    <title>OutlierKit Pricing & YouTube Research Guide (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Compare OutlierKit's 2026 Hobby, Pro and Max plans, free trial, YouTube outlier research, Competitor Studio, API/MCP access and who each plan is best for." />
     <link rel="canonical" href="https://coshuma.com/tool/outlierkit.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/tool/outlierkit.html" />
-    <meta property="og:title" content="OutlierKit Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="An AI-powered platform designed for content creators, OutlierKit helps identify trending topics and viral video ideas, specifically for YouTube-focuse... Check rating, pricing, and features." />
-
-    <!-- JSON-LD Structured Data for Google Indexing -->
+    <meta property="og:title" content="OutlierKit Pricing & YouTube Research Guide (2026) | GlobalSaaSHub" />
+    <meta property="og:description" content="A buyer-focused guide to OutlierKit's free trial, annual pricing, research credits, Competitor Studio and API/MCP access." />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "OutlierKit",
       "operatingSystem": "Web",
-      "applicationCategory": "Video & Shorts Gen",
-      "description": "An AI-powered platform designed for content creators, OutlierKit helps identify trending topics and viral video ideas, specifically for YouTube-focused audiences, to maximize engagement and growth."
+      "applicationCategory": "BusinessApplication",
+      "description": "YouTube competitor intelligence and outlier research software for creators, teams and agencies.",
+      "url": "https://outlierkit.com/"
     }
     </script>
-
-    <!-- Tailwind & Fonts -->
+    <script defer src="/affiliate-attribution.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,134 +32,129 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">&larr; Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
+    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
+      <section class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-6">
+        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=outlierkit.com&sz=128" alt="OutlierKit logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=outlierkit.com&sz=128" alt="OutlierKit logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Video & Shorts Gen</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">OutlierKit</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">YouTube research & competitor intelligence</div>
+              <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">OutlierKit pricing & buyer guide</h1>
             </div>
           </div>
-
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
         </div>
-
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">An AI-powered platform designed for content creators, OutlierKit helps identify trending topics and viral video ideas, specifically for YouTube-focused audiences, to maximize engagement and growth.</p>
+        <p class="text-slate-300 leading-relaxed max-w-3xl">OutlierKit is built for creators who want to decide <strong class="text-white">what to make next</strong> using public YouTube data. Its core workflow combines outlier-video research, keyword research, script analysis and channel analysis, while Pro and Max add niche-wide Competitor Studio plus MCP/API access.</p>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-xs text-slate-400 uppercase font-bold">Free trial</div><div class="text-white font-extrabold mt-1">10 credits</div><div class="text-slate-400 text-xs mt-1">No credit card required</div></div>
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-xs text-slate-400 uppercase font-bold">Annual entry plan</div><div class="text-white font-extrabold mt-1">$199/year</div><div class="text-slate-400 text-xs mt-1">Hobby · $16.60/mo effective</div></div>
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-xs text-slate-400 uppercase font-bold">Best fit</div><div class="text-white font-extrabold mt-1">YouTube topic research</div><div class="text-slate-400 text-xs mt-1">Creators, teams and agencies</div></div>
         </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI-powered trend analysis</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Viral video idea generation</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> YouTube audience insights</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Content strategy assistance</div>
-          </div>
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a data-cta="affiliate" data-tool-id="outlierkit" href="https://outlierkit.com/?ref=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start OutlierKit via verified partner link &rarr;</a>
+          <a data-cta="official" href="https://outlierkit.com/app/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-bold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Check official pricing</a>
         </div>
+        <p class="text-[11px] text-slate-500">Affiliate disclosure: GlobalSaaSHub may earn a commission if you purchase through the verified partner link, at no added cost to you. Pricing and plan details can change; confirm the final amount on OutlierKit before purchase.</p>
+      </section>
 
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <div>
+          <h2 class="text-2xl font-black text-white">Current annual plan snapshot</h2>
+          <p class="text-sm text-slate-400 mt-1">Official pricing checked September 2, 2026. Amounts below are annual-billing totals and their displayed monthly equivalents.</p>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-3">
+            <div class="text-purple-300 font-extrabold">Hobby</div>
+            <div><span class="text-2xl font-black text-white">$199</span><span class="text-slate-400 text-sm">/year</span></div>
+            <div class="text-xs text-emerald-400 font-bold">$16.60/mo effective</div>
+            <ul class="text-xs text-slate-300 space-y-2">
+              <li>100 credits/month</li>
+              <li>Outlier & keyword research</li>
+              <li>Script/hook and channel analysis</li>
             </ul>
           </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
+          <div class="p-5 rounded-2xl bg-purple-500/10 border border-purple-500/40 space-y-3">
+            <div class="text-purple-300 font-extrabold">Pro</div>
+            <div><span class="text-2xl font-black text-white">$299</span><span class="text-slate-400 text-sm">/year</span></div>
+            <div class="text-xs text-emerald-400 font-bold">$24.90/mo effective</div>
+            <ul class="text-xs text-slate-300 space-y-2">
+              <li>500 credits/month</li>
+              <li>Competitor Studio</li>
+              <li>MCP server & API access</li>
+            </ul>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-3">
+            <div class="text-purple-300 font-extrabold">Max</div>
+            <div><span class="text-2xl font-black text-white">$999</span><span class="text-slate-400 text-sm">/year</span></div>
+            <div class="text-xs text-emerald-400 font-bold">$83/mo effective</div>
+            <ul class="text-xs text-slate-300 space-y-2">
+              <li>2,000 credits/month</li>
+              <li>Connect 50+ YouTube channels</li>
+              <li>Agency-scale research capacity</li>
             </ul>
           </div>
         </div>
+        <div class="p-4 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 text-sm text-slate-300"><strong class="text-emerald-300">Low-risk first step:</strong> the current trial provides 10 credits without a credit card. That is enough to test basic outlier or keyword research before choosing a paid plan.</div>
+      </section>
 
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to OutlierKit</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/tubebuddy.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=tubebuddy.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">TubeBuddy</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/pictory.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=pictory.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Pictory</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/fliki.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=fliki.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Fliki</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-5">
+        <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-4">
+          <h2 class="text-xl font-black text-white">Choose OutlierKit if...</h2>
+          <ul class="text-sm text-slate-300 space-y-3 list-disc list-inside">
+            <li>You want topic and competitor research before filming.</li>
+            <li>You need low-competition keyword and outlier-video discovery.</li>
+            <li>You manage multiple channels and need niche-wide intelligence.</li>
+            <li>You want YouTube research available through Claude/MCP or an API on Pro/Max.</li>
+          </ul>
+        </div>
+        <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-4">
+          <h2 class="text-xl font-black text-white">Consider an alternative if...</h2>
+          <ul class="text-sm text-slate-300 space-y-3 list-disc list-inside">
+            <li>You mainly need optimization for videos already published.</li>
+            <li>You prefer a browser-extension-first YouTube SEO workflow.</li>
+            <li>You need text-to-video generation rather than research intelligence.</li>
+          </ul>
+          <div class="grid grid-cols-1 gap-2 pt-2">
+            <a href="/tool/tubebuddy.html" class="p-3 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 text-xs font-bold text-slate-200">TubeBuddy — YouTube SEO & channel workflow</a>
+            <a href="/tool/vidiq.html" class="p-3 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 text-xs font-bold text-slate-200">VidIQ — keyword and growth optimization</a>
+            <a href="/tool/pictory.html" class="p-3 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 text-xs font-bold text-slate-200">Pictory — text-to-video creation</a>
           </div>
         </div>
+      </section>
 
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://outlierkit.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official OutlierKit Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://outlierkit.com/?ref=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit OutlierKit via Verified Affiliate Link</span><span>→</span></a>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-4">
+        <h2 class="text-xl font-black text-white">What the credits buy</h2>
+        <p class="text-sm text-slate-300">OutlierKit's current pricing page lists keyword research and outlier research at 1 credit each, script analysis and single-channel analysis at 5 credits, Deep Research at 20 credits, and Competitor Studio at 50 credits. Credit costs are the same across plans; the plan changes the monthly allowance.</p>
+        <div class="grid grid-cols-2 md:grid-cols-5 gap-2 text-xs text-center">
+          <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white">Keyword</div><div class="text-purple-300">1 credit</div></div>
+          <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white">Outlier</div><div class="text-purple-300">1 credit</div></div>
+          <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white">Script/channel</div><div class="text-purple-300">5 credits</div></div>
+          <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white">Deep Research</div><div class="text-purple-300">20 credits</div></div>
+          <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white">Competitor Studio</div><div class="text-purple-300">50 credits</div></div>
         </div>
+      </section>
 
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of OutlierKit?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim OutlierKit Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/outlierkit.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="OutlierKit Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
+      <section class="p-6 rounded-3xl bg-gradient-to-r from-purple-500/10 to-indigo-500/10 border border-purple-500/30 space-y-4 text-center">
+        <h2 class="text-2xl font-black text-white">Test the workflow before paying</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto">Use the no-card 10-credit trial on your own niche first. If the research surfaces useful topics or competitor patterns, then compare Hobby, Pro and Max based on the number of channels and research volume you actually need.</p>
+        <div class="flex flex-col sm:flex-row gap-3 justify-center">
+          <a data-cta="affiliate" data-tool-id="outlierkit" href="https://outlierkit.com/?ref=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 hover:bg-purple-500 text-white">Start free via verified partner link &rarr;</a>
+          <a data-cta="official" href="https://outlierkit.com/app/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-bold text-sm bg-slate-800 hover:bg-slate-700 border border-slate-600 text-white">Review official plan details</a>
         </div>
-
-
-      </div>
+      </section>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
Revenue-first, zero-cost update for an already verified OutlierKit partner route.

Changes:
- replaces generic `Not yet editorially rated`, `Editorial review in progress` and `See official pricing` placeholders with a buyer-intent 2026 pricing guide
- preserves the exact verified customer-facing affiliate URL `https://outlierkit.com/?ref=sangkwon`
- adds above-the-fold and closing affiliate CTAs with `data-cta="affiliate"` and `data-tool-id="outlierkit"`
- enables the existing `/affiliate-attribution.js` helper so source-tagged traffic and affiliate clicks can be measured
- adds current official annual pricing: Hobby $199/year ($16.60/mo effective), Pro $299/year ($24.90/mo effective), Max $999/year ($83/mo effective)
- adds the current 10-credit no-card trial and plan credit allowances
- adds buyer-fit guidance and clearer alternatives to TubeBuddy, VidIQ and Pictory
- includes an explicit affiliate disclosure and tells visitors to verify final pricing before purchase

Official evidence checked Sep 2, 2026:
- https://outlierkit.com/app/pricing
- https://outlierkit.com/
- https://outlierkit.com/p/affiliate

Repository evidence: `tools.next.json` marks `https://outlierkit.com/?ref=sangkwon` as `affiliate_verified: true` / `approved_tracking`.

No paid services, new affiliate application, guessed tracking URL, fabricated rating or unsupported revenue claim is introduced.