### PR TITLE
Track Synthesia affiliate clicks

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/synthesia.html
+++ b/projects/GlobalSaaSHub/public/tool/synthesia.html
@@ -77,5 +77,6 @@
   </section>
 </main>
 <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">© 2026 GlobalSaaSHub · Global AI SaaS Decision Platform</footer>
+<script defer src="/affiliate-attribution.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds the shared affiliate attribution script to the existing Synthesia landing page so clicks on its already verified affiliate CTAs can be measured. No pricing, copy, layout, or affiliate URL changes.