### PR TITLE
Optimize Taskade buyer-intent affiliate landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/taskade.html
+++ b/projects/GlobalSaaSHub/public/tool/taskade.html
@@ -3,29 +3,26 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Taskade Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="AI-powered productivity and workflow automation workspace with task management, mind maps, and AI agents.... Discover features, pricing (Free plan available; Pro starting at $8/user/month (billed annually)), and official links for Taskade on GlobalSaaSHub." />
+    <title>Taskade Pricing, Free Plan & AI Agents Review (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Taskade buyer guide for 2026: compare the Free and Pro plans, AI app and agent limits, current annual pricing, best-fit use cases and COSHUMA's verified affiliate link." />
     <link rel="canonical" href="https://coshuma.com/tool/taskade.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/tool/taskade.html" />
-    <meta property="og:title" content="Taskade Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="AI-powered productivity and workflow automation workspace with task management, mind maps, and AI agents.... Check rating, pricing, and features." />
+    <meta property="og:title" content="Taskade Pricing, Free Plan & AI Agents Review (2026)" />
+    <meta property="og:description" content="Compare Taskade's current Free and Pro plans, AI credits, app and agent limits, and buyer fit before upgrading." />
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Taskade",
-      "operatingSystem": "Web",
-      "applicationCategory": "Workflow Automation",
-      "description": "AI-powered productivity and workflow automation workspace with task management, mind maps, and AI agents."
+      "operatingSystem": "Web, iOS, Android, macOS, Windows, Linux",
+      "applicationCategory": "BusinessApplication",
+      "url": "https://coshuma.com/tool/taskade.html",
+      "description": "AI workspace for building apps, AI agents and automations connected to collaborative projects and integrations."
     }
     </script>
 
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,134 +33,118 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
     <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
+      <article class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
+        <section class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=taskade.com&sz=128" alt="Taskade logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=taskade.com&sz=128" alt="Taskade logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Workflow Automation</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Taskade</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">AI Apps · Agents · Automation</div>
+              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Taskade Pricing & Best-Fit Guide</h1>
+              <p class="text-slate-400 text-sm mt-2">Checked against Taskade's official pricing and Partnership Program pages on September 2, 2026.</p>
             </div>
           </div>
+        </section>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
-        </div>
-
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">AI-powered productivity and workflow automation workspace with task management, mind maps, and AI agents.</p>
-        </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI Task Management</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI Agents</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Mind Mapping</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Real-Time Collaboration</div>
-          </div>
-        </div>
-
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (Free plan available; Pro starting at $8/user/month (billed annually))</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Taskade</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/expandi.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=expandi.io&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Expandi</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/reditus.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=getreditus.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Reditus</span></div><span class="text-[10px] font-extrabold text-emerald-400">14-day free trial; Startup plan at $99/month (billed annually) or $149 monthly</span></a>
-<a href="/tool/joiin.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=joiin.co&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Joiin</span></div><span class="text-[10px] font-extrabold text-emerald-400">Starting at $23/month (billed annually, 1 company)</span></a>
-          </div>
-        </div>
-
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <section class="rounded-2xl bg-gradient-to-br from-purple-500/10 to-indigo-500/5 border border-purple-500/20 p-6 space-y-4">
           <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">Free plan available; Pro starting at $8/user/month (billed annually)</div>
+            <h2 class="text-2xl font-black text-white">Quick verdict</h2>
+            <p class="text-slate-300 leading-relaxed mt-2">Taskade is a strong fit for builders and small teams that want AI apps, agents, automations and collaborative workspaces in one product. The current official pricing page shows a Free plan with no credit card required and a Pro plan at $10 per month in the annual-billing view, with 10 users included and 50,000 AI credits per month.</p>
           </div>
-          <a data-cta="official" href="https://www.taskade.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Taskade Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://www.taskade.com/?via=7zzjo7" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Taskade via Verified Affiliate Link</span><span>→</span></a>
-        </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <a data-cta="affiliate" data-tool-id="taskade" href="https://www.taskade.com/?via=7zzjo7" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start Taskade via verified affiliate link →</a>
+            <a data-cta="official" href="https://www.taskade.com/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">View official pricing →</a>
+          </div>
+          <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission if you become a paying Taskade customer through the verified affiliate link above, at no additional cost to you. Taskade's Partnership Program page, updated August 26, 2026, states a 50% recurring commission for life and a 90-day cookie window. Program terms can change, so the live partner documentation remains the source of truth.</p>
+        </section>
 
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Taskade?</span>
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">Current Taskade Free vs Pro</h2>
+          <p class="text-slate-300 text-sm leading-relaxed">The figures below are from Taskade's live pricing page when checked on September 2, 2026. The page was displaying the annual-billing view when Pro showed $10 per month.</p>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div class="p-5 rounded-2xl bg-[#181a29] border border-emerald-500/25">
+              <div class="text-xs uppercase tracking-wider text-emerald-400 font-bold">Free</div>
+              <div class="text-2xl font-black text-white mt-1">$0</div>
+              <p class="text-xs text-slate-400 mt-1">No credit card required.</p>
+              <ul class="text-sm text-slate-300 space-y-1.5 list-disc list-inside mt-4">
+                <li>1 user included.</li>
+                <li>6,000 one-time welcome credits shown on the current pricing page.</li>
+                <li>Keep up to 3 Taskade Genesis apps.</li>
+                <li>Clone community apps and use desktop/mobile apps.</li>
+                <li>Good for validating one real workflow before paying.</li>
+              </ul>
             </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
