### PR TITLE
fix attribution for Fliki affiliate clicks

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/fliki.html
+++ b/projects/GlobalSaaSHub/public/tool/fliki.html
@@ -22,6 +22,7 @@
     }
     </script>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
Adds the existing shared affiliate attribution script to the Fliki landing page. No pricing, copy, destination URL, or layout changes.