### PR TITLE
Optimize Brand24 buyer-intent affiliate landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/brand24.html
+++ b/projects/GlobalSaaSHub/public/tool/brand24.html
@@ -3,180 +3,223 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Brand24 Pricing, Features & Alternatives (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Review Brand24 for social media monitoring, pricing, features, and alternatives. Compare Brand24 with social media workflow options before choosing a tool." />
+    <title>Brand24 Review & Pricing (2026): 14-Day Free Trial, Features & Best Fit | GlobalSaaSHub</title>
+    <meta name="description" content="Brand24 review for buyers: current 2026 pricing, 14-day free trial, AI social listening features, best-fit use cases, limitations, and a verified partner signup link." />
     <link rel="canonical" href="https://coshuma.com/tool/brand24.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/tool/brand24.html" />
-    <meta property="og:title" content="Brand24 Pricing, Features & Alternatives (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Review Brand24 for social media monitoring and compare features, pricing information, and relevant alternatives." />
-
-    <!-- JSON-LD Structured Data for Google Indexing -->
+    <meta property="og:title" content="Brand24 Review & Pricing (2026): Is It Worth It for Social Listening?" />
+    <meta property="og:description" content="See Brand24 pricing, the 14-day free trial, AI monitoring features, and whether it fits your reputation, PR, or competitor-monitoring workflow." />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Brand24",
       "operatingSystem": "Web",
-      "applicationCategory": "Productivity & SaaS",
-      "description": "An essential social media monitoring tool that helps businesses track mentions, analyze sentiment, and understand their online presence."
+      "applicationCategory": "BusinessApplication",
+      "url": "https://brand24.com/",
+      "description": "AI-powered social listening software for monitoring online mentions, sentiment, reach, trends, and brand reputation."
     }
     </script>
