### PR TITLE
Track CustomGPT.ai affiliate clicks

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/customgpt-ai.html
+++ b/projects/GlobalSaaSHub/public/tool/customgpt-ai.html
@@ -41,5 +41,6 @@
       <section class="p-7 rounded-3xl bg-gradient-to-r from-purple-500/10 to-indigo-500/10 border border-purple-500/30 text-center space-y-4"><h2 class="text-2xl md:text-3xl font-black text-white">Validate one real knowledge workflow first</h2><p class="text-sm text-slate-300 max-w-2xl mx-auto">Load a representative knowledge set, test citations and measure query usage during the trial before deciding whether Standard or Premium makes economic sense.</p><a data-cta="affiliate" data-tool-id="customgpt-ai" href="https://customgpt.ai/?fpr=sangkwon-3b18de" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white hover:brightness-110 transition-all">Start CustomGPT.ai via Verified Affiliate Link →</a><div class="text-[11px] text-slate-400">Unique affiliate URL verified from CustomGPT.ai's welcome email to COSHUMA on September 1, 2026.</div></section>
     </main>
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS decision guides.</div></footer>
+    <script defer src="/affiliate-attribution.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Adds the shared affiliate attribution script to the existing hand-optimized CustomGPT.ai landing page. The verified account-specific affiliate CTA already exists; this change only enables COSHUMA GA4 affiliate_click measurement without changing pricing, copy, layout, or referral URL.