### PR TITLE
Add verified Murf AI and Brand24 revenue links

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/brand24.html
+++ b/projects/GlobalSaaSHub/public/tool/brand24.html
@@ -27,6 +27,7 @@
 
     <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
@@ -126,7 +127,9 @@
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
           </div>
           <a data-cta="official" href="https://brand24.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Brand24 Site</span><span>→</span></a>
+          <a data-cta="affiliate" data-tool-id="brand24" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Try Brand24 via Verified Partner Link</span><span>→</span></a>
         </div>
+        <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission when eligible purchases are attributed through the verified Brand24 partner link, at no extra cost to you.</p>
 
         <!-- Revenue-safe alternative path -->
         <div class="p-6 rounded-2xl bg-purple-500/5 border border-purple-500/25 space-y-3">
@@ -134,7 +137,7 @@
           <p class="text-sm text-slate-300 leading-relaxed">Brand24 focuses on monitoring mentions and sentiment. If your priority is managing and growing a social media presence with automation and AI-assisted workflows, compare Followr before deciding.</p>
           <div class="flex flex-col sm:flex-row gap-3">
             <a href="/tool/followr.html" class="px-5 py-3 rounded-xl font-bold text-sm border border-purple-500/30 text-purple-200 text-center hover:bg-purple-500/10 transition-all">Review Followr</a>
-            <a data-cta="affiliate" href="https://followr.ai/?ref=support22" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center hover:bg-purple-500 transition-all">Try Followr →</a>
+            <a data-cta="affiliate" data-tool-id="followr" href="https://followr.ai/?ref=support22" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center hover:bg-purple-500 transition-all">Try Followr →</a>
           </div>
           <p class="text-[11px] text-slate-500">Affiliate disclosure: GlobalSaaSHub may earn a commission if you purchase through the Followr link, at no extra cost to you.</p>
         </div>

--- a/projects/GlobalSaaSHub/public/tool/murf-ai.html
+++ b/projects/GlobalSaaSHub/public/tool/murf-ai.html
@@ -27,6 +27,7 @@
 
     <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
@@ -126,7 +127,9 @@
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
           </div>
           <a data-cta="official" href="https://murf.ai/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Murf AI Site</span><span>→</span></a>
+          <a data-cta="affiliate" data-tool-id="murf-ai" href="https://get.murf.ai/fqac0vixj0qs" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Try Murf AI via Verified Partner Link</span><span>→</span></a>
         </div>
+        <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission when eligible purchases are attributed through the verified Murf AI partner link, at no extra cost to you.</p>
 
         <!-- Claim Profile & Official Founder Badge Section -->
         <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">

--- a/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
+++ b/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
@@ -11,6 +11,8 @@ const verified = {
   'customgpt-ai': 'https://customgpt.ai/?fpr=sangkwon-3b18de',
   docsbot: 'https://docsbot.ai?via=31kq9q',
   databox: 'https://databox.com?aff_id=15298659&fp_ref=sangkwon-72c9ec',
+  'murf-ai': 'https://get.murf.ai/fqac0vixj0qs',
+  brand24: 'https://try.brand24.com/8xqrjxybmsbt',
 };
 
 for (const file of ['data/tools.json', 'data/tools.next.json']) {


### PR DESCRIPTION
Revenue update based on fresh partner-program emails received September 2, 2026.

- Murf AI supplied COSHUMA's personal referral link: `https://get.murf.ai/fqac0vixj0qs` and stated signups through it will be credited.
- Brand24 supplied COSHUMA's referral link: `https://try.brand24.com/8xqrjxybmsbt` and stated rewards of up to 30% recurring commission per sale.
- Adds those exact verified links to the affiliate sync helper.
- Adds revenue CTAs to the Murf AI and Brand24 landing pages with sponsored safety relations and the shared affiliate-attribution script.
- Adds `data-tool-id="followr"` to Brand24's pre-existing Followr affiliate CTA so GA4 attributes that alternate CTA to Followr rather than Brand24.

No pricing claims or affiliate terms beyond the email-grounded links are changed. Canonical `data/tools.json` is not modified in this PR; the helper update records the verified links for the existing sync path.