### PR TITLE
Track Inkfluence AI affiliate clicks

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/inkfluence-ai.html
+++ b/projects/GlobalSaaSHub/public/tool/inkfluence-ai.html
@@ -104,5 +104,6 @@
   </article>
 </main>
 <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform.</div></footer>
+<script defer src="/affiliate-attribution.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Revenue attribution fix only.

Inkfluence AI already has a verified COSHUMA affiliate CTA (`https://www.inkfluenceai.com/?ref=sangkwon`) and the page is marked approved_tracking in the repository, but the landing page did not load the shared `/affiliate-attribution.js` helper.

This PR adds only that script include so existing Inkfluence affiliate CTA clicks emit the same COSHUMA `affiliate_click` event as other tracked revenue pages. No pricing, copy, layout, or referral URL changes.