### PR TITLE
Monetize Databox comparison CTAs

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/databox-vs-brand24.html
+++ b/projects/GlobalSaaSHub/public/compare/databox-vs-brand24.html
@@ -96,8 +96,6 @@
         </div>
       </div>
 
-
-
       <!-- 2-Column Comparison Table -->
       <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
         <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
@@ -121,8 +119,6 @@
             <div class="text-lg font-black text-amber-400">Not rated</div>
           </div>
         </div>
-
-
 
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
           <div>
@@ -157,9 +153,10 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://databox.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Databox →</a>
-          <a href="https://brand24.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Brand24 →</a>
+          <a data-cta="affiliate" data-tool-id="databox" data-cta-source="compare_databox_brand24" href="https://databox.com?aff_id=15298659&fp_ref=sangkwon-72c9ec" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Start Databox Free →</a>
+          <a data-cta="affiliate" data-tool-id="brand24" data-cta-source="compare_databox_brand24" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Try Brand24 →</a>
         </div>
+        <p class="text-[10px] text-slate-500 text-center leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission if you sign up or purchase through these partner links, at no extra cost to you.</p>
       </div>
     </main>
 
@@ -168,5 +165,6 @@
         &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
       </div>
     </footer>
+    <script src="/affiliate-attribution.js"></script>
   </body>
 </html>

--- a/projects/GlobalSaaSHub/public/compare/databox-vs-text-cortex.html
+++ b/projects/GlobalSaaSHub/public/compare/databox-vs-text-cortex.html
@@ -96,8 +96,6 @@
         </div>
       </div>
 
-
-
       <!-- 2-Column Comparison Table -->
       <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
         <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
@@ -121,8 +119,6 @@
             <div class="text-lg font-black text-amber-400">Not rated</div>
           </div>
         </div>
-
-
 
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
           <div>
@@ -157,9 +153,10 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://databox.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Databox →</a>
-          <a href="https://textcortex.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Text Cortex →</a>
+          <a data-cta="affiliate" data-tool-id="databox" data-cta-source="compare_databox_textcortex" href="https://databox.com?aff_id=15298659&fp_ref=sangkwon-72c9ec" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Start Databox Free →</a>
+          <a href="https://textcortex.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Visit Text Cortex →</a>
         </div>
+        <p class="text-[10px] text-slate-500 text-center leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission if you sign up or purchase through the Databox partner link, at no extra cost to you. The Text Cortex link is an ordinary official-site link.</p>
       </div>
     </main>
 
@@ -168,5 +165,6 @@
         &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
       </div>
     </footer>
+    <script src="/affiliate-attribution.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Routes two buyer-intent Databox comparison pages through verified, email-grounded referral URLs. Also upgrades the Brand24 CTA on the Databox comparison to its verified partner link, adds affiliate disclosure, and loads the existing affiliate attribution script. No paid services or subscription changes.