### PR TITLE
Optimize Fliki vs TubeBuddy buyer conversion

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/fliki-vs-tubebuddy.html
+++ b/projects/GlobalSaaSHub/public/compare/fliki-vs-tubebuddy.html
@@ -3,35 +3,29 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Fliki vs TubeBuddy Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Fliki vs TubeBuddy. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
-
+    <title>Fliki vs TubeBuddy: Which Creator Tool Fits Best? (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Compare Fliki vs TubeBuddy by creator workflow, core features and pricing route. Use verified COSHUMA partner links to test Fliki or check TubeBuddy pricing." />
     <link rel="canonical" href="https://coshuma.com/compare/fliki-vs-tubebuddy.html" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/compare/fliki-vs-tubebuddy.html" />
-    <meta property="og:title" content="Fliki vs TubeBuddy Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Fliki and TubeBuddy by pricing, features, and verified public information." />
-
+    <meta property="og:title" content="Fliki vs TubeBuddy: Which Creator Tool Fits Best? (2026)" />
+    <meta property="og:description" content="Choose between AI video creation with Fliki and YouTube SEO/channel optimization with TubeBuddy." />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebPage",
       "name": "Fliki vs TubeBuddy Comparison",
       "url": "https://coshuma.com/compare/fliki-vs-tubebuddy.html",
-      "description": "Compare Fliki and TubeBuddy by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
+      "description": "Compare Fliki and TubeBuddy by creator workflow, features and current vendor pricing routes.",
+      "isPartOf": {"@type":"WebSite","name":"GlobalSaaSHub","url":"https://coshuma.com/"},
       "about": [
-        {"@type": "SoftwareApplication", "name": "Fliki", "url": "https://coshuma.com/tool/fliki.html"},
-        {"@type": "SoftwareApplication", "name": "TubeBuddy", "url": "https://coshuma.com/tool/tubebuddy.html"}
+        {"@type":"SoftwareApplication","name":"Fliki","url":"https://coshuma.com/tool/fliki.html"},
+        {"@type":"SoftwareApplication","name":"TubeBuddy","url":"https://coshuma.com/tool/tubebuddy.html"}
       ]
     }
     </script>
-    
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
@@ -47,126 +41,81 @@
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
     <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
+      <section class="text-center space-y-4">
+        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">⚖️ Creator Tool Comparison</div>
         <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Fliki vs TubeBuddy</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Video & Shorts Gen tool.
-        </p>
-      </div>
-
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
+        <p class="text-slate-300 text-sm md:text-base max-w-2xl mx-auto">Fliki is the better fit when your bottleneck is producing videos from text and voice. TubeBuddy is the better fit when the video already exists and your bottleneck is YouTube SEO, keyword research and channel operations.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-2xl mx-auto pt-2">
+          <a data-cta="affiliate" data-tool-id="fliki" href="https://fliki.ai?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-4 px-5 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white shadow-lg transition-all">Try Fliki via Partner Link →</a>
+          <a data-cta="affiliate" data-tool-id="tubebuddy" href="https://www.tubebuddy.com/pricing?a=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-4 px-5 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white shadow-lg transition-all">Check TubeBuddy Pricing →</a>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Fliki if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose TubeBuddy if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
+        <p class="text-[11px] text-slate-500 max-w-2xl mx-auto">Affiliate disclosure: the two buttons above use verified COSHUMA partner links. GlobalSaaSHub may earn a commission if you purchase through them, at no extra cost to you.</p>
+      </section>
+
+      <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-5">
+        <div class="flex items-center justify-between gap-3 flex-wrap">
+          <h2 class="text-xl font-bold text-white">Quick decision</h2>
+          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">Partner links verified in COSHUMA data</span>
         </div>
-      </div>
-
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/fliki.html" class="hover:text-purple-300">Fliki</a>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-3">
+            <h3 class="font-bold text-purple-300">Choose Fliki if you need to create the content</h3>
+            <ul class="space-y-2 text-slate-300 text-xs">
+              <li>✓ Turn text or scripts into videos</li>
+              <li>✓ Add AI voiceovers and avatars</li>
+              <li>✓ Translate or dub video content</li>
+              <li>✓ Reduce manual editing work for repeatable videos</li>
+            </ul>
+            <a href="/tool/fliki.html" class="inline-block text-xs font-bold text-purple-300 hover:text-purple-200">Read the Fliki review →</a>
           </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/tubebuddy.html" class="hover:text-blue-300">TubeBuddy</a>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-3">
