### PR TITLE
Track Frase affiliate clicks

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/frase.html
+++ b/projects/GlobalSaaSHub/public/tool/frase.html
@@ -79,5 +79,6 @@
   </section>
 </main>
 <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">© 2026 GlobalSaaSHub · Global AI SaaS Decision Platform</footer>
+<script defer src="/affiliate-attribution.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds the shared affiliate attribution script to the existing Frase revenue landing page. The affiliate URL is already marked verified/approved_tracking in GlobalSaaSHub data. No pricing, copy, layout, or affiliate URL changes.