### PR TITLE
Strengthen GoHighLevel buyer-intent comparison CTA

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/gohighlevel-vs-livechat.html
+++ b/projects/GlobalSaaSHub/public/compare/gohighlevel-vs-livechat.html
@@ -96,7 +96,11 @@
         </div>
       </div>
 
-
+      <div class="p-5 rounded-2xl bg-purple-500/10 border border-purple-500/30 text-center space-y-3">
+        <p class="text-sm font-bold text-white">Already leaning toward GoHighLevel?</p>
+        <a data-cta="affiliate" data-tool-id="gohighlevel" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex items-center justify-center px-6 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white shadow-lg transition-all">Visit GoHighLevel via Partner Link →</a>
+        <p class="text-[10px] text-slate-400">Affiliate disclosure: GlobalSaaSHub may earn a commission if you purchase through this link.</p>
+      </div>
 
       <!-- 2-Column Comparison Table -->
       <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
@@ -121,8 +125,6 @@
             <div class="text-lg font-black text-amber-400">Not rated</div>
           </div>
         </div>
-
-
 
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
           <div>
@@ -157,9 +159,10 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get GoHighLevel →</a>
+          <a data-cta="affiliate" data-tool-id="gohighlevel" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get GoHighLevel →</a>
           <a href="https://www.livechat.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get LiveChat →</a>
         </div>
+        <p class="text-[10px] text-slate-500 text-center">GoHighLevel links on this page are affiliate links; GlobalSaaSHub may earn a commission from qualifying purchases.</p>
       </div>
     </main>
 
@@ -168,5 +171,6 @@
         &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
       </div>
     </footer>
+    <script src="/affiliate-attribution.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Adds a prominent verified GoHighLevel partner CTA to the buyer-intent LiveChat comparison page, marks both GoHighLevel CTAs for affiliate attribution, adds disclosure, and loads the existing affiliate-attribution script. No paid services or pricing claims added.