### PR TITLE
Track Descript vs OutlierKit affiliate clicks

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/descript-vs-outlierkit.html
+++ b/projects/GlobalSaaSHub/public/compare/descript-vs-outlierkit.html
@@ -32,6 +32,7 @@
     </script>
     
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
@@ -157,9 +158,10 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://get.descript.com/ole5fu20j5sq" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Descript →</a>
-          <a href="https://outlierkit.com/?ref=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get OutlierKit →</a>
+          <a data-cta="affiliate" data-tool-id="descript" href="https://get.descript.com/ole5fu20j5sq" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Descript →</a>
+          <a data-cta="affiliate" data-tool-id="outlierkit" href="https://outlierkit.com/?ref=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get OutlierKit →</a>
         </div>
+        <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: GlobalSaaSHub may earn a commission if you purchase through these verified partner links, at no additional cost to you.</p>
       </div>
     </main>
 


### PR DESCRIPTION
Revenue attribution fix for the buyer-intent Descript vs OutlierKit comparison page.

- Both outbound CTAs already use repository-verified approved tracking URLs.
- Add `data-cta="affiliate"` and correct `data-tool-id` values to both CTAs.
- Load the existing `/affiliate-attribution.js` helper so clicks emit COSHUMA affiliate attribution events.
- Add an explicit affiliate disclosure.

No pricing, offer, referral URL, paid service, or subscription changes.