### PR TITLE
Track Relevance AI affiliate clicks

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/relevance-ai.html
+++ b/projects/GlobalSaaSHub/public/tool/relevance-ai.html
@@ -27,6 +27,7 @@
 
     <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
Revenue attribution fix only. Relevance AI already uses the verified affiliate CTA (`https://relevanceai.com?via=sangkwon`) but the page did not load the shared `/affiliate-attribution.js`, so affiliate clicks were not emitted to COSHUMA GA4. This PR adds only that script include; no pricing, copy, layout, or affiliate URL changes.