### PR TITLE
Track Fireflies affiliate CTA attribution

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/fireflies-ai.html
+++ b/projects/GlobalSaaSHub/public/tool/fireflies-ai.html
@@ -147,5 +147,6 @@
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
       <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
+    <script src="/affiliate-attribution.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Adds the existing `/affiliate-attribution.js` instrumentation to the Fireflies buyer-intent page. The page already uses the verified Fireflies referral URL from the account's FirstPromoter welcome email and tags both revenue CTAs with `data-cta="affiliate"` / `data-tool-id="fireflies-ai"`, but it was missing the attribution script that other monetized pages load. No pricing, referral URL, or paid-service changes.