### PR TITLE
Track Pictory affiliate clicks

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/pictory.html
+++ b/projects/GlobalSaaSHub/public/tool/pictory.html
@@ -25,6 +25,7 @@
     </script>
 
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
Revenue attribution fix only.

Pictory already has COSHUMA's verified partner CTA (`https://pictory.ai?fpr=sangkwon-an23`) with `data-cta="affiliate"` / `data-tool-id="pictory"`, but the landing page did not load the shared `/affiliate-attribution.js` helper.

This PR adds only that script include so Pictory affiliate CTA clicks emit the same COSHUMA `affiliate_click` event as other tracked revenue pages. No pricing, copy, layout, or referral URL changes.