### PR TITLE
Track Systeme.io affiliate clicks

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/systeme-io.html
+++ b/projects/GlobalSaaSHub/public/tool/systeme-io.html
@@ -22,6 +22,7 @@
   }
   </script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="/affiliate-attribution.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
Adds the shared COSHUMA affiliate attribution script to the existing verified Systeme.io buyer landing. No pricing, copy, layout, or affiliate URL changes. This enables GA4 affiliate_click measurement for the already verified Systeme.io revenue CTA.