### PR TITLE
Optimize AWeber buyer-intent affiliate landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/aweber.html
+++ b/projects/GlobalSaaSHub/public/tool/aweber.html
@@ -3,29 +3,26 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AWeber Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="A long-standing and reliable email marketing service, perfect for small businesses and creators looking to build their audience and automate communica... Discover features, pricing (See official pricing), and official links for AWeber on GlobalSaaSHub." />
+    <title>AWeber Pricing, 14-Day Trial & Best Fit (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="AWeber buyer guide for 2026: compare current Lite and Plus pricing, the 14-day trial, email automation features, best-fit use cases and a verified affiliate link." />
     <link rel="canonical" href="https://coshuma.com/tool/aweber.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/tool/aweber.html" />
-    <meta property="og:title" content="AWeber Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="A long-standing and reliable email marketing service, perfect for small businesses and creators looking to build their audience and automate communica... Check rating, pricing, and features." />
+    <meta property="og:title" content="AWeber Pricing, 14-Day Trial & Best Fit (2026)" />
+    <meta property="og:description" content="Compare AWeber's current Lite and Plus pricing, 14-day trial, email automation capabilities and buyer fit before choosing a plan." />
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "AWeber",
       "operatingSystem": "Web",
-      "applicationCategory": "Email & Outreach",
-      "description": "A long-standing and reliable email marketing service, perfect for small businesses and creators looking to build their audience and automate communication."
+      "applicationCategory": "BusinessApplication",
+      "url": "https://coshuma.com/tool/aweber.html",
+      "description": "Email marketing and automation platform with newsletters, landing pages, subscriber management, automations, analytics, ecommerce tools and AI-assisted content features."
     }
     </script>
 
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,134 +33,126 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
     <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
+      <article class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
+        <section class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=aweber.com&sz=128" alt="AWeber logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=aweber.com&sz=128" alt="AWeber logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Email & Outreach</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">AWeber</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">Email Marketing &amp; Automation</div>
+              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">AWeber Pricing &amp; Best-Fit Guide</h1>
+              <p class="text-slate-400 text-sm mt-2">Checked against AWeber's official pricing and Advocate Program documentation on September 2, 2026.</p>
             </div>
           </div>
+        </section>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
-        </div>
-
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">A long-standing and reliable email marketing service, perfect for small businesses and creators looking to build their audience and automate communication.</p>
-        </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Email Campaign Creation</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Automated Email Sequences</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Landing Page Builder</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Subscriber Management & Segmentation</div>
-          </div>
-        </div>
-
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to AWeber</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/convertkit.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=kit.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Kit (formerly ConvertKit)</span></div><span class="text-[10px] font-extrabold text-emerald-400">Free plan; Creator plan from $33/month for 1,000 subscribers</span></a>
-<a href="/tool/moosend.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=moosend.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Moosend</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/rytr.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=rytr.me&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Rytr</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
-
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <section class="rounded-2xl bg-gradient-to-br from-purple-500/10 to-indigo-500/5 border border-purple-500/20 p-6 space-y-4">
           <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
+            <h2 class="text-2xl font-black text-white">Quick verdict</h2>
+            <p class="text-slate-300 leading-relaxed mt-2">AWeber is a practical fit for creators and small businesses that want email campaigns, automations, landing pages, subscriber management and ecommerce tools in one established platform. For 0–500 subscribers, AWeber's live pricing page currently shows Lite from $12.49 per month billed annually and Plus from $19.99 per month billed annually, with a 14-day trial highlighted on the pricing page.</p>
           </div>
-          <a data-cta="official" href="https://www.aweber.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official AWeber Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit AWeber via Verified Affiliate Link</span><span>→</span></a>
-        </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <a data-cta="affiliate" data-tool-id="aweber" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start AWeber via verified affiliate link →</a>
+            <a data-cta="official" href="https://www.aweber.com/pricing.htm" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">View official pricing →</a>
+          </div>
+          <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission if you purchase through the verified affiliate link above, at no additional cost to you. AWeber's official Advocate Program documentation currently describes recurring commissions from 30% to 50% depending on paid-referral volume and a 90-day tracking cookie. Pricing and referral terms can change, so confirm the live vendor pages before paying.</p>
+        </section>
 
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of AWeber?</span>
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">Current AWeber pricing for up to 500 subscribers</h2>
+          <p class="text-slate-300 text-sm leading-relaxed">The figures below are the starting prices shown on AWeber's live pricing page when checked on September 2, 2026. The page was displaying annual billing, so use the live billing toggle to recheck the monthly option before purchase.</p>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+              <div class="text-xs uppercase tracking-wider text-slate-400 font-bold">Lite</div>
+              <div class="text-2xl font-black text-emerald-400 mt-1">$12.49/month</div>
+              <p class="text-xs text-slate-400 mt-1">Billed annually for the 0–500 subscriber selection shown on the official pricing page.</p>
+              <ul class="text-sm text-slate-300 space-y-1.5 list-disc list-inside mt-4">
+                <li>Up to 10× subscriber volume in monthly sends.</li>
+                <li>1 email list.</li>
+                <li>3 landing pages and 3 email automations.</li>
+                <li>Up to 3 users and 1 custom segment.</li>
+              </ul>
             </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