+            <h3 class="font-bold text-blue-300">Choose TubeBuddy if you need to grow the channel</h3>
+            <ul class="space-y-2 text-slate-300 text-xs">
+              <li>✓ YouTube keyword research</li>
+              <li>✓ Video SEO optimization</li>
+              <li>✓ Bulk channel-management workflows</li>
+              <li>✓ Channel health and optimization tooling</li>
+            </ul>
+            <a href="/tool/tubebuddy.html" class="inline-block text-xs font-bold text-blue-300 hover:text-blue-200">Read the TubeBuddy review →</a>
           </div>
         </div>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
+        <h2 class="text-xl font-bold text-white">Side-by-side buyer check</h2>
+        <div class="overflow-x-auto">
+          <table class="w-full text-left text-sm border-separate border-spacing-y-2">
+            <thead class="text-slate-400 text-xs uppercase">
+              <tr><th class="py-2 pr-3">Decision factor</th><th class="py-2 px-3">Fliki</th><th class="py-2 pl-3">TubeBuddy</th></tr>
+            </thead>
+            <tbody class="text-slate-300 text-xs">
+              <tr class="bg-[#181a29]"><td class="p-3 rounded-l-xl font-bold text-white">Primary job</td><td class="p-3">AI-assisted video creation</td><td class="p-3 rounded-r-xl">YouTube optimization and channel workflow</td></tr>
+              <tr class="bg-[#181a29]"><td class="p-3 rounded-l-xl font-bold text-white">Best starting point</td><td class="p-3">A script, article or content idea</td><td class="p-3 rounded-r-xl">An existing YouTube channel or upload workflow</td></tr>
+              <tr class="bg-[#181a29]"><td class="p-3 rounded-l-xl font-bold text-white">Pricing</td><td class="p-3">Confirm current plan on vendor page</td><td class="p-3 rounded-r-xl">Confirm current plan on vendor page</td></tr>
+              <tr class="bg-[#181a29]"><td class="p-3 rounded-l-xl font-bold text-white">Use both?</td><td class="p-3" colspan="2">Yes. Fliki can help produce videos, while TubeBuddy can support YouTube discovery and channel optimization after publication.</td></tr>
+            </tbody>
+          </table>
         </div>
+      </section>
 
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
+      <section class="p-6 rounded-3xl bg-gradient-to-br from-purple-500/10 to-blue-500/10 border border-purple-500/20 text-center space-y-4">
+        <h2 class="text-2xl font-black text-white">Choose based on the bottleneck you have today</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto">Need faster video creation? Start with Fliki. Need better YouTube optimization and channel tooling? Check TubeBuddy. Current pricing and plan terms can change, so confirm them on the vendor page before purchase.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-2xl mx-auto">
+          <a data-cta="affiliate" data-tool-id="fliki" href="https://fliki.ai?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Open Fliki →</a>
+          <a data-cta="affiliate" data-tool-id="tubebuddy" href="https://www.tubebuddy.com/pricing?a=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Open TubeBuddy Pricing →</a>
         </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Fliki Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Text-to-video creation</div>
-<div>✓ AI voiceovers</div>
-<div>✓ AI avatars</div>
-<div>✓ Video translation and dubbing</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">TubeBuddy Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Video SEO optimization</div>
-<div>✓ Keyword research tools</div>
-<div>✓ Bulk processing features</div>
-<div>✓ Channel health reports</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://fliki.ai?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Fliki →</a>
-          <a href="https://www.tubebuddy.com/pricing?a=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get TubeBuddy →</a>
-        </div>
-      </div>
+        <p class="text-[10px] text-slate-500">COSHUMA may earn a commission from qualifying purchases made through these verified partner links.</p>
+      </section>
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.</div>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
Improves the Fliki vs TubeBuddy buyer-intent comparison without changing either verified partner URL.

- adds above-the-fold affiliate CTAs for both verified partner routes
- adds affiliate disclosure near the first CTAs
- connects both vendors to `/affiliate-attribution.js` via `data-cta` and `data-tool-id`
- replaces generic autogenerated copy with clearer job-to-be-done guidance
- keeps current vendor pricing claims conservative and directs buyers to confirm live terms