### PR TITLE
Optimize n8n vs Make buyer conversion and queue Chatbase revenue link

### DIFF
--- a/projects/GlobalSaaSHub/data/browser_required_queue.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.json
@@ -57,5 +57,20 @@
       "Do not guess or construct a referral parameter or merchant link.",
       "Do not reapply to programs already pending, approved, rejected, cooling down or closed."
     ]
+  },
+  {
+    "id": "chatbase-dub-approved-referral-link",
+    "priority": "high",
+    "status": "browser_required",
+    "cost": "0",
+    "verified_at": "2026-09-03T19:56:00+09:00",
+    "reason": "Dub's August 26 approval email confirms that the existing COSHUMA Dub Partner account is approved for the Chatbase program and can earn up to 30% per sale for 1 year, but the email exposes only the authenticated Chatbase Links dashboard path rather than a customer-facing referral URL. Dub's August 30 network rejection explicitly says it affects only marketplace access and does not affect existing program partnerships or payouts. A newer email sent to support@coshuma.com asks for a new Dub Partner account to finish a separate Dub application, which would conflict with the existing rejected-network state and should not be treated as a reason to reapply.",
+    "next_action": "Reuse the already authenticated Dub Partner session for the existing account, open the Chatbase program Links area, copy the exact customer-facing unique referral URL, verify its destination and account-specific tracking identifier, then update Chatbase affiliate data and eligible COSHUMA detail/comparison CTAs. Preserve the existing Chatbase approval; do not create another Dub Partner Network application.",
+    "do_not": [
+      "Do not use the partners.dub.co Chatbase dashboard, Links page, earnings page, login page or email-tracking redirect as a customer revenue link.",
+      "Do not guess or construct a Chatbase referral parameter.",
+      "Do not create a second Dub Partner account with support@coshuma.com merely because the saved-application reminder email keeps arriving.",
+      "Do not reapply to the Dub Partner Network while the August 30 rejection/cooldown remains the latest authoritative network status."
+    ]
   }
 ]

--- a/projects/GlobalSaaSHub/public/compare/n8n-vs-make-com.html
+++ b/projects/GlobalSaaSHub/public/compare/n8n-vs-make-com.html
@@ -3,170 +3,141 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>n8n vs Make.com Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of n8n vs Make.com. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
-
+    <title>n8n vs Make.com: Pricing, Self-Hosting & Automation Winner (2026) | COSHUMA</title>
+    <meta name="description" content="Compare n8n vs Make.com for 2026 by hosted pricing, self-hosting, app integrations, AI workflows and buyer fit. See when Make is the faster choice and when n8n offers more control." />
     <link rel="canonical" href="https://coshuma.com/compare/n8n-vs-make-com.html" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/compare/n8n-vs-make-com.html" />
-    <meta property="og:title" content="n8n vs Make.com Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare n8n and Make.com by pricing, features, and verified public information." />
-
+    <meta property="og:title" content="n8n vs Make.com: Which Automation Platform Fits Better in 2026?" />
+    <meta property="og:description" content="Buyer-focused comparison of n8n and Make.com with current official pricing, deployment differences and a low-risk way to test both." />
     <script type="application/ld+json">
     {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "n8n vs Make.com Comparison",
-      "url": "https://coshuma.com/compare/n8n-vs-make-com.html",
-      "description": "Compare n8n and Make.com by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "n8n", "url": "https://coshuma.com/tool/n8n.html"},
-        {"@type": "SoftwareApplication", "name": "Make.com", "url": "https://coshuma.com/tool/make-com.html"}
+      "@context":"https://schema.org",
+      "@type":"WebPage",
+      "name":"n8n vs Make.com Comparison",
+      "url":"https://coshuma.com/compare/n8n-vs-make-com.html",
+      "description":"Compare n8n and Make.com by deployment model, current pricing, automation depth and buyer fit.",
+      "isPartOf":{"@type":"WebSite","name":"COSHUMA GlobalSaaSHub","url":"https://coshuma.com/"},
+      "about":[
+        {"@type":"SoftwareApplication","name":"n8n","url":"https://n8n.io/"},
+        {"@type":"SoftwareApplication","name":"Make.com","url":"https://www.make.com/"}
       ]
     }
     </script>
