### PR TITLE
Optimize ElevenLabs vs Murf AI revenue CTAs

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/elevenlabs-vs-murf-ai.html
+++ b/projects/GlobalSaaSHub/public/compare/elevenlabs-vs-murf-ai.html
@@ -1,172 +1,105 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ElevenLabs vs Murf AI Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of ElevenLabs vs Murf AI. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ElevenLabs vs Murf AI (2026): Voice AI Comparison | GlobalSaaSHub</title>
+  <meta name="description" content="Compare ElevenLabs and Murf AI for AI voice generation, voice cloning, text-to-speech, and production workflows. Use verified partner links when you are ready to try either tool." />
+  <link rel="canonical" href="https://coshuma.com/compare/elevenlabs-vs-murf-ai.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/elevenlabs-vs-murf-ai.html" />
+  <meta property="og:title" content="ElevenLabs vs Murf AI (2026) | GlobalSaaSHub" />
+  <meta property="og:description" content="A practical buyer-intent comparison of ElevenLabs and Murf AI with verified partner CTAs." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"WebPage",
+    "name":"ElevenLabs vs Murf AI Comparison",
+    "url":"https://coshuma.com/compare/elevenlabs-vs-murf-ai.html",
+    "about":[
+      {"@type":"SoftwareApplication","name":"ElevenLabs","url":"https://coshuma.com/tool/elevenlabs.html"},
+      {"@type":"SoftwareApplication","name":"Murf AI","url":"https://coshuma.com/tool/murf-ai.html"}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="/affiliate-attribution.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}
+  </style>
+</head>
+<body class="min-h-screen bg-[#0b0c10] text-slate-100">
+  <header class="border-b border-[#222538] bg-[#07080c]/90 sticky top-0 z-50 py-4 px-6 backdrop-blur-md">
+    <div class="max-w-5xl mx-auto flex items-center justify-between">
+      <a href="/" class="font-extrabold text-white">GlobalSaaSHub</a>
+      <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">← All Tools</a>
+    </div>
+  </header>
 
-    <link rel="canonical" href="https://coshuma.com/compare/elevenlabs-vs-murf-ai.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/elevenlabs-vs-murf-ai.html" />
-    <meta property="og:title" content="ElevenLabs vs Murf AI Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare ElevenLabs and Murf AI by pricing, features, and verified public information." />
+  <main class="max-w-5xl mx-auto px-4 py-10 space-y-8">
+    <section class="text-center space-y-4">
+      <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Voice AI buyer comparison</div>
+      <h1 class="text-4xl md:text-5xl font-black tracking-tight">ElevenLabs vs Murf AI</h1>
+      <p class="max-w-3xl mx-auto text-slate-300">Both products cover AI voice creation. The useful decision is which workflow fits your job: ElevenLabs is positioned here for voice cloning, text-to-speech and sound-generation workflows, while Murf AI is positioned for studio-style voice production with cloning, editing and background-audio capabilities.</p>
+    </section>
 
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "ElevenLabs vs Murf AI Comparison",
-      "url": "https://coshuma.com/compare/elevenlabs-vs-murf-ai.html",
-      "description": "Compare ElevenLabs and Murf AI by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "ElevenLabs", "url": "https://coshuma.com/tool/elevenlabs.html"},
-        {"@type": "SoftwareApplication", "name": "Murf AI", "url": "https://coshuma.com/tool/murf-ai.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+    <section class="grid md:grid-cols-2 gap-5">
+      <article class="rounded-3xl bg-[#131520] border border-purple-500/30 p-6 space-y-5">
+        <div>
+          <div class="text-xs font-bold text-purple-300 uppercase tracking-wider">Choose ElevenLabs when</div>
+          <h2 class="text-2xl font-black mt-1">Voice generation flexibility matters most</h2>
+        </div>
+        <ul class="space-y-2 text-sm text-slate-300">
+          <li>✓ AI voice cloning</li>
+          <li>✓ Text-to-speech</li>
+          <li>✓ Sound effects generation</li>
+          <li>✓ Multi-lingual support</li>
+        </ul>
+        <a data-cta="affiliate" data-tool-id="elevenlabs" href="https://try.elevenlabs.io/ldc2xmh2x2t5" target="_blank" rel="sponsored noopener noreferrer" class="block w-full py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center shadow-lg">Try ElevenLabs via verified partner link →</a>
+        <a href="/tool/elevenlabs.html" class="block text-center text-xs text-slate-400 hover:text-white">See the ElevenLabs detail page</a>
+      </article>
+
+      <article class="rounded-3xl bg-[#131520] border border-blue-500/30 p-6 space-y-5">
+        <div>
+          <div class="text-xs font-bold text-blue-300 uppercase tracking-wider">Choose Murf AI when</div>
+          <h2 class="text-2xl font-black mt-1">A studio-style voice workflow fits better</h2>
+        </div>
+        <ul class="space-y-2 text-sm text-slate-300">
+          <li>✓ Studio-quality AI voices</li>
+          <li>✓ Custom voice cloning</li>
+          <li>✓ Speech-to-text editor</li>
+          <li>✓ Background music and sound</li>
+        </ul>
+        <a data-cta="affiliate" data-tool-id="murf-ai" href="https://get.murf.ai/fqac0vixj0qs" target="_blank" rel="sponsored noopener noreferrer" class="block w-full py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center shadow-lg">Try Murf AI via verified partner link →</a>
+        <a href="/tool/murf-ai.html" class="block text-center text-xs text-slate-400 hover:text-white">See the Murf AI detail page</a>
+      </article>
+    </section>
+
+    <section class="rounded-3xl bg-[#131520] border border-[#222538] p-6 space-y-5">
+      <h2 class="text-2xl font-black">Fast decision guide</h2>
+      <div class="grid md:grid-cols-3 gap-4 text-sm">
+        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white mb-1">Need cloned or generated voices?</div><p class="text-slate-400">Both are relevant. Compare the actual output and workflow before committing to a paid plan.</p></div>
+        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white mb-1">Need sound effects too?</div><p class="text-slate-400">ElevenLabs lists sound effects generation among the capabilities captured in our current tool data.</p></div>
+        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white mb-1">Need a studio-oriented editor?</div><p class="text-slate-400">Murf AI lists speech-to-text editing plus background music and sound among the capabilities captured in our current tool data.</p></div>
       </div>
-    </header>
+      <p class="text-xs text-slate-500">Pricing and plan limits can change. Check the vendor page reached through the button before purchasing.</p>
+    </section>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">ElevenLabs vs Murf AI</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Voice & Speech AI tool.
-        </p>
+    <section class="rounded-3xl bg-gradient-to-r from-purple-950/50 to-blue-950/50 border border-purple-500/20 p-6 text-center space-y-4">
+      <h2 class="text-2xl font-black">Ready to test one?</h2>
+      <p class="text-sm text-slate-300">Use the verified partner link for the product you actually want to evaluate. COSHUMA may earn a commission if an eligible signup or purchase is attributed, at no extra cost to you.</p>
+      <div class="grid sm:grid-cols-2 gap-3 max-w-2xl mx-auto">
+        <a data-cta="affiliate" data-tool-id="elevenlabs" href="https://try.elevenlabs.io/ldc2xmh2x2t5" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white">Open ElevenLabs →</a>
+        <a data-cta="affiliate" data-tool-id="murf-ai" href="https://get.murf.ai/fqac0vixj0qs" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white">Open Murf AI →</a>
       </div>
+    </section>
+  </main>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose ElevenLabs if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Murf AI if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
-      </div>
-
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/elevenlabs.html" class="hover:text-purple-300">ElevenLabs</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/murf-ai.html" class="hover:text-blue-300">Murf AI</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">Varies</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">ElevenLabs Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ AI Voice Cloning</div>
-<div>✓ Text-to-Speech</div>
-<div>✓ Sound Effects Generator</div>
-<div>✓ Multi-lingual Support</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Murf AI Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Studio-quality AI voices</div>
-<div>✓ Custom voice cloning</div>
-<div>✓ Speech-to-text editor</div>
-<div>✓ Background music and sound</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://try.elevenlabs.io/ldc2xmh2x2t5" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get ElevenLabs →</a>
-          <a href="https://murf.ai/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Murf AI →</a>
-        </div>
-      </div>
-    </main>
-
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
-  </body>
+  <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
+    <div class="max-w-5xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Independent comparison and affiliate disclosure included.</div>
+  </footer>
+</body>
 </html>


### PR DESCRIPTION
Revenue-focused update for the buyer-intent ElevenLabs vs Murf AI comparison page.

- replaces the generic Murf homepage CTA with the personal referral URL verified in Murf's PartnerStack welcome email
- preserves the existing verified ElevenLabs affiliate URL
- adds affiliate attribution hooks to both products
- adds affiliate disclosure and clearer decision-oriented copy
- avoids fixed pricing claims so the page does not become stale

No paid services or new subscriptions used.