### PR TITLE
Track verified Vista Social affiliate revenue clicks

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/vista-social.html
+++ b/projects/GlobalSaaSHub/public/tool/vista-social.html
@@ -160,5 +160,6 @@
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
       <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
+    <script defer src="/affiliate-attribution.js"></script>
   </body>
 </html>

--- a/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
+++ b/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
@@ -13,6 +13,7 @@ const verified = {
   databox: 'https://databox.com?aff_id=15298659&fp_ref=sangkwon-72c9ec',
   'murf-ai': 'https://get.murf.ai/fqac0vixj0qs',
   brand24: 'https://try.brand24.com/8xqrjxybmsbt',
+  'vista-social': 'https://vistasocial.com?fpr=sangkwon14',
 };
 
 for (const file of ['data/tools.json', 'data/tools.next.json']) {


### PR DESCRIPTION
Revenue attribution cleanup grounded in the Vista Social approval email.

- Records the exact customer-facing referral URL supplied by Vista Social: `https://vistasocial.com?fpr=sangkwon14`.
- Adds it to the verified-affiliate sync helper so future data syncs preserve the approved tracking route.
- Loads the shared `/affiliate-attribution.js` on the existing Vista Social buyer-intent landing so its already-published affiliate CTAs emit COSHUMA `affiliate_click` events.
- No pricing, offer, layout, paid service, or unverified URL changes.