### PR TITLE
Track CartStack affiliate clicks

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/cartstack.html
+++ b/projects/GlobalSaaSHub/public/tool/cartstack.html
@@ -86,5 +86,6 @@
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS decision guides.</div></footer>
+    <script defer src="/affiliate-attribution.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Adds the shared `/affiliate-attribution.js` loader to the existing CartStack buyer-intent landing so its already-verified `data-cta="affiliate"` CTAs emit GA4 `affiliate_click` events. No pricing, copy, layout, or referral URL changes.