### PR TITLE
Track Castmagic affiliate clicks

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/castmagic.html
+++ b/projects/GlobalSaaSHub/public/tool/castmagic.html
@@ -28,6 +28,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <script defer src="/affiliate-attribution.js"></script>
     <style>
       body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
       h1, h2, h3 { font-family: 'Outfit', sans-serif; }


### PR DESCRIPTION
Adds the shared affiliate attribution script to the existing Castmagic buyer-intent landing. The verified Castmagic referral URL, pricing copy, layout, and CTA wording are unchanged; this only enables COSHUMA to record affiliate_click events for existing revenue CTAs.