### PR TITLE
Optimize Vista Social vs BoldDesk buyer conversion

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/vista-social-vs-bolddesk.html
+++ b/projects/GlobalSaaSHub/public/compare/vista-social-vs-bolddesk.html
@@ -3,34 +3,27 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vista Social vs BoldDesk Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Vista Social vs BoldDesk. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
-
+    <title>Vista Social vs BoldDesk: Social Media vs Help Desk (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Vista Social vs BoldDesk in 2026: compare social media management with AI customer support, current entry pricing, free trials, best-fit use cases and verified partner links." />
     <link rel="canonical" href="https://coshuma.com/compare/vista-social-vs-bolddesk.html" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/compare/vista-social-vs-bolddesk.html" />
-    <meta property="og:title" content="Vista Social vs BoldDesk Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Vista Social and BoldDesk by pricing, features, and verified public information." />
-
+    <meta property="og:title" content="Vista Social vs BoldDesk: Which Workflow Do You Actually Need? (2026)" />
+    <meta property="og:description" content="Choose Vista Social for social publishing, engagement and reporting; choose BoldDesk for omnichannel support, ticketing and AI-assisted customer service." />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebPage",
       "name": "Vista Social vs BoldDesk Comparison",
       "url": "https://coshuma.com/compare/vista-social-vs-bolddesk.html",
-      "description": "Compare Vista Social and BoldDesk by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
+      "description": "A buyer-focused comparison of Vista Social and BoldDesk using current public vendor information.",
+      "isPartOf": {"@type": "WebSite", "name": "GlobalSaaSHub", "url": "https://coshuma.com/"},
       "about": [
         {"@type": "SoftwareApplication", "name": "Vista Social", "url": "https://coshuma.com/tool/vista-social.html"},
         {"@type": "SoftwareApplication", "name": "BoldDesk", "url": "https://coshuma.com/tool/bolddesk.html"}
       ]
     }
     </script>
-    
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -47,126 +40,98 @@
           <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
           <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
     <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
+      <section class="text-center space-y-4">
+        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Buyer-intent comparison • Updated September 3, 2026</div>
         <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Vista Social vs BoldDesk</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Workflow Automation tool.
-        </p>
-      </div>
-
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
+        <p class="text-slate-300 text-base max-w-2xl mx-auto leading-relaxed">These products solve different bottlenecks. Vista Social is built around social publishing, engagement, reporting and team workflows. BoldDesk is built around customer-support ticketing, omnichannel service, automation and AI-assisted support.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-2 max-w-2xl mx-auto">
+          <a data-cta="affiliate" data-tool-id="vista-social" href="https://vistasocial.com?fpr=sangkwon14" target="_blank" rel="sponsored noopener noreferrer" class="py-4 px-5 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center shadow-lg transition-all">Try Vista Social free for 14 days →</a>
+          <a data-cta="affiliate" data-tool-id="bolddesk" href="https://www.bolddesk.com/?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-4 px-5 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center shadow-lg transition-all">Try BoldDesk free for 15 days →</a>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Vista Social if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
+        <p class="text-[11px] text-slate-500 max-w-2xl mx-auto leading-relaxed"><strong class="text-slate-400">Affiliate disclosure:</strong> COSHUMA may earn a commission if you sign up or purchase through the partner links above, at no additional cost beyond the vendor's offer. Vendor pricing and program terms can change.</p>
+      </section>
+
+      <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-5">
+        <h2 class="text-xl font-black text-white">Fast decision</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-3">
+            <div class="font-bold text-purple-300">Choose Vista Social if your bottleneck is social media operations.</div>
+            <p class="text-sm text-slate-300 leading-relaxed">It is the more direct fit for teams that need to schedule content, manage engagement, collaborate on approvals, run reports, handle DMs and manage multiple social profiles from one system.</p>
           </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose BoldDesk if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-3">
+            <div class="font-bold text-blue-300">Choose BoldDesk if your bottleneck is customer support.</div>
+            <p class="text-sm text-slate-300 leading-relaxed">It is the more direct fit for teams that need tickets, live chat, omnichannel conversations, workflow automation, a knowledge base, reporting and AI support tools in one help-desk platform.</p>
           </div>
         </div>