-
-    <!-- Tailwind & Fonts -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "Does Brand24 have a free trial?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Brand24's official pricing page states that the first 14 days are free and no credit card is required."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How much does Brand24 cost?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "As checked on September 3, 2026, Brand24 lists Individual at $249/month or $199/month billed annually, Team at $349/month or $299/month billed annually, Pro at $499/month or $399/month billed annually, Business at $699/month or $599/month billed annually, and Enterprise from $1,499/month billed annually."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Who is Brand24 best for?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Brand24 is best suited to teams that need social listening, reputation monitoring, sentiment analysis, PR measurement, competitor monitoring, or alerts around online mentions."
+          }
+        }
+      ]
+    }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script defer src="/affiliate-attribution.js"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700;800;900&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
+      body { font-family: 'Inter', sans-serif; background: #0b0c10; color: #f1f5f9; }
       h1, h2, h3 { font-family: 'Outfit', sans-serif; }
     </style>
   </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
+  <body class="min-h-screen bg-[#0b0c10] text-slate-100">
+    <header class="sticky top-0 z-50 border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md">
+      <div class="max-w-5xl mx-auto px-5 py-4 flex items-center justify-between gap-4">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-9 w-9 rounded-xl bg-purple-600 flex items-center justify-center font-black text-white">G</div>
+          <span class="font-extrabold tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 text-purple-200 hover:bg-purple-500/10">Browse AI & SaaS tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
-          <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=brand24.com&sz=128" alt="Brand24 logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
-            <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Productivity & SaaS</span>
+    <main class="max-w-5xl mx-auto px-5 py-10 md:py-14 space-y-8">
+      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-10 shadow-2xl">
+        <div class="grid md:grid-cols-[1fr_auto] gap-8 items-start">
+          <div class="space-y-5">
+            <div class="flex items-center gap-4">
+              <img src="https://www.google.com/s2/favicons?domain=brand24.com&sz=128" alt="Brand24 logo" class="h-14 w-14 rounded-2xl border border-[#2a2e42] bg-slate-900 p-2" />
+              <div>
+                <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">AI social listening</div>
+                <h1 class="text-4xl md:text-5xl font-black text-white mt-1">Brand24 Review & Pricing</h1>
               </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Brand24</h1>
             </div>
-          </div>
-
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
-        </div>
-
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">An essential social media monitoring tool that helps businesses track mentions, analyze sentiment, and understand their online presence.</p>
-        </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Real-time Brand Monitoring</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Sentiment Analysis</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Influencer Discovery</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Alerts & Notifications</div>
-          </div>
-        </div>
-
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Brand24</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/followr.html" class="p-3.5 rounded-xl bg-[#181a29] border border-purple-500/30 hover:border-purple-400 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=followr.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Followr</span></div><span class="text-[10px] font-extrabold text-emerald-400">Social workflow</span></a>
-            <a href="/tool/text-cortex.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=textcortex.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Text Cortex</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/triple-whale.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=triplewhale.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Triple Whale</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
-
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://brand24.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Brand24 Site</span><span>→</span></a>
-          <a data-cta="affiliate" data-tool-id="brand24" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Try Brand24 via Verified Partner Link</span><span>→</span></a>
-        </div>
-        <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission when eligible purchases are attributed through the verified Brand24 partner link, at no extra cost to you.</p>
-
-        <!-- Revenue-safe alternative path -->
-        <div class="p-6 rounded-2xl bg-purple-500/5 border border-purple-500/25 space-y-3">
-          <h2 class="text-lg font-bold text-white">Need social media workflow automation instead?</h2>
-          <p class="text-sm text-slate-300 leading-relaxed">Brand24 focuses on monitoring mentions and sentiment. If your priority is managing and growing a social media presence with automation and AI-assisted workflows, compare Followr before deciding.</p>
-          <div class="flex flex-col sm:flex-row gap-3">
-            <a href="/tool/followr.html" class="px-5 py-3 rounded-xl font-bold text-sm border border-purple-500/30 text-purple-200 text-center hover:bg-purple-500/10 transition-all">Review Followr</a>
-            <a data-cta="affiliate" data-tool-id="followr" href="https://followr.ai/?ref=support22" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center hover:bg-purple-500 transition-all">Try Followr →</a>
-          </div>
-          <p class="text-[11px] text-slate-500">Affiliate disclosure: GlobalSaaSHub may earn a commission if you purchase through the Followr link, at no extra cost to you.</p>
-        </div>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Brand24?</span>
+            <p class="text-lg text-slate-300 leading-relaxed max-w-3xl">Brand24 is built for teams that need to catch online mentions, understand sentiment, track brand reputation, and turn social-listening data into reports and AI-assisted insights.</p>
+            <div class="flex flex-wrap gap-2 text-xs font-bold">
+              <span class="px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/25 text-emerald-300">14-day free trial</span>
+              <span class="px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/25 text-emerald-300">No credit card required</span>
+              <span class="px-3 py-1.5 rounded-full bg-purple-500/10 border border-purple-500/25 text-purple-200">Verified COSHUMA partner link</span>
             </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
+            <div class="flex flex-col sm:flex-row gap-3 pt-1">
+              <a data-cta="affiliate" data-tool-id="brand24" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white font-extrabold text-center hover:brightness-110 shadow-lg shadow-purple-950/40">Try Brand24 via Verified Partner Link →</a>
+              <a data-cta="official" href="https://brand24.com/prices/" target="_blank" rel="noopener noreferrer" class="px-6 py-4 rounded-xl border border-slate-600 bg-slate-800/60 text-white font-bold text-center hover:bg-slate-700">Check official pricing</a>
+            </div>
+            <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission when an eligible purchase is attributed through the verified Brand24 partner link, at no extra cost to you.</p>
           </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Brand24 Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/brand24.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Brand24 Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
+          <aside class="w-full md:w-72 rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-5 space-y-4">
+            <div>
+              <div class="text-xs uppercase tracking-wider text-slate-500 font-bold">Best for</div>
+              <div class="mt-2 text-sm text-slate-200 leading-relaxed">PR, reputation, competitor monitoring, customer-insight and social-listening teams.</div>
+            </div>
+            <div class="border-t border-[#222538] pt-4">
+              <div class="text-xs uppercase tracking-wider text-slate-500 font-bold">Watch out for</div>
+              <div class="mt-2 text-sm text-slate-300 leading-relaxed">The entry plan is relatively expensive for casual monitoring. Buyers should match keyword, mention, user and update-frequency limits to their workload.</div>
+            </div>
+          </aside>
         </div>
+      </section>
 
+      <section class="grid md:grid-cols-3 gap-4">
+        <div class="rounded-2xl border border-[#25293b] bg-[#121520] p-5">
+          <div class="text-purple-300 font-bold text-sm">Monitor broadly</div>
+          <p class="text-sm text-slate-300 mt-2 leading-relaxed">Brand24 says it monitors mentions across social media, news, blogs, videos, forums, podcasts, reviews and other online sources.</p>
+        </div>
+        <div class="rounded-2xl border border-[#25293b] bg-[#121520] p-5">
+          <div class="text-purple-300 font-bold text-sm">Understand sentiment</div>
+          <p class="text-sm text-slate-300 mt-2 leading-relaxed">Sentiment analysis separates positive, negative and neutral mentions so teams can prioritize reputation and customer-response work.</p>
+        </div>
+        <div class="rounded-2xl border border-[#25293b] bg-[#121520] p-5">
+          <div class="text-purple-300 font-bold text-sm">Use AI for triage</div>
+          <p class="text-sm text-slate-300 mt-2 leading-relaxed">Brand24 lists AI Insights, topic analysis, anomaly detection and Brand Assistant capabilities across its product and higher-tier plans.</p>
+        </div>
+      </section>
 
-      </div>
+      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-5">
+        <div>
+          <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Current pricing</div>
+          <h2 class="text-2xl md:text-3xl font-black text-white mt-1">Brand24 pricing checked September 3, 2026</h2>
+          <p class="text-sm text-slate-400 mt-2">Prices below are taken from Brand24's official pricing page. Software pricing can change, so verify before purchase.</p>
+        </div>
+        <div class="overflow-x-auto rounded-2xl border border-[#2a2e42]">
+          <table class="w-full min-w-[720px] text-left text-sm">
+            <thead class="bg-[#0d1018] text-slate-300">
+              <tr>
+                <th class="p-4">Plan</th>
+                <th class="p-4">Monthly</th>
+                <th class="p-4">Annual billing</th>
+                <th class="p-4">Useful official limits / notes</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-[#25293b] text-slate-300">
+              <tr><td class="p-4 font-bold text-white">Individual</td><td class="p-4">$249/mo</td><td class="p-4">$199/mo</td><td class="p-4">3 keywords, 2K mentions/mo, 1 user, updates every 12h</td></tr>
+              <tr><td class="p-4 font-bold text-white">Team</td><td class="p-4">$349/mo</td><td class="p-4">$299/mo</td><td class="p-4">7 keywords, 10K mentions/mo, unlimited users, hourly updates</td></tr>
+              <tr><td class="p-4 font-bold text-white">Pro</td><td class="p-4">$499/mo</td><td class="p-4">$399/mo</td><td class="p-4">12 keywords, 40K mentions/mo, unlimited users, real-time updates</td></tr>
+              <tr><td class="p-4 font-bold text-white">Business</td><td class="p-4">$699/mo</td><td class="p-4">$599/mo</td><td class="p-4">25 keywords, 100K mentions/mo, real-time updates, broader AI/reporting features</td></tr>
+              <tr><td class="p-4 font-bold text-white">Enterprise</td><td class="p-4">From $1,499/mo</td><td class="p-4">From $1,499/mo</td><td class="p-4">Custom keyword and mention limits, enterprise support and advanced features</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a data-cta="affiliate" data-tool-id="brand24" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3.5 rounded-xl bg-purple-600 text-white font-extrabold text-center hover:bg-purple-500">Try Brand24 with the verified partner link →</a>
+          <a href="https://brand24.com/prices/" target="_blank" rel="noopener noreferrer" class="px-5 py-3.5 rounded-xl border border-slate-600 text-slate-200 font-bold text-center hover:bg-slate-800">Verify latest pricing at Brand24</a>
+        </div>
+      </section>
+
+      <section class="grid md:grid-cols-2 gap-5">
+        <div class="rounded-3xl border border-emerald-500/20 bg-emerald-500/5 p-6">
+          <h2 class="text-xl font-black text-white">Brand24 makes sense if…</h2>
+          <ul class="mt-4 space-y-3 text-sm text-slate-300">
+            <li>✓ You need to monitor brand, product, competitor or campaign mentions across many online sources.</li>
+            <li>✓ You need sentiment and reach signals to prioritize PR or support responses.</li>
+            <li>✓ You need reports and alerts rather than only a social publishing calendar.</li>
+            <li>✓ The value of catching reputation issues or media opportunities justifies the subscription cost.</li>
+          </ul>
+        </div>
+        <div class="rounded-3xl border border-rose-500/20 bg-rose-500/5 p-6">
+          <h2 class="text-xl font-black text-white">Consider another tool if…</h2>
+          <ul class="mt-4 space-y-3 text-sm text-slate-300">
+            <li>• You mainly need social posting, scheduling or content generation rather than listening.</li>
+            <li>• You are a solo user with light monitoring needs and the entry price is difficult to justify.</li>
+            <li>• You need to evaluate a very high mention volume but have not checked plan limits first.</li>
+            <li>• Your main requirement is a low-cost creator workflow rather than reputation intelligence.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-5">
+        <h2 class="text-2xl font-black text-white">Feature reality check</h2>
+        <div class="grid sm:grid-cols-2 gap-4 text-sm">
+          <div class="rounded-2xl bg-[#0d1018] border border-[#25293b] p-5"><div class="font-bold text-white">AI Sentiment Analysis</div><p class="mt-2 text-slate-400 leading-relaxed">Available across the listed plans on the official pricing page.</p></div>
+          <div class="rounded-2xl bg-[#0d1018] border border-[#25293b] p-5"><div class="font-bold text-white">AI Insights & Topics</div><p class="mt-2 text-slate-400 leading-relaxed">Brand24 lists AI-generated insights and topic analysis, with availability and limits varying by plan.</p></div>
+          <div class="rounded-2xl bg-[#0d1018] border border-[#25293b] p-5"><div class="font-bold text-white">Alerts & anomaly detection</div><p class="mt-2 text-slate-400 leading-relaxed">Storm Alerts and AI anomaly detection are designed to surface sudden changes in mention volume or reach.</p></div>
+          <div class="rounded-2xl bg-[#0d1018] border border-[#25293b] p-5"><div class="font-bold text-white">Reports & exports</div><p class="mt-2 text-slate-400 leading-relaxed">Brand24 lists email reports plus Excel, PowerPoint and infographic reporting/export options.</p></div>
+        </div>
+      </section>
+
+      <section class="rounded-3xl border border-purple-500/25 bg-purple-500/5 p-6 md:p-8 space-y-4">
+        <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Alternative path</div>
+        <h2 class="text-2xl font-black text-white">Need social-media workflow automation more than social listening?</h2>
+        <p class="text-sm text-slate-300 leading-relaxed max-w-3xl">Brand24 is primarily a monitoring and intelligence tool. If your priority is AI-assisted social-media workflow management instead, review Followr before deciding.</p>
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a href="/tool/followr.html" class="px-5 py-3 rounded-xl border border-purple-500/30 text-purple-100 font-bold text-center hover:bg-purple-500/10">Review Followr</a>
+          <a data-cta="affiliate" data-tool-id="followr" href="https://followr.ai/?ref=support22" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3 rounded-xl bg-purple-600 text-white font-extrabold text-center hover:bg-purple-500">Try Followr →</a>
+        </div>
+        <p class="text-[11px] text-slate-500">Affiliate disclosure: GlobalSaaSHub may earn a commission if you purchase through the Followr link, at no extra cost to you.</p>
+      </section>
+
+      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-4">
+        <h2 class="text-2xl font-black text-white">FAQ</h2>
+        <div class="space-y-4 text-sm">
+          <div><h3 class="font-bold text-white">Does Brand24 have a free trial?</h3><p class="text-slate-400 mt-1 leading-relaxed">Yes. Brand24's official pricing page states that the first 14 days are free and no credit card is required.</p></div>
+          <div><h3 class="font-bold text-white">Is Brand24 cheap?</h3><p class="text-slate-400 mt-1 leading-relaxed">Not for light use. The official monthly Individual plan was $249/month when checked on September 3, 2026. The value case is strongest when monitoring reputation, PR, competitors or customer sentiment has measurable business impact.</p></div>
+          <div><h3 class="font-bold text-white">What should I check before starting?</h3><p class="text-slate-400 mt-1 leading-relaxed">Check how many keywords and mentions you expect, how many users need access, how quickly mentions must update, and which AI/reporting features are included in the plan you are considering.</p></div>
+        </div>
+      </section>
+
+      <section class="rounded-3xl border border-purple-500/30 bg-gradient-to-br from-purple-500/10 to-indigo-500/5 p-7 md:p-9 text-center space-y-4">
+        <h2 class="text-3xl font-black text-white">Ready to test Brand24 with your own keywords?</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto">Use the trial to validate mention quality, alert usefulness, sentiment accuracy for your market, and whether the plan limits match your real workload before committing.</p>
+        <a data-cta="affiliate" data-tool-id="brand24" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-4 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white font-extrabold hover:brightness-110 shadow-lg shadow-purple-950/40">Try Brand24 via Verified Partner Link →</a>
+        <p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn a commission from eligible purchases attributed through this partner link, at no extra cost to you.</p>
+      </section>
     </main>
 
-    <!-- Footer -->
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
+    <footer class="border-t border-[#222538] bg-[#07080c] mt-10">
+      <div class="max-w-5xl mx-auto px-5 py-8 text-xs text-slate-500 flex flex-col md:flex-row gap-2 md:items-center md:justify-between">
+        <span>© 2026 GlobalSaaSHub. Independent AI & SaaS decision support.</span>
+        <span>Brand24 pricing/features last checked September 3, 2026 against official Brand24 pages.</span>
       </div>
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
Revenue-first, zero-cost optimization for the newly verified Brand24 partner route.

Grounding:
- Brand24's Sept. 2 partner-program email supplied COSHUMA's exact referral URL `https://try.brand24.com/8xqrjxybmsbt` and states rewards of up to 30% recurring commission per sale.
- Brand24's official pricing page currently states a 14-day free trial with no credit card required and lists Individual $249/mo ($199/mo annual billing), Team $349/$299, Pro $499/$399, Business $699/$599, and Enterprise from $1,499/mo.
- Official Brand24 feature pages confirm social listening, sentiment analysis, AI insights/topic analysis, anomaly detection, alerts, and reporting/export capabilities.

Changes:
- Rebuild the Brand24 detail page around high-intent search and purchase questions instead of generic filler.
- Put the verified Brand24 partner CTA above the fold and repeat it at pricing and final-decision points.
- Add current pricing, trial details, fit/skip guidance, feature reality checks, FAQ schema, and dated verification language.
- Keep affiliate attribution via `/affiliate-attribution.js` and `data-tool-id="brand24"`.
- Preserve the separate Followr alternative path for visitors who actually need social workflow automation rather than listening.

No paid services, guessed links, unverified approval claims, or new subscriptions are introduced.