+            <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/30">
+              <div class="text-xs uppercase tracking-wider text-purple-300 font-bold">Pro</div>
+              <div class="text-2xl font-black text-emerald-400 mt-1">$10/month</div>
+              <p class="text-xs text-slate-400 mt-1">Shown in Taskade's annual-billing view; confirm the live billing toggle before purchase.</p>
+              <ul class="text-sm text-slate-300 space-y-1.5 list-disc list-inside mt-4">
+                <li>10 users included.</li>
+                <li>50,000 AI credits per month.</li>
+                <li>Unlimited AI apps.</li>
+                <li>Unlimited AI agents and workspaces.</li>
+                <li>Access to frontier AI models and broader integrations.</li>
+              </ul>
+            </div>
           </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Taskade Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/taskade.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Taskade Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
+        </section>
 
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">What makes Taskade different</h2>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">AI app building:</strong> Taskade Genesis can turn prompts into hosted apps, dashboards, client portals and internal tools connected to workspace data.</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">AI agents:</strong> paid plans can run multiple agents with workspace knowledge, tools and automations.</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">Automation:</strong> agents and workflows can connect to external services through Taskade's integration layer.</div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-300"><strong class="text-white">Collaboration:</strong> projects, workspaces and generated apps live in the same environment instead of being split across separate tools.</div>
+          </div>
+        </section>
 
-      </div>
+        <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
+            <h3 class="text-base font-bold text-emerald-400">Choose Taskade if...</h3>
+            <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+              <li>You want AI agents, app generation and automation in one workspace.</li>
+              <li>You prefer a free starting point before committing to a paid plan.</li>
+              <li>Your team can benefit from a flat plan that includes multiple users rather than separate per-seat tools.</li>
+              <li>You want generated tools to stay connected to shared workspace knowledge.</li>
+            </ul>
+          </div>
+          <div class="p-5 rounded-2xl bg-amber-500/5 border border-amber-500/20 space-y-2">
+            <h3 class="text-base font-bold text-amber-300">Check carefully before upgrading if...</h3>
+            <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+              <li>You do not expect to use AI generation enough to justify recurring credits.</li>
+              <li>You only need a conventional task manager rather than AI apps and agents.</li>
+              <li>You need a specific enterprise control such as SSO, custom domains or organization-wide provisioning.</li>
+              <li>Your usage is credit-heavy, because complex builds can consume materially more credits than simple prompts.</li>
+            </ul>
+          </div>
+        </section>
+
+        <section class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] space-y-4">
+          <h2 class="text-xl font-bold text-white">Why the free plan is the safest first step</h2>
+          <p class="text-slate-300 leading-relaxed">Taskade's official pricing page says the Free plan requires no credit card and includes a one-time AI credit grant. That makes it practical to build one representative app or agent workflow first, then decide whether the Pro plan's monthly credits and unlimited apps/agents solve a real need.</p>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <a data-cta="affiliate" data-tool-id="taskade" href="https://www.taskade.com/?via=7zzjo7" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Try Taskade via verified affiliate link →</a>
+            <a data-cta="official" href="https://www.taskade.com/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Recheck live pricing →</a>
+          </div>
+        </section>
+      </article>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
+
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>
-


### PR DESCRIPTION
## Revenue impact
- replaces stale placeholder rating/pros copy and outdated $8/user pricing
- surfaces the verified COSHUMA Taskade tracking URL in two buyer-intent CTAs
- adds `/affiliate-attribution.js` so Taskade affiliate clicks enter the existing attribution flow
- updates buyer guidance from Taskade's live pricing page checked 2026-09-02
- cites Taskade's official Partnership Program terms: 50% recurring commission for life and 90-day cookie (official page updated 2026-08-26)

## Scope
One static landing page only: `projects/GlobalSaaSHub/public/tool/taskade.html`.

No paid services, secrets, deployment configuration, or unrelated files changed.