+            <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/30">
+              <div class="text-xs uppercase tracking-wider text-purple-300 font-bold">Plus</div>
+              <div class="text-2xl font-black text-emerald-400 mt-1">$19.99/month</div>
+              <p class="text-xs text-slate-400 mt-1">Billed annually for the 0–500 subscriber selection shown on the official pricing page.</p>
+              <ul class="text-sm text-slate-300 space-y-1.5 list-disc list-inside mt-4">
+                <li>Up to 12× subscriber volume in monthly sends.</li>
+                <li>Unlimited email lists, landing pages and automations.</li>
+                <li>Unlimited custom segments and users.</li>
+                <li>Advanced reporting, analytics and priority support.</li>
+              </ul>
+            </div>
           </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim AWeber Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/aweber.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="AWeber Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">Trial:</strong> AWeber's live pricing page currently promotes a 14-day trial for its standard plans. Paid-plan card requirements and the exact amount due after the trial should be confirmed on the live checkout flow before starting.</div>
+        </section>
 
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">What AWeber can replace in your stack</h2>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">Email campaigns:</strong> newsletters, broadcasts, templates, RSS-to-email and HTML email creation.</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">Automation:</strong> autoresponders, email automations, tagging and behavioral automation capabilities depending on plan.</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">Lead capture:</strong> landing pages, signup forms, segmentation and subscriber-management tools.</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">Creator sales tools:</strong> ecommerce features, subscriptions, payment plans, sales tracking and purchase tagging are listed in the platform's plan comparison.</div>
+          </div>
+        </section>
 
-      </div>
+        <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
+            <h3 class="text-base font-bold text-emerald-400">Choose AWeber if...</h3>
+            <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+              <li>You want email marketing and basic sales tools in one platform.</li>
+              <li>You prefer a mature product with straightforward creator and small-business workflows.</li>
+              <li>You expect to use landing pages and automations without stitching together several services.</li>
+              <li>You want to test the workflow during a currently advertised 14-day trial before committing.</li>
+            </ul>
+          </div>
+          <div class="p-5 rounded-2xl bg-amber-500/5 border border-amber-500/20 space-y-2">
+            <h3 class="text-base font-bold text-amber-300">Check carefully before buying if...</h3>
+            <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+              <li>You need more than the Lite plan's list, landing-page or automation limits.</li>
+              <li>Your subscriber count is growing quickly enough that higher-volume pricing materially changes the total cost.</li>
+              <li>You need advanced segmentation, analytics or branding removal but are comparing only the Lite price.</li>
+              <li>You are choosing between AWeber and a free-first competitor and total cost is your main priority.</li>
+            </ul>
+          </div>
+        </section>
+
+        <section class="space-y-4 pt-4 border-t border-[#222538]">
+          <h2 class="text-xl font-bold text-white">Useful alternatives on COSHUMA</h2>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <a href="/tool/convertkit.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">Kit</div><div class="text-xs text-slate-400 mt-1">Compare another creator-focused email and audience platform.</div></a>
+            <a href="/tool/moosend.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">Moosend</div><div class="text-xs text-slate-400 mt-1">Compare another email marketing and automation option.</div></a>
+            <a href="/tool/rytr.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">Rytr</div><div class="text-xs text-slate-400 mt-1">Compare a lower-cost AI writing tool if content generation is the main need.</div></a>
+          </div>
+        </section>
+
+        <section class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] space-y-4">
+          <h2 class="text-xl font-bold text-white">Bottom line</h2>
+          <p class="text-slate-300 leading-relaxed">AWeber is strongest when you want an established email platform that can cover newsletters, automations, landing pages, segmentation and basic ecommerce without a complex setup. For a small list, compare Lite against Plus based on the limits you will actually use, then confirm the live billing toggle and checkout total before committing.</p>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <a data-cta="affiliate" data-tool-id="aweber" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start AWeber via verified affiliate link →</a>
+            <a data-cta="official" href="https://www.aweber.com/pricing.htm" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Recheck live pricing →</a>
+          </div>
+        </section>
+      </article>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
+
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>
-


### PR DESCRIPTION
Revenue-focused, no-cost landing improvement for GlobalSaaSHub.

- replaces placeholder rating/review copy with current buyer guidance
- uses AWeber's live 2026 pricing for Lite and Plus and its advertised 14-day trial
- preserves the verified affiliate URL from tools.json
- adds data-tool-id="aweber" and loads /affiliate-attribution.js
- adds clear affiliate disclosure and official pricing fallback
- limits the PR to projects/GlobalSaaSHub/public/tool/aweber.html