-      </div>
+      </section>
 
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
+        <h2 class="text-xl font-bold text-white">Current public pricing snapshot</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-3">
+            <div class="text-xs font-bold uppercase tracking-wider text-purple-300">Vista Social</div>
+            <div class="text-2xl font-black text-emerald-400">From $79/month</div>
+            <p class="text-sm text-slate-300 leading-relaxed">Professional is currently listed at $79/month, with a 14-day free trial and no credit card required. Higher tiers add more profiles, users and agency-oriented capabilities.</p>
+            <a data-cta="official" href="https://vistasocial.com/pricing" target="_blank" rel="noopener noreferrer" class="inline-flex text-xs font-bold text-purple-300 hover:text-purple-200">Check Vista Social pricing →</a>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-3">
+            <div class="text-xs font-bold uppercase tracking-wider text-blue-300">BoldDesk</div>
+            <div class="text-2xl font-black text-emerald-400">$99/month for 5 agents</div>
+            <p class="text-sm text-slate-300 leading-relaxed">BoldDesk currently lists $99/month for 5 agents when billed yearly, plus a 15-day free trial with no credit card required. Its public positioning is one all-inclusive platform rather than feature-gated tiers.</p>
+            <a data-cta="official" href="https://www.bolddesk.com/" target="_blank" rel="noopener noreferrer" class="inline-flex text-xs font-bold text-blue-300 hover:text-blue-200">Check BoldDesk pricing →</a>
+          </div>
+        </div>
+        <p class="text-[11px] text-slate-500">Pricing snapshot checked against the vendors' public pages on September 3, 2026. Always verify the live checkout or pricing page before paying.</p>
+      </section>
 
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
+        <h2 class="text-xl font-bold text-white">Side-by-side capabilities</h2>
         <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/vista-social.html" class="hover:text-purple-300">Vista Social</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/bolddesk.html" class="hover:text-blue-300">BoldDesk</a>
-          </div>
+          <a href="/tool/vista-social.html" class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white hover:text-purple-300">Vista Social</a>
+          <a href="/tool/bolddesk.html" class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white hover:text-blue-300">BoldDesk</a>
         </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Vista Social Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ AI-powered social media management</div>
-<div>✓ Content publishing and scheduling</div>
-<div>✓ Engagement tracking and analytics</div>
-<div>✓ Team collaboration workflows</div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs font-bold text-purple-300 uppercase tracking-wider mb-3">Vista Social strengths</div>
+            <div class="space-y-2 text-sm text-slate-300">
+              <div>✓ Social publishing and scheduling</div>
+              <div>✓ Engagement and message management</div>
+              <div>✓ Reporting and analytics</div>
+              <div>✓ Team collaboration and approval workflows</div>
+              <div>✓ DM automation and social listening options</div>
             </div>
           </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">BoldDesk Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Ticket Management System</div>
-<div>✓ Self-Service Portal (Knowledge Base)</div>
-<div>✓ Automated Workflow Rules</div>
-<div>✓ Reporting & Analytics</div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs font-bold text-blue-300 uppercase tracking-wider mb-3">BoldDesk strengths</div>
+            <div class="space-y-2 text-sm text-slate-300">
+              <div>✓ Omnichannel ticketing and live chat</div>
+              <div>✓ Workflow automation and SLA management</div>
+              <div>✓ Knowledge base and customer portal</div>
+              <div>✓ AI Copilot and AI Agents</div>
+              <div>✓ Advanced reports and custom dashboards</div>
             </div>
           </div>
         </div>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a data-cta="affiliate" href="https://vistasocial.com?fpr=sangkwon14" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Vista Social →</a>
-          <a href="https://www.bolddesk.com/?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get BoldDesk →</a>
+      <section class="p-6 rounded-3xl bg-gradient-to-br from-purple-500/10 to-blue-500/10 border border-purple-500/20 space-y-4">
+        <h2 class="text-xl font-black text-white">Bottom line</h2>
+        <p class="text-slate-300 leading-relaxed">Do not choose between these two on brand recognition alone: choose based on the workflow producing the cost. Social publishing, engagement and reporting point to Vista Social. Support tickets, live chat and service automation point to BoldDesk. Both currently offer no-card trials, so the lowest-risk next step is to test the product that matches your actual bottleneck.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <a data-cta="affiliate" data-tool-id="vista-social" href="https://vistasocial.com?fpr=sangkwon14" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center transition-all">Start Vista Social trial →</a>
+          <a data-cta="affiliate" data-tool-id="bolddesk" href="https://www.bolddesk.com/?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center transition-all">Start BoldDesk trial →</a>
         </div>
-      </div>
+      </section>
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
+    <script defer src="/affiliate-attribution.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Revenue-focused, no-cost update grounded in current vendor pages and existing verified affiliate records.

- Moves both verified revenue CTAs into the first screen and repeats them at the final decision point.
- Adds `data-tool-id` for Vista Social and BoldDesk plus `/affiliate-attribution.js` so COSHUMA can distinguish affiliate clicks by product.
- Replaces generic `Not rated` decision copy with buyer-fit guidance: social-media operations vs customer-support operations.
- Refreshes the public pricing/trial snapshot checked on 2026-09-03.
- Preserves the exact verified tracking routes already recorded in the repository.
- Adds explicit affiliate disclosure. No paid service or subscription added.