### PR TITLE
Optimize Text affiliate conversion with current 2026 hooks

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/text-vs-gohighlevel.html
+++ b/projects/GlobalSaaSHub/public/compare/text-vs-gohighlevel.html
@@ -4,13 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Text vs GoHighLevel: Pricing, Features & Best Fit (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Compare Text vs GoHighLevel for customer service, CRM, sales automation and agency workflows. See current public pricing, core differences, and which platform fits your use case in 2026." />
+    <meta name="description" content="Compare Text vs GoHighLevel for AI customer service, ecommerce sales, CRM and marketing automation. See current public pricing and verified partner trial links." />
 
     <link rel="canonical" href="https://coshuma.com/compare/text-vs-gohighlevel.html" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/compare/text-vs-gohighlevel.html" />
     <meta property="og:title" content="Text vs GoHighLevel: Pricing & Best Fit (2026)" />
-    <meta property="og:description" content="Text is focused on AI customer service and live support; GoHighLevel is an all-in-one CRM and marketing platform for agencies and businesses. Compare current public pricing and best-fit use cases." />
+    <meta property="og:description" content="Text is focused on AI customer service and ecommerce conversations; GoHighLevel is an all-in-one CRM and marketing platform for agencies and businesses." />
 
     <script type="application/ld+json">
     {
@@ -18,7 +18,7 @@
       "@type": "WebPage",
       "name": "Text vs GoHighLevel: Pricing, Features & Best Fit (2026)",
       "url": "https://coshuma.com/compare/text-vs-gohighlevel.html",
-      "description": "Compare Text and GoHighLevel by current public pricing, customer-service capabilities, CRM and marketing automation features, and best-fit use cases.",
+      "description": "Compare Text and GoHighLevel by current public pricing, customer-service capabilities, ecommerce sales workflows, CRM and marketing automation features.",
       "isPartOf": {
         "@type": "WebSite",
         "name": "GlobalSaaSHub",
@@ -32,6 +32,7 @@
     </script>
 
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="/affiliate-attribution.js" defer></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
@@ -53,28 +54,43 @@
 
     <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
       <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">⚖️ Customer Service vs All-in-One CRM</div>
+        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">⚖️ AI Customer Service vs All-in-One CRM</div>
         <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Text vs GoHighLevel</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">Text is built around AI customer service, live chat and ticketing. GoHighLevel combines CRM, funnels, automation, scheduling and agency sub-accounts. This comparison focuses on current public pricing and practical fit.</p>
+        <p class="text-slate-400 text-sm max-w-2xl mx-auto">Choose Text when customer conversations, ecommerce assistance and support automation are the bottleneck. Choose GoHighLevel when you need CRM, funnels, booking, marketing automation and agency sub-accounts in one stack.</p>
       </div>
 
       <div class="p-4 rounded-2xl bg-amber-500/5 border border-amber-500/20 text-xs text-slate-300 leading-relaxed">
         <strong class="text-amber-300">Affiliate disclosure:</strong> GlobalSaaSHub may earn a commission if you sign up through the buttons on this page. That does not change the price you pay. Pricing can change, so confirm the final amount on the vendor checkout page.
       </div>
 
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="p-5 rounded-2xl bg-purple-500/10 border border-purple-500/25 space-y-3">
+          <div class="text-xs uppercase tracking-wider font-extrabold text-purple-300">Best for AI customer service</div>
+          <h2 class="text-xl font-bold text-white">Try Text if support should also help sell</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">Text combines AI Agents, live chat and ticketing, and its newer ecommerce tools can recommend products from connected catalogs and report revenue tied to conversations.</p>
+          <a data-cta="affiliate" data-tool-id="text" href="https://www.text.com/?a=8IetMhQvR&utm_campaign=pp_text-wins-martech-awards&utm_source=PP" target="_blank" rel="sponsored noopener noreferrer" class="block py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center transition-all">Start Text's 14-Day Trial →</a>
+        </div>
+        <div class="p-5 rounded-2xl bg-blue-500/10 border border-blue-500/25 space-y-3">
+          <div class="text-xs uppercase tracking-wider font-extrabold text-blue-300">Best for CRM & agency operations</div>
+          <h2 class="text-xl font-bold text-white">Try GoHighLevel if the whole funnel is the bottleneck</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">HighLevel combines CRM, pipelines, funnels, booking, email/SMS automation, payments and multiple sub-accounts, with a 14-day free trial for new customers.</p>
+          <a data-cta="affiliate" data-tool-id="gohighlevel" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="block py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center transition-all">Start GoHighLevel's 14-Day Trial →</a>
+        </div>
+      </section>
+
       <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
         <div class="flex items-center justify-between gap-3 flex-wrap">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2"><span>🧠 Which one should you choose?</span></h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">✓ Official public data checked September 01, 2026</span>
+          <h2 class="text-lg font-bold text-white">Which one should you choose?</h2>
+          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">✓ Official public data checked September 3, 2026</span>
         </div>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
           <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
             <div class="font-bold text-purple-300">Choose Text if:</div>
-            <p class="text-slate-300 leading-relaxed">Your priority is customer service: AI agents, live chat, inbox/ticketing, human handoff and support workflows in one platform. Text currently lists Essential at $19/user/month and Growth at $79/user/month when billed yearly.</p>
+            <p class="text-slate-300 leading-relaxed">Your priority is customer service: AI agents, live chat, inbox/ticketing, human handoff and support workflows. It is increasingly compelling for ecommerce because product recommendations can work from connected catalogs and sales reports can tie conversations to revenue.</p>
           </div>
           <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
             <div class="font-bold text-blue-300">Choose GoHighLevel if:</div>
-            <p class="text-slate-300 leading-relaxed">You need a broader sales and marketing stack: CRM, pipelines, funnels, booking, email/SMS automation and multiple client sub-accounts. Current public pricing lists Starter at $97/month, Unlimited at $297/month and Pro/SaaS Pro at $497/month.</p>
+            <p class="text-slate-300 leading-relaxed">You need a broader sales and marketing stack: CRM, pipelines, funnels, booking, email/SMS automation and multiple client sub-accounts. Current official pricing lists Starter at $97/month, Unlimited at $297/month and Agency Pro at $497/month.</p>
           </div>
         </div>
       </div>
@@ -88,26 +104,20 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Core Focus</div>
-            <div class="text-sm font-extrabold text-purple-300">AI customer service & support</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Core Focus</div>
-            <div class="text-sm font-extrabold text-blue-300">CRM, marketing & agency operations</div>
-          </div>
+          <div><div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Core Focus</div><div class="text-sm font-extrabold text-purple-300">AI customer service & ecommerce conversations</div></div>
+          <div><div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Core Focus</div><div class="text-sm font-extrabold text-blue-300">CRM, marketing & agency operations</div></div>
         </div>
 
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
           <div>
             <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Public Pricing</div>
             <div class="text-base font-extrabold text-emerald-400">$19 Essential / $79 Growth</div>
-            <div class="text-[10px] text-slate-400 mt-1">per user/month, billed yearly; monthly billing shown by Text is $25 / $99</div>
+            <div class="text-[10px] text-slate-400 mt-1">per user/month when billed yearly on Text's current pricing page</div>
           </div>
           <div>
             <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Public Pricing</div>
             <div class="text-base font-extrabold text-emerald-400">$97 / $297 / $497 per month</div>
-            <div class="text-[10px] text-slate-400 mt-1">Starter / Unlimited / Pro or SaaS Pro on current official HighLevel pages</div>
+            <div class="text-[10px] text-slate-400 mt-1">Starter / Unlimited / Agency Pro on HighLevel's current official pricing page</div>
           </div>
         </div>
 
@@ -115,10 +125,10 @@
           <div>
             <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Text strengths</div>
             <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ AI Agent included in paid plans</div>
-              <div>✓ Live chat, inbox and ticketing</div>
-              <div>✓ AI Copilot and reply assistance</div>
-              <div>✓ Email, messaging and ecommerce integrations</div>
+              <div>✓ AI Agent, live chat, inbox and ticketing</div>
+              <div>✓ Product recommendations from connected catalogs</div>
+              <div>✓ Sales reports for chat and AI-agent revenue</div>
+              <div>✓ Text access through the ChatGPT marketplace</div>
             </div>
           </div>
           <div>
@@ -133,10 +143,12 @@
         </div>
 
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 pt-2">
-          <a data-cta="affiliate" data-tool-id="text" href="https://www.text.com/?a=8IetMhQvR&utm_campaign=pp_text-wins-martech-awards&utm_source=PP" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Check Text pricing →</a>
-          <a data-cta="affiliate" data-tool-id="gohighlevel" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Check GoHighLevel pricing →</a>
+          <a data-cta="affiliate" data-tool-id="text" href="https://www.text.com/?a=8IetMhQvR&utm_campaign=pp_text-wins-martech-awards&utm_source=PP" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Try Text Free for 14 Days →</a>
+          <a data-cta="affiliate" data-tool-id="gohighlevel" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Try GoHighLevel Free for 14 Days →</a>
         </div>
       </div>
+
+      <div class="p-5 rounded-2xl bg-[#0b0c10] border border-[#222538] text-xs text-slate-400 leading-relaxed"><strong class="text-slate-300">Verification note:</strong> Text feature updates and partner guidance were checked against official Text sources through September 3, 2026. HighLevel pricing and its standard 14-day new-customer trial were checked against HighLevel's official pricing page. Both revenue buttons use COSHUMA's previously verified customer-facing affiliate URLs.</div>
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">

--- a/projects/GlobalSaaSHub/public/tool/text.html
+++ b/projects/GlobalSaaSHub/public/tool/text.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Text Pricing, 14-Day Trial & AI Customer Service Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Compare Text Essential and Growth pricing, AI Agent limits, live chat and help desk features, and start the 14-day trial through COSHUMA's verified affiliate link." />
+    <meta name="description" content="Compare Text pricing, AI customer service, ecommerce selling features, ChatGPT integration and the 14-day trial through COSHUMA's verified affiliate link." />
     <link rel="canonical" href="https://coshuma.com/tool/text.html" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/text.html" />
     <meta property="og:title" content="Text Pricing, 14-Day Trial & AI Customer Service Review (2026)" />
-    <meta property="og:description" content="Current Text pricing, AI customer-service plan guidance and a verified partner CTA." />
+    <meta property="og:description" content="Current Text pricing, ecommerce AI features, ChatGPT integration and a verified partner CTA." />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -21,6 +21,7 @@
     }
     </script>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="/affiliate-attribution.js" defer></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
@@ -46,14 +47,14 @@
 
         <section class="p-5 rounded-2xl bg-purple-500/10 border border-purple-500/25 space-y-3">
           <div class="text-xs uppercase tracking-wider font-extrabold text-purple-300">Quick recommendation</div>
-          <p class="text-slate-200 leading-relaxed">Start with the <strong>14-day free trial</strong> if you want to test AI Agents, live chat and help desk workflows without a credit card. Essential fits smaller teams; Growth is aimed at teams that need more AI Agents, resolutions, visitor tracking and proactive campaigns.</p>
+          <p class="text-slate-200 leading-relaxed">Start with the <strong>14-day free trial</strong> if you want to test AI Agents, live chat and help desk workflows without a credit card. Text is especially worth a look for ecommerce teams that want product recommendations inside chat and clearer sales attribution.</p>
           <a data-cta="affiliate" data-tool-id="text" href="https://www.text.com/?a=8IetMhQvR&utm_campaign=pp_text-wins-martech-awards&utm_source=PP" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex items-center justify-center px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start Text's 14-Day Trial →</a>
           <p class="text-[11px] text-slate-400">Affiliate disclosure: COSHUMA may earn a commission if you become a paying customer through this verified link, at no extra cost to you.</p>
         </section>
 
         <section class="space-y-4">
           <h2 class="text-xl font-bold text-white">Current Text pricing</h2>
-          <p class="text-sm text-slate-400">Pricing checked against Text's official pricing page on September 2, 2026. The public page currently highlights annual billing and says yearly billing can save up to 24%. Final pricing and limits should be confirmed at checkout.</p>
+          <p class="text-sm text-slate-400">Pricing checked against Text's official pricing page in September 2026. The public page highlights annual billing and says yearly billing can save up to 24%. Final pricing and limits should be confirmed at checkout.</p>
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-emerald-400 font-extrabold">Essential — $19/user/mo</div><p class="text-sm text-slate-300 mt-2">Displayed with yearly billing. Includes 1 AI Agent, 10 AI resolutions, 50 live visitors tracked, 10,000 API calls, 3 proactive campaigns, AI Copilot, inbox/ticketing and workflow automation.</p></div>
             <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-emerald-400 font-extrabold">Growth — $79/user/mo</div><p class="text-sm text-slate-300 mt-2">Displayed with yearly billing. Adds 10 AI Agents, 200 AI resolutions, 400 live visitors tracked, 20,000 API calls and 30 proactive campaigns.</p></div>
@@ -71,8 +72,21 @@
           </div>
         </section>
 
+        <section class="space-y-4 p-6 rounded-2xl bg-indigo-500/5 border border-indigo-500/20">
+          <div>
+            <div class="text-xs uppercase tracking-wider font-extrabold text-indigo-300">Fresh 2026 conversion hooks</div>
+            <h2 class="text-xl font-bold text-white mt-1">Why ecommerce teams should look at Text now</h2>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-indigo-300 text-sm">Sell from any catalog</div><p class="text-xs text-slate-300 mt-2 leading-relaxed">Text's AI Agent can recommend products from a catalog connected through its API, so this is no longer limited to one storefront platform.</p></div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-indigo-300 text-sm">Tie chats to revenue</div><p class="text-xs text-slate-300 mt-2 leading-relaxed">Sales reporting can compare revenue and conversion across AI-agent chats, human-agent chats and visits without chat, reducing guesswork about support ROI.</p></div>
+            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-indigo-300 text-sm">Use Text inside ChatGPT</div><p class="text-xs text-slate-300 mt-2 leading-relaxed">Text is available in the ChatGPT marketplace, letting connected users query their own chats and tickets from ChatGPT while respecting their Text permissions.</p></div>
+          </div>
+          <a data-cta="affiliate" data-tool-id="text" href="https://www.text.com/?a=8IetMhQvR&utm_campaign=pp_text-wins-martech-awards&utm_source=PP" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex items-center justify-center px-6 py-3.5 rounded-xl font-extrabold text-sm bg-indigo-600 hover:bg-indigo-500 text-white transition-all">Test Text with Your Store →</a>
+        </section>
+
         <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2"><h3 class="text-sm font-bold text-emerald-400">Best reasons to choose Text</h3><ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>Combines AI support, chat and ticketing in one platform.</li><li>No-card 14-day trial reduces the risk of testing it.</li><li>Built-in proactive campaigns can support sales as well as support.</li><li>Essential provides a low-cost entry point for smaller teams.</li></ul></div>
+          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2"><h3 class="text-sm font-bold text-emerald-400">Best reasons to choose Text</h3><ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>Combines AI support, chat and ticketing in one platform.</li><li>No-card 14-day trial reduces the risk of testing it.</li><li>Built-in proactive campaigns can support sales as well as support.</li><li>Recent ecommerce features connect conversations more directly to product discovery and revenue reporting.</li></ul></div>
           <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2"><h3 class="text-sm font-bold text-rose-400">Check before upgrading</h3><ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>Pricing is per user and AI-resolution limits differ by plan.</li><li>Growth is a substantial jump from Essential, so usage should justify it.</li><li>AI resolution refill charges can apply after included limits are exceeded.</li></ul></div>
         </section>
 
@@ -91,7 +105,7 @@
           <div class="flex flex-col sm:flex-row gap-3"><a data-cta="affiliate" data-tool-id="text" href="https://www.text.com/?a=8IetMhQvR&utm_campaign=pp_text-wins-martech-awards&utm_source=PP" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Try Text Free for 14 Days →</a><a data-cta="official" href="https://www.text.com/pricing/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-bold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Check Official Pricing</a></div>
         </section>
 
-        <section class="p-5 rounded-2xl bg-[#0b0c10] border border-[#222538] text-xs text-slate-400 leading-relaxed"><strong class="text-slate-300">Editorial note:</strong> This page is based on Text's current public pricing and partner documentation. COSHUMA does not claim hands-on testing where it has not been independently verified.</section>
+        <section class="p-5 rounded-2xl bg-[#0b0c10] border border-[#222538] text-xs text-slate-400 leading-relaxed"><strong class="text-slate-300">Editorial note:</strong> This page is based on Text's current public pricing, official product updates and partner communications checked through September 3, 2026. COSHUMA does not claim hands-on testing where it has not been independently verified.</section>
       </div>
     </main>
 


### PR DESCRIPTION
Revenue-focused, zero-cost update for GlobalSaaSHub:

- adds `/affiliate-attribution.js` to the Text detail and Text vs GoHighLevel buyer-intent pages so existing verified affiliate CTAs can emit product-level click attribution
- moves verified Text and GoHighLevel trial CTAs into higher-intent positions on the comparison page
- refreshes Text's conversion copy using official September 2026 evidence: catalog-based product recommendations, sales/revenue reporting tied to conversations, and Text's ChatGPT marketplace integration
- preserves the existing verified customer-facing affiliate URLs; no generic dashboard/onboarding links were introduced
- updates public-data verification language through September 3, 2026

Sources checked: Text Partner Program email received Sep 3, official Text product updates/help pages, and HighLevel's official pricing page. No paid services or subscriptions used.