### PR TITLE
Optimize GoHighLevel vs Gallabox buyer conversion

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/gohighlevel-vs-gallabox.html
+++ b/projects/GlobalSaaSHub/public/compare/gohighlevel-vs-gallabox.html
@@ -1,172 +1,109 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>GoHighLevel vs Gallabox Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of GoHighLevel vs Gallabox. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>GoHighLevel vs Gallabox: Agency CRM or Omnichannel AI? (2026) | GlobalSaaSHub</title>
+  <meta name="description" content="GoHighLevel vs Gallabox for 2026: choose GoHighLevel for agency CRM, funnels, pipelines and broad marketing automation, or Gallabox for WhatsApp-first omnichannel AI conversations. Current pricing and trial guidance." />
+  <link rel="canonical" href="https://coshuma.com/compare/gohighlevel-vs-gallabox.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/gohighlevel-vs-gallabox.html" />
+  <meta property="og:title" content="GoHighLevel vs Gallabox: Agency CRM or Omnichannel AI? (2026)" />
+  <meta property="og:description" content="A buyer-focused comparison for teams deciding between an all-in-one agency growth platform and an omnichannel AI conversation platform." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"WebPage",
+    "name":"GoHighLevel vs Gallabox: Agency CRM or Omnichannel AI?",
+    "url":"https://coshuma.com/compare/gohighlevel-vs-gallabox.html",
+    "dateModified":"2026-09-03",
+    "about":[
+      {"@type":"SoftwareApplication","name":"GoHighLevel","url":"https://www.gohighlevel.com/"},
+      {"@type":"SoftwareApplication","name":"Gallabox","url":"https://gallabox.com/"}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen flex flex-col justify-between">
+  <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+    <div class="max-w-6xl mx-auto flex items-center justify-between">
+      <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div><span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span></a>
+      <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">← Back to All Tools</a>
+    </div>
+  </header>
 
-    <link rel="canonical" href="https://coshuma.com/compare/gohighlevel-vs-gallabox.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/gohighlevel-vs-gallabox.html" />
-    <meta property="og:title" content="GoHighLevel vs Gallabox Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare GoHighLevel and Gallabox by pricing, features, and verified public information." />
+  <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
+    <section class="text-center space-y-4">
+      <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Buyer-intent comparison · verified Sep. 3, 2026</div>
+      <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">GoHighLevel vs Gallabox</h1>
+      <p class="text-slate-300 text-base max-w-2xl mx-auto leading-relaxed"><strong class="text-white">GoHighLevel</strong> is the broader agency growth stack: CRM, pipelines, funnels, websites, calendars, messaging, payments and automation. <strong class="text-white">Gallabox</strong> is more focused on AI-powered customer conversations across WhatsApp, Instagram and web chat.</p>
+    </section>
 
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "GoHighLevel vs Gallabox Comparison",
-      "url": "https://coshuma.com/compare/gohighlevel-vs-gallabox.html",
-      "description": "Compare GoHighLevel and Gallabox by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "GoHighLevel", "url": "https://coshuma.com/tool/gohighlevel.html"},
-        {"@type": "SoftwareApplication", "name": "Gallabox", "url": "https://coshuma.com/tool/gallabox.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
-      </div>
-    </header>
-
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
+    <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-5">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="p-5 rounded-2xl bg-purple-500/10 border border-purple-500/25 space-y-3">
+          <div class="text-xs uppercase tracking-wider font-bold text-purple-300">Choose GoHighLevel when</div>
+          <h2 class="text-xl font-extrabold text-white">You need one operating system for agency growth</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">Best fit when CRM, pipelines, landing pages, funnels, calendars, email/SMS, reputation, payments and workflow automation need to live in the same platform.</p>
+          <div class="text-sm text-emerald-300 font-bold">Starter $97/mo · 14-day free trial</div>
+          <a data-cta="affiliate" data-tool-id="gohighlevel" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="block py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center">Start GoHighLevel Trial →</a>
         </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">GoHighLevel vs Gallabox</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Chatbots & Support tool.
-        </p>
-      </div>
-
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose GoHighLevel if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Gallabox if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
+        <div class="p-5 rounded-2xl bg-blue-500/10 border border-blue-500/25 space-y-3">
+          <div class="text-xs uppercase tracking-wider font-bold text-blue-300">Choose Gallabox when</div>
+          <h2 class="text-xl font-extrabold text-white">Your bottleneck is inbound conversations</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">Best fit when WhatsApp, Instagram and web inquiries need instant capture, AI qualification, shared-inbox handling, campaigns and conversation automation.</p>
+          <div class="text-sm text-emerald-300 font-bold">Basic $150/mo billed quarterly · free trial, no card required</div>
+          <a data-cta="official" data-tool-id="gallabox" href="https://gallabox.com/pricing" target="_blank" rel="noopener noreferrer" class="block py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center">View Gallabox Pricing →</a>
         </div>
       </div>
+      <p class="text-[11px] text-slate-400">Affiliate disclosure: COSHUMA may earn a commission if you purchase GoHighLevel after using the verified partner link, at no extra cost to you. Gallabox is linked to its official page because no verified COSHUMA affiliate URL is currently published for it.</p>
+    </section>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/gohighlevel.html" class="hover:text-purple-300">GoHighLevel</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/gallabox.html" class="hover:text-blue-300">Gallabox</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">GoHighLevel Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ CRM & Pipeline</div>
-<div>✓ Automated SMS/Email</div>
-<div>✓ Sales Funnels</div>
-<div>✓ AI Chatbots</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Gallabox Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ WhatsApp Business API integration</div>
-<div>✓ Automated marketing campaigns</div>
-<div>✓ Lead generation and qualification</div>
-<div>✓ Customer support chatbots</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get GoHighLevel →</a>
-          <a href="https://www.gallabox.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Gallabox →</a>
-        </div>
+    <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+      <h2 class="text-2xl font-extrabold text-white">Quick decision table</h2>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm border-collapse">
+          <thead><tr class="text-left text-slate-400 border-b border-[#2b2e42]"><th class="py-3 pr-4">Question</th><th class="py-3 pr-4 text-purple-300">GoHighLevel</th><th class="py-3 text-blue-300">Gallabox</th></tr></thead>
+          <tbody class="text-slate-300">
+            <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold text-white">Primary job</td><td class="py-3 pr-4">All-in-one CRM, marketing and agency automation</td><td class="py-3">Omnichannel conversational AI and lead handling</td></tr>
+            <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold text-white">Start free?</td><td class="py-3 pr-4">14-day free trial</td><td class="py-3">Free trial with 500 AI credits; no credit card required</td></tr>
+            <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold text-white">Entry price reference</td><td class="py-3 pr-4">Starter $97/mo</td><td class="py-3">Basic $150/mo, billed quarterly</td></tr>
+            <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold text-white">Best-known channels/workflows</td><td class="py-3 pr-4">CRM, funnels, websites, calendars, email, SMS, calls, payments</td><td class="py-3">WhatsApp, Instagram and website chat</td></tr>
+            <tr><td class="py-3 pr-4 font-bold text-white">Best fit</td><td class="py-3 pr-4">Agencies or businesses replacing multiple growth tools</td><td class="py-3">Teams where inbound chat conversion and follow-up are the core bottleneck</td></tr>
+          </tbody>
+        </table>
       </div>
-    </main>
+      <p class="text-[11px] text-slate-500">Pricing and feature references checked against the vendors' official pricing/product pages on September 3, 2026. GoHighLevel lists usage-based charges and optional add-ons for some telecom/AI capabilities. Gallabox bills WhatsApp/voice usage separately from its platform fee. Confirm checkout terms before purchase.</p>
+    </section>
 
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
+    <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div class="p-5 rounded-2xl bg-[#131520] border border-[#222538] space-y-3">
+        <h2 class="text-lg font-bold text-white">GoHighLevel is the better buy if…</h2>
+        <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>You manage multiple clients or sub-accounts.</li><li>You want CRM, funnels, calendars, messaging and payments together.</li><li>You need broad workflow automation beyond chat.</li><li>You may later use agency rebilling, SaaS mode or white-label workflows.</li></ul>
       </div>
-    </footer>
-  </body>
+      <div class="p-5 rounded-2xl bg-[#131520] border border-[#222538] space-y-3">
+        <h2 class="text-lg font-bold text-white">Gallabox is the better buy if…</h2>
+        <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>Your leads arrive mainly through WhatsApp, Instagram or web chat.</li><li>You want AI to qualify, reply and follow up inside conversations.</li><li>You need a shared inbox and campaign automation around messaging channels.</li><li>You do not need a full agency CRM/funnel stack.</li></ul>
+      </div>
+    </section>
+
+    <section class="p-6 rounded-3xl bg-gradient-to-br from-purple-500/10 to-blue-500/10 border border-purple-500/30 space-y-4">
+      <h2 class="text-2xl font-extrabold text-white">Best next step: test the platform that matches the bottleneck</h2>
+      <p class="text-sm text-slate-300">If you are consolidating agency growth tools, start with GoHighLevel's trial. If the real problem is converting and managing WhatsApp/Instagram/web conversations, review Gallabox's current trial and channel limits first.</p>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <a data-cta="affiliate" data-tool-id="gohighlevel" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center">Try GoHighLevel →</a>
+        <a data-cta="official" data-tool-id="gallabox" href="https://gallabox.com/pricing" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center">Check Gallabox →</a>
+      </div>
+      <div class="text-[11px] text-slate-500">Prefer official non-affiliate pages? <a href="https://www.gohighlevel.com/pricing" target="_blank" rel="noopener noreferrer" class="underline">GoHighLevel pricing</a> · <a href="https://gallabox.com/pricing" target="_blank" rel="noopener noreferrer" class="underline">Gallabox pricing</a>.</div>
+    </section>
+  </main>
+
+  <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div></footer>
+  <script src="/affiliate-attribution.js" defer></script>
+</body>
 </html>


### PR DESCRIPTION
Revenue-focused no-cost update for GlobalSaaSHub:

- replaces generic `Not rated` / `See official pricing` copy with buyer-fit guidance
- moves the verified GoHighLevel partner CTA into high-intent positions
- adds per-product attribution via `data-cta`, `data-tool-id`, and `/affiliate-attribution.js`
- keeps Gallabox on official non-affiliate pricing because no verified COSHUMA referral URL is available
- refreshes pricing/trial context from official vendor pages checked 2026-09-03
- adds clear affiliate disclosure

No paid services or guessed referral parameters used.