### PR TITLE
Track Make.com affiliate clicks

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/make-com.html
+++ b/projects/GlobalSaaSHub/public/tool/make-com.html
@@ -136,5 +136,6 @@
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
       <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
+    <script defer src="/affiliate-attribution.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Load the shared affiliate-attribution script on the existing Make.com buyer-intent landing so its verified partner CTAs emit COSHUMA's GA4 affiliate_click events. No pricing, copy, layout, or affiliate URL changes.