### PR TITLE
Monetize Dorik buyer-intent comparison CTAs

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/dorik-vs-make-com.html
+++ b/projects/GlobalSaaSHub/public/compare/dorik-vs-make-com.html
@@ -32,6 +32,7 @@
     </script>
     
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
@@ -96,8 +97,6 @@
         </div>
       </div>
 
-
-
       <!-- 2-Column Comparison Table -->
       <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
         <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
@@ -121,8 +120,6 @@
             <div class="text-lg font-black text-amber-400">Not rated</div>
           </div>
         </div>
-
-
 
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
           <div>
@@ -157,9 +154,10 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://dorik.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Dorik →</a>
-          <a href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Make.com →</a>
+          <a data-cta="affiliate" data-tool-id="dorik" href="https://dorik.com/?ref=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Dorik →</a>
+          <a data-cta="affiliate" data-tool-id="make-com" href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Make.com →</a>
         </div>
+        <p class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: both primary buttons use COSHUMA's verified partner routes. GlobalSaaSHub may earn a commission if you become a paying customer after using them, at no extra cost to you.</p>
       </div>
     </main>
 

--- a/projects/GlobalSaaSHub/public/compare/dorik-vs-unbounce.html
+++ b/projects/GlobalSaaSHub/public/compare/dorik-vs-unbounce.html
@@ -32,6 +32,7 @@
     </script>
     
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
@@ -96,8 +97,6 @@
         </div>
       </div>
 
-
-
       <!-- 2-Column Comparison Table -->
       <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
         <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
@@ -121,8 +120,6 @@
             <div class="text-lg font-black text-amber-400">Not rated</div>
           </div>
         </div>
-
-
 
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
           <div>
@@ -157,9 +154,10 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://dorik.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Dorik →</a>
+          <a data-cta="affiliate" data-tool-id="dorik" href="https://dorik.com/?ref=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Dorik →</a>
           <a href="https://unbounce.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Unbounce →</a>
         </div>
+        <p class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: the Dorik button uses COSHUMA's verified partner route. GlobalSaaSHub may earn a commission if you become a paying Dorik customer after using it, at no extra cost to you.</p>
       </div>
     </main>
 


### PR DESCRIPTION
## Revenue impact
Two indexed buyer-intent comparison pages still sent Dorik clicks to the generic homepage even though COSHUMA already has a verified Dorik partner route. This PR closes those revenue leaks.

## Changes
- Dorik vs Make.com: route Dorik through `https://dorik.com/?ref=coshuma`
- Dorik vs Unbounce: route Dorik through the same verified partner route
- add `data-cta="affiliate"` / `data-tool-id` attribution markers
- load the existing `/affiliate-attribution.js`
- add explicit affiliate disclosures
- preserve Make.com's existing verified partner route and add its attribution markers

No paid service, subscription, or advertising is introduced.