### PR TITLE
Monetize DocsBot comparison CTAs

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/carv-vs-docsbot.html
+++ b/projects/GlobalSaaSHub/public/compare/carv-vs-docsbot.html
@@ -32,6 +32,7 @@
     </script>
     
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
@@ -96,8 +97,6 @@
         </div>
       </div>
 
-
-
       <!-- 2-Column Comparison Table -->
       <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
         <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
@@ -121,8 +120,6 @@
             <div class="text-lg font-black text-amber-400">Not rated</div>
           </div>
         </div>
-
-
 
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
           <div>
@@ -158,8 +155,9 @@
 
         <div class="grid grid-cols-2 gap-4 pt-2">
           <a href="https://www.carv.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Carv →</a>
-          <a href="https://docsbot.ai/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get DocsBot →</a>
+          <a data-cta="affiliate" data-tool-id="docsbot" href="https://docsbot.ai?via=31kq9q" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Try DocsBot via Verified Link →</a>
         </div>
+        <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: the DocsBot button uses COSHUMA's verified referral link. COSHUMA may earn a commission if you purchase after using it, at no extra cost to you.</p>
       </div>
     </main>
 

--- a/projects/GlobalSaaSHub/public/compare/liftmycv-vs-docsbot.html
+++ b/projects/GlobalSaaSHub/public/compare/liftmycv-vs-docsbot.html
@@ -32,6 +32,7 @@
     </script>
     
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
@@ -96,8 +97,6 @@
         </div>
       </div>
 
-
-
       <!-- 2-Column Comparison Table -->
       <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
         <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
@@ -121,8 +120,6 @@
             <div class="text-lg font-black text-amber-400">Not rated</div>
           </div>
         </div>
-
-
 
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
           <div>
@@ -157,9 +154,10 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://www.liftmycv.com/?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get LiftmyCV →</a>
-          <a href="https://docsbot.ai/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get DocsBot →</a>
+          <a data-cta="affiliate" data-tool-id="liftmycv" href="https://www.liftmycv.com/?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get LiftmyCV →</a>
+          <a data-cta="affiliate" data-tool-id="docsbot" href="https://docsbot.ai?via=31kq9q" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Try DocsBot via Verified Link →</a>
         </div>
+        <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: the LiftmyCV and DocsBot buttons use verified COSHUMA affiliate links. COSHUMA may earn a commission if you purchase after using them, at no extra cost to you.</p>
       </div>
     </main>
 


### PR DESCRIPTION
Adds COSHUMA's verified DocsBot referral URL to two buyer-intent comparison pages that were still sending visitors to the generic DocsBot homepage. Also adds affiliate disclosure and click-attribution hooks. LiftmyCV's existing verified affiliate CTA is instrumented on its comparison page. No paid services or new applications involved.