-    
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
+      body { font-family:'Inter',sans-serif; background:#0b0c10; color:#f1f5f9; }
+      h1,h2,h3 { font-family:'Outfit',sans-serif; }
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+    <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div><span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span></a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← All AI & SaaS Tools</a>
       </div>
     </header>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
+    <main class="max-w-5xl mx-auto px-4 py-10 w-full space-y-7">
+      <section class="p-7 md:p-9 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-6">
+        <div class="text-center space-y-3">
+          <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">WORKFLOW AUTOMATION · BUYER GUIDE</div>
+          <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">n8n vs Make.com</h1>
+          <p class="text-slate-300 max-w-3xl mx-auto leading-relaxed">Choose <strong>n8n</strong> when technical control, custom logic and self-hosting matter more. Choose <strong>Make.com</strong> when you want the fastest visual setup, a large managed app ecosystem and less infrastructure work.</p>
+          <p class="text-xs text-slate-500">Pricing and public product details checked September 3, 2026 against the vendors' official pages.</p>
         </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">n8n vs Make.com</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Coding & Dev Tools tool.
-        </p>
-      </div>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <article class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/25 space-y-3">
+            <div class="text-xs font-extrabold uppercase text-purple-300">Choose n8n if</div>
+            <h2 class="text-xl font-black text-white">You want more technical control</h2>
+            <ul class="text-sm text-slate-300 space-y-2">
+              <li>✓ Self-hosting is part of your architecture plan.</li>
+              <li>✓ Your team is comfortable with APIs, code and custom workflow logic.</li>
+              <li>✓ You want workflow pricing based on executions rather than every module action.</li>
+              <li>✓ AI-agent and backend-style automations are central use cases.</li>
+            </ul>
+            <a data-cta="official" href="https://n8n.io/pricing/" target="_blank" rel="noopener noreferrer" class="block px-5 py-3.5 rounded-xl bg-slate-800 border border-slate-600 hover:bg-slate-700 font-extrabold text-sm text-white text-center">Check n8n Official Pricing →</a>
+          </article>
+
+          <article class="p-5 rounded-2xl bg-gradient-to-br from-blue-500/10 to-purple-500/10 border border-blue-500/30 space-y-3">
+            <div class="text-xs font-extrabold uppercase text-blue-300">Choose Make.com if</div>
+            <h2 class="text-xl font-black text-white">You want the quickest managed start</h2>
+            <ul class="text-sm text-slate-300 space-y-2">
+              <li>✓ Nontechnical users need a visual builder.</li>
+              <li>✓ You want 3,000+ apps and prebuilt modules without managing servers.</li>
+              <li>✓ You prefer a permanent free plan for light automations.</li>
+              <li>✓ Your team values fast implementation over maximum infrastructure control.</li>
+            </ul>
+            <a data-cta="affiliate" data-tool-id="make-com" data-cta-source="compare_n8n_make_hero" href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="block px-5 py-3.5 rounded-xl bg-gradient-to-r from-blue-600 to-purple-600 hover:brightness-110 font-extrabold text-sm text-white text-center">Start Make.com Free via COSHUMA →</a>
+            <p class="text-[11px] text-slate-400">Affiliate disclosure: COSHUMA may earn a commission if you later become a qualifying paid Make customer through this verified partner link, at no extra cost to you.</p>
+          </article>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose n8n if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
+      </section>
+
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <div><h2 class="text-2xl font-black text-white">Current pricing snapshot</h2><p class="text-sm text-slate-400 mt-2">Use these figures as a buying reference, then confirm the final checkout because billing terms, usage tiers and regional taxes can change.</p></div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-3">
+            <div class="font-black text-white text-lg">n8n hosted plans</div>
+            <div class="text-sm text-slate-300 space-y-2">
+              <p><strong class="text-emerald-400">Starter:</strong> €20/month billed annually, 2,500 workflow executions, unlimited users, 1 shared project and 5 concurrent executions.</p>
+              <p><strong class="text-emerald-400">Pro:</strong> €50/month billed annually, 10,000 executions, 3 shared projects, admin roles, global variables and workflow history.</p>
+              <p><strong class="text-slate-200">Business:</strong> currently positioned as a self-hosted plan, with higher collaboration and governance features.</p>
             </div>
+            <p class="text-xs text-slate-500">n8n's official pages currently advertise a free trial with no credit card required for Starter and Pro.</p>
           </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Make.com if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-3">
+            <div class="font-black text-white text-lg">Make.com plans at 10,000 credits/month</div>
+            <div class="text-sm text-slate-300 space-y-2">
+              <p><strong class="text-emerald-400">Free:</strong> $0/month with up to 1,000 credits and a 15-minute minimum interval.</p>
+              <p><strong class="text-emerald-400">Core:</strong> $12/month for 10,000 credits, unlimited active scenarios and minute-level scheduling.</p>
+              <p><strong class="text-emerald-400">Pro:</strong> $21/month for 10,000 credits with priority execution and advanced controls.</p>
+              <p><strong class="text-emerald-400">Teams:</strong> $38/month for 10,000 credits with team roles and shared templates.</p>
             </div>
+            <p class="text-xs text-slate-500">Make says each module action generally consumes one credit, so complex scenarios can use multiple credits per run.</p>
           </div>
         </div>
-      </div>
+      </section>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/n8n.html" class="hover:text-purple-300">n8n</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/make-com.html" class="hover:text-blue-300">Make.com</a>
-          </div>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">The decision that matters more than headline price</h2>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-white">Deployment</div><p class="text-slate-400 text-xs mt-2 leading-relaxed">n8n gives technical teams a self-hosting path. Make is primarily a managed service, which removes server maintenance but gives you less infrastructure control.</p></div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-white">Usage model</div><p class="text-slate-400 text-xs mt-2 leading-relaxed">n8n emphasizes workflow executions with unlimited steps on current hosted plans. Make counts module actions as credits, so a single multi-step scenario can consume several credits.</p></div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-white">Skill level</div><p class="text-slate-400 text-xs mt-2 leading-relaxed">Make is generally easier for business users to adopt quickly. n8n becomes more attractive as workflows require custom code, deeper API logic or infrastructure ownership.</p></div>
         </div>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">Fast buyer scenarios</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20"><strong class="text-emerald-300">Pick Make:</strong><p class="text-slate-300 mt-2">A marketing or operations team wants to connect forms, Sheets, CRM, email and AI services this week without managing infrastructure.</p></div>
+          <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/20"><strong class="text-purple-300">Pick n8n:</strong><p class="text-slate-300 mt-2">A technical team wants custom API logic, code-heavy transformations, AI agents or a self-hosted deployment integrated with internal systems.</p></div>
+          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20"><strong class="text-emerald-300">Start with Make Free:</strong><p class="text-slate-300 mt-2">Your automation volume is light and you want to prove the workflow before paying.</p></div>
+          <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/20"><strong class="text-purple-300">Trial n8n hosted:</strong><p class="text-slate-300 mt-2">You want to evaluate n8n's execution model and technical flexibility before deciding whether hosted or self-hosted deployment is the better long-term path.</p></div>
         </div>
+      </section>
 
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">Open-source: free, Enterprise: custom pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
+      <section class="p-7 rounded-3xl bg-gradient-to-r from-blue-500/10 to-purple-500/10 border border-blue-500/30 text-center space-y-4">
+        <h2 class="text-2xl md:text-3xl font-black text-white">Want the lower-friction starting point?</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto">Make's permanent free tier is the simplest way to validate a visual automation without paying. If you later need self-hosting or deeper technical control, compare the proven workflow against n8n before migrating.</p>
+        <div class="flex flex-col sm:flex-row gap-3 justify-center">
+          <a data-cta="affiliate" data-tool-id="make-com" data-cta-source="compare_n8n_make_bottom" href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-7 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-blue-600 to-purple-600 text-white hover:brightness-110 transition-all">Start Make.com Free via Verified Partner Link →</a>
+          <a data-cta="official" href="https://n8n.io/pricing/" target="_blank" rel="noopener noreferrer" class="px-7 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 border border-slate-600 text-white hover:bg-slate-700 transition-all">Compare n8n Official Plans</a>
         </div>
+        <p class="text-[11px] text-slate-400">COSHUMA's Make partner code is <code>pc=coshuma</code>. n8n does not currently have a verified COSHUMA revenue link in this repository, so n8n buttons remain official non-affiliate links.</p>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">n8n Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Low-code workflow building</div>
-<div>✓ AI agent development</div>
-<div>✓ 500+ app integrations</div>
-<div>✓ Customizable automation logic</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Make.com Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Visual Drag & Drop</div>
-<div>✓ 3000+ Integrations</div>
-<div>✓ Advanced Branching</div>
-<div>✓ JSON Parsing</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://n8n.io/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get n8n →</a>
-          <a href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Make.com →</a>
-        </div>
-      </div>
+      <section class="p-5 rounded-2xl bg-[#0f1119] border border-[#222538] text-xs text-slate-400 leading-relaxed">
+        <strong class="text-slate-300">Sources checked:</strong> n8n official pricing/product pages and Make's official pricing page on September 3, 2026. COSHUMA does not invent ratings, affiliate parameters or hidden pricing. Final vendor checkout and current plan terms control.
+      </section>
     </main>
 
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
+    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS decision guides.</div></footer>
   </body>
 </html>


### PR DESCRIPTION
Revenue-focused no-cost update:

- Replaces the generic n8n vs Make.com page with current buyer-intent guidance and official pricing context.
- Adds two attributed Make.com affiliate CTAs using the already verified `pc=coshuma` customer-facing partner link.
- Keeps n8n official-only because no verified COSHUMA revenue link exists for n8n.
- Adds `/affiliate-attribution.js` and source labels for Make CTA measurement.
- Records the already-approved Chatbase/Dub partnership as browser-required for exact referral-link recovery, while explicitly preventing a duplicate Dub Partner Network/account reapplication after the August 30 marketplace rejection.

No paid services or subscriptions used.