### PR TITLE
Publish verified Shopify affiliate revenue CTAs

### DIFF
--- a/projects/GlobalSaaSHub/data/browser_required_queue.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.json
@@ -1,19 +1,5 @@
 [
   {
-    "id": "shopify-impact-referral-link",
-    "priority": "high",
-    "status": "browser_required",
-    "cost": "0",
-    "verified_at": "2026-09-01T16:39:00+09:00",
-    "reason": "Shopify Affiliate Program approval is verified, but the approval email instructs the affiliate to log in to Impact to obtain a unique referral link. The current repository has no Shopify affiliate_url and its stored affiliate_final_url is an Impact campaign signup URL, so it must not be used as a revenue link.",
-    "next_action": "Using an already authenticated browser session, open Impact, obtain the account-specific Shopify referral/tracking URL, verify that it contains a unique tracking identifier, then update tools.json/tools.next.json and only then replace eligible Shopify CTAs.",
-    "do_not": [
-      "Do not use the Shopify homepage as an affiliate link.",
-      "Do not use the Impact campaign signup/onboarding URL as an affiliate link.",
-      "Do not submit another Shopify application."
-    ]
-  },
-  {
     "id": "omi-ai-affiliate-referral-link",
     "priority": "high",
     "status": "browser_required",

--- a/projects/GlobalSaaSHub/public/compare/shopify-vs-privy.html
+++ b/projects/GlobalSaaSHub/public/compare/shopify-vs-privy.html
@@ -96,8 +96,6 @@
         </div>
       </div>
 
-
-
       <!-- 2-Column Comparison Table -->
       <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
         <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
@@ -121,8 +119,6 @@
             <div class="text-lg font-black text-amber-400">Not rated</div>
           </div>
         </div>
-
-
 
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
           <div>
@@ -157,9 +153,10 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://www.shopify.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Shopify →</a>
+          <a data-cta="affiliate" data-tool-id="shopify" href="https://shopify.pxf.io/7670642-link?sharedid=7670642" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Shopify →</a>
           <a href="https://www.privy.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Privy →</a>
         </div>
+        <p class="text-[10px] text-slate-500">COSHUMA is a Shopify Affiliate and may receive compensation if you sign up through the Shopify partner link.</p>
       </div>
     </main>
 
@@ -168,5 +165,6 @@
         &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
       </div>
     </footer>
+    <script defer src="/affiliate-attribution.js"></script>
   </body>
 </html>

--- a/projects/GlobalSaaSHub/public/compare/shopify-vs-reply-io.html
+++ b/projects/GlobalSaaSHub/public/compare/shopify-vs-reply-io.html
@@ -96,8 +96,6 @@
         </div>
       </div>
 
-
-
       <!-- 2-Column Comparison Table -->
       <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
         <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
@@ -121,8 +119,6 @@
             <div class="text-lg font-black text-amber-400">Not rated</div>
           </div>
         </div>
-
-
 
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
           <div>
@@ -157,9 +153,10 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://www.shopify.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Shopify →</a>
+          <a data-cta="affiliate" data-tool-id="shopify" href="https://shopify.pxf.io/7670642-link?sharedid=7670642" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Shopify →</a>
           <a href="https://reply.io/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Reply.io →</a>
         </div>
+        <p class="text-[10px] text-slate-500">COSHUMA is a Shopify Affiliate and may receive compensation if you sign up through the Shopify partner link.</p>
       </div>
     </main>
 
@@ -168,5 +165,6 @@
         &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
       </div>
     </footer>
+    <script defer src="/affiliate-attribution.js"></script>
   </body>
 </html>

--- a/projects/GlobalSaaSHub/public/tool/shopify.html
+++ b/projects/GlobalSaaSHub/public/tool/shopify.html
@@ -3,17 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Shopify Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="A leading e-commerce platform that enables businesses to build, run, and grow online stores with robust sales and management tools.... Discover features, pricing (Pricing details on website), and official links for Shopify on GlobalSaaSHub." />
+    <title>Shopify Review, Features & Best Fit (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="See what Shopify is best for, how it supports online selling, and start through COSHUMA's verified Shopify partner link." />
     <link rel="canonical" href="https://coshuma.com/tool/shopify.html" />
-    
-    <!-- Open Graph SEO Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/shopify.html" />
-    <meta property="og:title" content="Shopify Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="A leading e-commerce platform that enables businesses to build, run, and grow online stores with robust sales and management tools.... Check rating, pricing, and features." />
-
-    <!-- JSON-LD Structured Data for Google Indexing -->
+    <meta property="og:title" content="Shopify Review, Features & Best Fit (2026) | GlobalSaaSHub" />
+    <meta property="og:description" content="A buyer-focused Shopify guide with a verified COSHUMA partner route and clear affiliate disclosure." />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -21,11 +17,9 @@
       "name": "Shopify",
       "operatingSystem": "Web",
       "applicationCategory": "Sales & CRM",
-      "description": "A leading e-commerce platform that enables businesses to build, run, and grow online stores with robust sales and management tools."
+      "description": "A leading e-commerce platform that enables businesses to build, run, and grow online stores with sales and management tools."
     }
     </script>
-
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,133 +30,72 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">&larr; Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
+    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-6">
+      <section class="p-8 rounded-3xl bg-[#131520] border border-purple-500/30 shadow-2xl space-y-6">
+        <div class="flex flex-col md:flex-row md:items-center justify-between gap-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=shopify.com&sz=128" alt="Shopify logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=shopify.com&sz=128" alt="Shopify logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Sales & CRM</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Shopify</h1>
+              <div class="inline-flex items-center px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">E-commerce platform</div>
+              <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Shopify</h1>
+              <p class="text-slate-400 mt-2">Build and operate an online store from one commerce platform.</p>
             </div>
           </div>
-
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
         </div>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">A leading e-commerce platform that enables businesses to build, run, and grow online stores with robust sales and management tools.</p>
+        <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-3">
+          <div class="text-sm font-bold text-emerald-300">Best fit</div>
+          <p class="text-sm text-slate-300 leading-relaxed">A practical choice for businesses that want a hosted store builder with integrated selling, inventory management, payments and marketing tools instead of assembling those pieces separately.</p>
         </div>
 
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Intuitive Store Builder</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Integrated Payment Gateway</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Inventory Management</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Marketing and Analytics Tools</div>
-          </div>
+        <div class="grid sm:grid-cols-2 gap-3">
+          <a data-cta="affiliate" data-tool-id="shopify" href="https://shopify.pxf.io/7670642-link?sharedid=7670642" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold text-center bg-gradient-to-r from-purple-600 to-indigo-600 text-white shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start Shopify via Partner Link &rarr;</a>
+          <a data-cta="official" href="https://www.shopify.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold text-center bg-slate-800 border border-slate-600 hover:bg-slate-700">Visit Shopify Official Site</a>
         </div>
+        <p class="text-[11px] text-slate-500">COSHUMA is a Shopify Affiliate and may receive compensation if you sign up through the partner link above. This does not add a fee to your purchase.</p>
+      </section>
 
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (Pricing details on website)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-xl font-bold text-white">What Shopify can change for a business</h2>
+        <div class="grid sm:grid-cols-2 gap-3 text-sm">
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-purple-300 mb-1">Launch faster</div><p class="text-slate-300">Use a hosted store builder instead of building a commerce stack from scratch.</p></div>
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-purple-300 mb-1">Run sales in one place</div><p class="text-slate-300">Manage products, inventory and selling workflows from the same platform.</p></div>
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-purple-300 mb-1">Reduce tool sprawl</div><p class="text-slate-300">Keep core store, payment and management tasks connected instead of splitting them across unrelated tools.</p></div>
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-purple-300 mb-1">Create a revenue channel</div><p class="text-slate-300">The business value is straightforward: an online storefront gives you a place to convert traffic into orders.</p></div>
         </div>
+      </section>
 
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Shopify</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/privy.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=privy.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Privy</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/reply-io.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=reply.io&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Reply.io</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/omnisend.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=omnisend.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Omnisend</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-4">
+        <h2 class="text-xl font-bold text-white">Core capabilities</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-200">&#10003; Intuitive Store Builder</div>
+          <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-200">&#10003; Integrated Payment Gateway</div>
+          <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-200">&#10003; Inventory Management</div>
+          <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538] text-sm text-slate-200">&#10003; Marketing and Analytics Tools</div>
         </div>
+      </section>
 
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">Pricing details on website</div>
-          </div>
-          <a data-cta="official" href="https://www.shopify.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Shopify Site</span><span>→</span></a>
-        </div>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Shopify?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Shopify Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/shopify.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Shopify Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
-      </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
+        <h2 class="text-xl font-bold text-white">Ready to evaluate Shopify?</h2>
+        <p class="text-sm text-slate-300">Use the verified COSHUMA partner route for Shopify, then confirm the current plan and offer details on Shopify before purchasing.</p>
+        <a data-cta="affiliate" data-tool-id="shopify" href="https://shopify.pxf.io/7670642-link?sharedid=7670642" target="_blank" rel="sponsored noopener noreferrer" class="block px-6 py-4 rounded-xl font-extrabold text-center bg-purple-600 hover:bg-purple-500 text-white">Open Shopify via Verified Partner Link &rarr;</a>
+        <p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may receive compensation from qualifying Shopify referrals.</p>
+      </section>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
+    <script defer src="/affiliate-attribution.js"></script>
   </body>
 </html>
-

--- a/projects/GlobalSaaSHub/public/tool/shopify.html
+++ b/projects/GlobalSaaSHub/public/tool/shopify.html
@@ -62,7 +62,7 @@
           <a data-cta="affiliate" data-tool-id="shopify" href="https://shopify.pxf.io/7670642-link?sharedid=7670642" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold text-center bg-gradient-to-r from-purple-600 to-indigo-600 text-white shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start Shopify via Partner Link &rarr;</a>
           <a data-cta="official" href="https://www.shopify.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold text-center bg-slate-800 border border-slate-600 hover:bg-slate-700">Visit Shopify Official Site</a>
         </div>
-        <p class="text-[11px] text-slate-500">COSHUMA is a Shopify Affiliate and may receive compensation if you sign up through the partner link above. This does not add a fee to your purchase.</p>
+        <p class="text-[11px] text-slate-500">COSHUMA is a Shopify Affiliate and may receive compensation if you sign up through the partner link above.</p>
       </section>
 
       <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">

--- a/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
+++ b/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
@@ -13,6 +13,7 @@ const verified = {
   databox: 'https://databox.com?aff_id=15298659&fp_ref=sangkwon-72c9ec',
   'murf-ai': 'https://get.murf.ai/fqac0vixj0qs',
   brand24: 'https://try.brand24.com/8xqrjxybmsbt',
+  shopify: 'https://shopify.pxf.io/7670642-link?sharedid=7670642',
   'vista-social': 'https://vistasocial.com?fpr=sangkwon14',
 };
 


### PR DESCRIPTION
Revenue update grounded in Shopify's September 2, 2026 affiliate welcome email.

Evidence:
- Shopify sent COSHUMA the personalized customer-facing link `https://shopify.pxf.io/7670642-link?sharedid=7670642`.
- The same email explicitly says to copy that link exactly, permits sharing it on the website/social channels, and requires disclosure that COSHUMA may receive compensation.

Changes:
- replaces the Shopify detail page's generic official-only CTA with two prominent verified affiliate CTAs plus an official-site fallback
- adds the required Shopify affiliate disclosure
- loads `/affiliate-attribution.js` so Shopify clicks emit the existing COSHUMA `affiliate_click` event
- routes the Shopify CTAs on both existing Shopify comparison pages through the exact verified partner link and adds disclosure/attribution there too
- records the exact Shopify URL in `sync_verified_affiliates.mjs` so the existing verified-link sync path can promote it into `tools.json` / `tools.next.json`
- removes the now-stale Shopify Impact browser-required queue item because the personalized customer-facing link is now present in the official Shopify email

No paid service, guessed tracking parameter, generic homepage-as-affiliate-link, or duplicate application is introduced. Canonical `tools.json` is not hand-edited in this PR; the existing sync helper now carries the verified Shopify route.