### PR TITLE
Optimize Merlin buyer-intent comparison revenue paths

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/merlin-vs-bolddesk.html
+++ b/projects/GlobalSaaSHub/public/compare/merlin-vs-bolddesk.html
@@ -1,172 +1,103 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Merlin vs BoldDesk Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Merlin vs BoldDesk. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Merlin vs BoldDesk: AI Assistant or Help Desk? (2026) | GlobalSaaSHub</title>
+  <meta name="description" content="Merlin vs BoldDesk for 2026: choose Merlin for multi-model AI and browser productivity, or BoldDesk for ticketing, live chat, omnichannel support and help-desk automation. Current pricing and free-trial guidance." />
+  <link rel="canonical" href="https://coshuma.com/compare/merlin-vs-bolddesk.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/merlin-vs-bolddesk.html" />
+  <meta property="og:title" content="Merlin vs BoldDesk: AI Assistant or Help Desk? (2026)" />
+  <meta property="og:description" content="A buyer-focused comparison of two products built for very different jobs." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"WebPage",
+    "name":"Merlin vs BoldDesk: AI Assistant or Help Desk?",
+    "url":"https://coshuma.com/compare/merlin-vs-bolddesk.html",
+    "dateModified":"2026-09-03",
+    "about":[
+      {"@type":"SoftwareApplication","name":"Merlin AI","url":"https://www.getmerlin.in/"},
+      {"@type":"SoftwareApplication","name":"BoldDesk","url":"https://www.bolddesk.com/"}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen flex flex-col justify-between">
+  <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+    <div class="max-w-6xl mx-auto flex items-center justify-between">
+      <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div><span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span></a>
+      <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">← Back to All Tools</a>
+    </div>
+  </header>
 
-    <link rel="canonical" href="https://coshuma.com/compare/merlin-vs-bolddesk.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/merlin-vs-bolddesk.html" />
-    <meta property="og:title" content="Merlin vs BoldDesk Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Merlin and BoldDesk by pricing, features, and verified public information." />
+  <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
+    <section class="text-center space-y-4">
+      <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Buyer-intent comparison · verified Sep. 3, 2026</div>
+      <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Merlin vs BoldDesk</h1>
+      <p class="text-slate-300 text-base max-w-2xl mx-auto leading-relaxed">These are not substitutes. <strong class="text-white">Merlin</strong> is an AI assistant for research, writing, summarization and browser work. <strong class="text-white">BoldDesk</strong> is a customer-support platform for tickets, live chat, omnichannel messaging, knowledge base and automation.</p>
+    </section>
 
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "Merlin vs BoldDesk Comparison",
-      "url": "https://coshuma.com/compare/merlin-vs-bolddesk.html",
-      "description": "Compare Merlin and BoldDesk by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "Merlin", "url": "https://coshuma.com/tool/merlin.html"},
-        {"@type": "SoftwareApplication", "name": "BoldDesk", "url": "https://coshuma.com/tool/bolddesk.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
-      </div>
-    </header>
-
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
+    <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-5">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="p-5 rounded-2xl bg-purple-500/10 border border-purple-500/25 space-y-3">
+          <div class="text-xs uppercase tracking-wider font-bold text-purple-300">Choose Merlin when</div>
+          <h2 class="text-xl font-extrabold text-white">Your bottleneck is individual AI work</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">Best fit for people who want multiple AI models, web research, summarization, creation tools and a Chrome/browser assistant in one product.</p>
+          <div class="text-sm text-emerald-300 font-bold">Free $0 · Pro $19/mo on the current annual-plan view</div>
+          <a data-cta="affiliate" data-tool-id="merlin" href="https://www.getmerlin.in/chat?ref=yjeyytn" target="_blank" rel="sponsored noopener noreferrer" class="block py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center">Try Merlin Free →</a>
         </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Merlin vs BoldDesk</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Workflow Automation tool.
-        </p>
-      </div>
-
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Merlin if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose BoldDesk if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
+        <div class="p-5 rounded-2xl bg-blue-500/10 border border-blue-500/25 space-y-3">
+          <div class="text-xs uppercase tracking-wider font-bold text-blue-300">Choose BoldDesk when</div>
+          <h2 class="text-xl font-extrabold text-white">Your bottleneck is customer support operations</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">Best fit for teams that need help-desk ticketing, live chat, 10+ support channels, workflow/SLA automation, knowledge base, reporting and AI support features.</p>
+          <div class="text-sm text-emerald-300 font-bold">From $99/mo for 5 agents billed yearly · 15-day trial</div>
+          <a data-cta="affiliate" data-tool-id="bolddesk" href="https://www.bolddesk.com/?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="block py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center">Start BoldDesk Free Trial →</a>
         </div>
       </div>
+      <p class="text-[11px] text-slate-400">Affiliate disclosure: COSHUMA may earn a commission if you purchase after using either verified partner link, at no extra cost to you.</p>
+    </section>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/merlin.html" class="hover:text-purple-300">Merlin</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/bolddesk.html" class="hover:text-blue-300">BoldDesk</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Merlin Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ AI-powered summarization</div>
-<div>✓ Intelligent content generation</div>
-<div>✓ Workflow automation capabilities</div>
-<div>✓ Cross-platform integration</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">BoldDesk Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Ticket Management System</div>
-<div>✓ Self-Service Portal (Knowledge Base)</div>
-<div>✓ Automated Workflow Rules</div>
-<div>✓ Reporting & Analytics</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://www.getmerlin.in/chat?ref=yjeyytn" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Merlin →</a>
-          <a href="https://www.bolddesk.com/?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get BoldDesk →</a>
-        </div>
+    <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+      <h2 class="text-2xl font-extrabold text-white">Quick decision table</h2>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm border-collapse">
+          <thead><tr class="text-left text-slate-400 border-b border-[#2b2e42]"><th class="py-3 pr-4">Question</th><th class="py-3 pr-4 text-purple-300">Merlin</th><th class="py-3 text-blue-300">BoldDesk</th></tr></thead>
+          <tbody class="text-slate-300">
+            <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold text-white">Primary job</td><td class="py-3 pr-4">AI assistant & browser productivity</td><td class="py-3">Customer-support operations</td></tr>
+            <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold text-white">Start free?</td><td class="py-3 pr-4">Yes, $0 plan</td><td class="py-3">Yes, 15-day trial; no credit card required</td></tr>
+            <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold text-white">Paid reference</td><td class="py-3 pr-4">Pro $19/mo on annual pricing view</td><td class="py-3">5 agents: $99/mo billed yearly</td></tr>
+            <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold text-white">AI models</td><td class="py-3 pr-4">Multiple major model families in one assistant</td><td class="py-3">AI Copilot/Agents inside support workflows</td></tr>
+            <tr><td class="py-3 pr-4 font-bold text-white">Use it when</td><td class="py-3 pr-4">You personally research, write, summarize, analyze or create</td><td class="py-3">A team receives and resolves customer conversations</td></tr>
+          </tbody>
+        </table>
       </div>
-    </main>
+      <p class="text-[11px] text-slate-500">Pricing and feature references checked against the vendors' official pages on September 3, 2026. Merlin enforces fair-use limits; BoldDesk pricing varies by agent count and billing cadence. Confirm checkout terms before purchase.</p>
+    </section>
 
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
+    <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div class="p-5 rounded-2xl bg-[#131520] border border-[#222538] space-y-3"><h2 class="text-lg font-bold text-white">Merlin is the better buy if…</h2><ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>You want one place for several AI model families.</li><li>You regularly summarize websites, videos or documents.</li><li>You want AI available inside browser workflows.</li><li>You can validate fit on a permanent free plan first.</li></ul></div>
+      <div class="p-5 rounded-2xl bg-[#131520] border border-[#222538] space-y-3"><h2 class="text-lg font-bold text-white">BoldDesk is the better buy if…</h2><ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>You need structured ticket ownership and support queues.</li><li>You support customers across email, chat, WhatsApp, social or voice.</li><li>You need SLAs, knowledge base, workflows and reporting.</li><li>You have at least a small support team rather than a solo AI workflow.</li></ul></div>
+    </section>
+
+    <section class="p-6 rounded-3xl bg-gradient-to-br from-purple-500/10 to-blue-500/10 border border-purple-500/30 space-y-4">
+      <h2 class="text-2xl font-extrabold text-white">Best next step: test the tool that matches the job</h2>
+      <p class="text-sm text-slate-300">Do not choose on the word “AI.” Choose on the workflow you need to fix. Merlin has a free plan; BoldDesk offers a 15-day trial with no credit card required.</p>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <a data-cta="affiliate" data-tool-id="merlin" href="https://www.getmerlin.in/chat?ref=yjeyytn" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center">Try Merlin Free →</a>
+        <a data-cta="affiliate" data-tool-id="bolddesk" href="https://www.bolddesk.com/?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center">Try BoldDesk Free →</a>
       </div>
-    </footer>
-  </body>
+      <div class="text-[11px] text-slate-500">Prefer official non-affiliate pages? <a href="https://www.getmerlin.in/pricing" target="_blank" rel="noopener noreferrer" class="underline">Merlin pricing</a> · <a href="https://www.bolddesk.com/pricing" target="_blank" rel="noopener noreferrer" class="underline">BoldDesk pricing</a>.</div>
+    </section>
+  </main>
+
+  <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div></footer>
+  <script src="/affiliate-attribution.js" defer></script>
+</body>
 </html>

--- a/projects/GlobalSaaSHub/public/compare/merlin-vs-notion-ai.html
+++ b/projects/GlobalSaaSHub/public/compare/merlin-vs-notion-ai.html
@@ -1,172 +1,103 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Merlin vs Notion AI Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Merlin vs Notion AI. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Merlin vs Notion AI: Which AI Workflow Fits Better? (2026) | GlobalSaaSHub</title>
+  <meta name="description" content="Merlin vs Notion AI for 2026: compare a multi-model browser AI assistant with workspace-native AI. Current plan guidance, best-fit use cases, and a verified Merlin partner link." />
+  <link rel="canonical" href="https://coshuma.com/compare/merlin-vs-notion-ai.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/merlin-vs-notion-ai.html" />
+  <meta property="og:title" content="Merlin vs Notion AI: Which AI Workflow Fits Better? (2026)" />
+  <meta property="og:description" content="Choose Merlin for cross-web AI work or Notion AI for AI embedded inside a shared workspace." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"WebPage",
+    "name":"Merlin vs Notion AI: Which AI Workflow Fits Better?",
+    "url":"https://coshuma.com/compare/merlin-vs-notion-ai.html",
+    "dateModified":"2026-09-03",
+    "about":[
+      {"@type":"SoftwareApplication","name":"Merlin AI","url":"https://www.getmerlin.in/"},
+      {"@type":"SoftwareApplication","name":"Notion AI","url":"https://www.notion.com/product/ai"}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen flex flex-col justify-between">
+  <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+    <div class="max-w-6xl mx-auto flex items-center justify-between">
+      <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div><span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span></a>
+      <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">← Back to All Tools</a>
+    </div>
+  </header>
 
-    <link rel="canonical" href="https://coshuma.com/compare/merlin-vs-notion-ai.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/merlin-vs-notion-ai.html" />
-    <meta property="og:title" content="Merlin vs Notion AI Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Merlin and Notion AI by pricing, features, and verified public information." />
+  <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
+    <section class="text-center space-y-4">
+      <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Buyer-intent comparison · verified Sep. 3, 2026</div>
+      <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Merlin vs Notion AI</h1>
+      <p class="text-slate-300 text-base max-w-2xl mx-auto leading-relaxed">Choose <strong class="text-white">Merlin</strong> when you want a multi-model AI assistant that follows you around the web. Choose <strong class="text-white">Notion AI</strong> when your documents, projects, meetings and company knowledge already live in Notion.</p>
+    </section>
 
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "Merlin vs Notion AI Comparison",
-      "url": "https://coshuma.com/compare/merlin-vs-notion-ai.html",
-      "description": "Compare Merlin and Notion AI by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "Merlin", "url": "https://coshuma.com/tool/merlin.html"},
-        {"@type": "SoftwareApplication", "name": "Notion AI", "url": "https://coshuma.com/tool/notion-ai.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
-      </div>
-    </header>
-
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
+    <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-5">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="p-5 rounded-2xl bg-purple-500/10 border border-purple-500/25 space-y-3">
+          <div class="text-xs uppercase tracking-wider font-bold text-purple-300">Choose Merlin when</div>
+          <h2 class="text-xl font-extrabold text-white">AI needs to work across websites and model providers</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">Merlin combines multiple AI model families with browser assistance, web research, summarization, creation tools and cross-device workflows.</p>
+          <div class="text-sm text-emerald-300 font-bold">Free $0 · Pro $19/mo on the current annual-plan view</div>
+          <a data-cta="affiliate" data-tool-id="merlin" href="https://www.getmerlin.in/chat?ref=yjeyytn" target="_blank" rel="sponsored noopener noreferrer" class="block py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center">Try Merlin Free →</a>
         </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Merlin vs Notion AI</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Workflow Automation tool.
-        </p>
-      </div>
-
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Merlin if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Notion AI if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with Free trial; Business plan with Notion AI at $20/user/month pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
+        <div class="p-5 rounded-2xl bg-blue-500/10 border border-blue-500/25 space-y-3">
+          <div class="text-xs uppercase tracking-wider font-bold text-blue-300">Choose Notion AI when</div>
+          <h2 class="text-xl font-extrabold text-white">AI needs your workspace context</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">Notion AI is built into the Notion workspace and can help with writing, databases, meeting notes, research and connected knowledge. Ongoing AI access is included with Business and Enterprise plans.</p>
+          <div class="text-sm text-emerald-300 font-bold">Business $20/seat/mo · Free/Plus get limited complimentary AI responses</div>
+          <a data-cta="official" data-tool-id="notion-ai" href="https://www.notion.com/product/ai" target="_blank" rel="noopener noreferrer" class="block py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center">See Notion AI →</a>
         </div>
       </div>
+      <p class="text-[11px] text-slate-400">Affiliate disclosure: COSHUMA may earn a commission if you purchase Merlin after using the verified Merlin partner link, at no extra cost to you. The Notion link on this page is an official non-affiliate link.</p>
+    </section>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/merlin.html" class="hover:text-purple-300">Merlin</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/notion-ai.html" class="hover:text-blue-300">Notion AI</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">Free trial; Business plan with Notion AI at $20/user/month</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Merlin Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ AI-powered summarization</div>
-<div>✓ Intelligent content generation</div>
-<div>✓ Workflow automation capabilities</div>
-<div>✓ Cross-platform integration</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Notion AI Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Inline Writing Help</div>
-<div>✓ Meeting Summaries</div>
-<div>✓ Database Automation</div>
-<div>✓ Custom Prompts</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://www.getmerlin.in/chat?ref=yjeyytn" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Merlin →</a>
-          <a href="https://www.notion.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Notion AI →</a>
-        </div>
+    <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+      <h2 class="text-2xl font-extrabold text-white">Quick decision table</h2>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm border-collapse">
+          <thead><tr class="text-left text-slate-400 border-b border-[#2b2e42]"><th class="py-3 pr-4">Question</th><th class="py-3 pr-4 text-purple-300">Merlin</th><th class="py-3 text-blue-300">Notion AI</th></tr></thead>
+          <tbody class="text-slate-300">
+            <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold text-white">Primary job</td><td class="py-3 pr-4">Cross-web AI assistant</td><td class="py-3">Workspace-native AI teammate</td></tr>
+            <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold text-white">Best context</td><td class="py-3 pr-4">Web pages, documents, videos, prompts and model switching</td><td class="py-3">Notion pages, databases, projects, meetings and connected work knowledge</td></tr>
+            <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold text-white">Start free?</td><td class="py-3 pr-4">Yes, permanent $0 plan</td><td class="py-3">Limited complimentary AI responses; eligible teams may receive a Business trial</td></tr>
+            <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold text-white">Paid reference</td><td class="py-3 pr-4">Pro $19/mo on annual pricing view</td><td class="py-3">Business $20/seat/mo; Enterprise contact sales</td></tr>
+            <tr><td class="py-3 pr-4 font-bold text-white">Best buyer</td><td class="py-3 pr-4">Individual power user who works across many sites/tools</td><td class="py-3">Team that already runs work and knowledge inside Notion</td></tr>
+          </tbody>
+        </table>
       </div>
-    </main>
+      <p class="text-[11px] text-slate-500">Checked against official Merlin and Notion pages on September 3, 2026. Merlin applies fair-use limits. Notion says Notion AI is available on Business and Enterprise for ongoing use, while Free and Plus receive limited complimentary AI responses; eligibility for paid-plan trials varies.</p>
+    </section>
 
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
+    <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div class="p-5 rounded-2xl bg-[#131520] border border-[#222538] space-y-3"><h2 class="text-lg font-bold text-white">Merlin wins if…</h2><ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>You want access to several major AI model families.</li><li>You summarize webpages, YouTube videos or documents frequently.</li><li>You want AI inside Chrome/browser workflows.</li><li>You are not committed to one workspace for all context.</li></ul></div>
+      <div class="p-5 rounded-2xl bg-[#131520] border border-[#222538] space-y-3"><h2 class="text-lg font-bold text-white">Notion AI wins if…</h2><ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>Your company knowledge already lives in Notion.</li><li>You want AI meeting notes, research and database work in the same workspace.</li><li>You need AI that can search connected work information with workspace context.</li><li>Your team is already considering Business or Enterprise for collaboration features.</li></ul></div>
+    </section>
+
+    <section class="p-6 rounded-3xl bg-gradient-to-br from-purple-500/10 to-blue-500/10 border border-purple-500/30 space-y-4">
+      <h2 class="text-2xl font-extrabold text-white">Best next step</h2>
+      <p class="text-sm text-slate-300">If you are evaluating a standalone AI assistant, start with Merlin's free plan and test your actual browser/research tasks. If your AI value depends on team docs, projects and shared knowledge, inspect Notion AI inside the workspace where that context already exists.</p>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <a data-cta="affiliate" data-tool-id="merlin" href="https://www.getmerlin.in/chat?ref=yjeyytn" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center">Try Merlin Free →</a>
+        <a data-cta="official" data-tool-id="notion-ai" href="https://www.notion.com/pricing" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center">See Notion Pricing →</a>
       </div>
-    </footer>
-  </body>
+      <div class="text-[11px] text-slate-500">Prefer Merlin's official non-affiliate pricing page? <a href="https://www.getmerlin.in/pricing" target="_blank" rel="noopener noreferrer" class="underline">View it here</a>.</div>
+    </section>
+  </main>
+
+  <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div></footer>
+  <script src="/affiliate-attribution.js" defer></script>
+</body>
 </html>


### PR DESCRIPTION
Revenue-focused, zero-cost optimization for Merlin buyer-intent traffic.

Grounding checked on 2026-09-03:
- Merlin's exact verified customer-facing referral URL is the Tapfiliate URL already recorded in the repository and approval email.
- Merlin official pricing currently shows Free $0 and Pro $19/month on the annual-plan view, with fair-use limits.
- BoldDesk official pricing shows $99/month for 5 agents billed yearly plus a 15-day free trial with no credit card required.
- Notion official pricing shows Business at $20/seat/month; Notion Help states ongoing Notion AI is included on Business/Enterprise, while Free/Plus receive limited complimentary AI responses.

Changes:
- replace generic `Not rated`/`See official pricing` comparison copy with actual job-to-be-done guidance;
- move verified Merlin and BoldDesk revenue CTAs above the fold and repeat them at the final decision point;
- add `data-cta`/`data-tool-id` attribution and load `/affiliate-attribution.js`;
- keep Notion explicitly non-affiliate and link only to official Notion pages;
- add dated pricing/trial context and affiliate disclosure.

No paid services, guessed tracking links, duplicate applications, or new subscriptions.