### PR TITLE
Optimize ElevenLabs vs LOVO buyer conversion

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/elevenlabs-vs-lovo.html
+++ b/projects/GlobalSaaSHub/public/compare/elevenlabs-vs-lovo.html
@@ -1,172 +1,147 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ElevenLabs vs Lovo Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of ElevenLabs vs Lovo. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ElevenLabs vs LOVO (2026): Voice AI & Video Workflow Comparison | GlobalSaaSHub</title>
+  <meta name="description" content="Compare ElevenLabs and LOVO for AI voice generation, voice cloning, video creation, pricing, and free-trial fit. Includes a verified ElevenLabs partner link and official LOVO trial path." />
+  <link rel="canonical" href="https://coshuma.com/compare/elevenlabs-vs-lovo.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/elevenlabs-vs-lovo.html" />
+  <meta property="og:title" content="ElevenLabs vs LOVO (2026) | GlobalSaaSHub" />
+  <meta property="og:description" content="A practical buyer comparison for AI voice generation versus all-in-one voice-and-video production." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"WebPage",
+    "name":"ElevenLabs vs LOVO Comparison",
+    "url":"https://coshuma.com/compare/elevenlabs-vs-lovo.html",
+    "dateModified":"2026-09-03",
+    "about":[
+      {"@type":"SoftwareApplication","name":"ElevenLabs","url":"https://coshuma.com/tool/elevenlabs.html"},
+      {"@type":"SoftwareApplication","name":"LOVO","url":"https://coshuma.com/tool/lovo.html"}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="/affiliate-attribution.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}
+  </style>
+</head>
+<body class="min-h-screen bg-[#0b0c10] text-slate-100">
+  <header class="border-b border-[#222538] bg-[#07080c]/90 sticky top-0 z-50 py-4 px-6 backdrop-blur-md">
+    <div class="max-w-5xl mx-auto flex items-center justify-between">
+      <a href="/" class="font-extrabold text-white">GlobalSaaSHub</a>
+      <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">← All Tools</a>
+    </div>
+  </header>
 
-    <link rel="canonical" href="https://coshuma.com/compare/elevenlabs-vs-lovo.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/elevenlabs-vs-lovo.html" />
-    <meta property="og:title" content="ElevenLabs vs Lovo Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare ElevenLabs and Lovo by pricing, features, and verified public information." />
+  <main class="max-w-5xl mx-auto px-4 py-10 space-y-8">
+    <section class="text-center space-y-4">
+      <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Voice AI buyer comparison · Updated Sep 3, 2026</div>
+      <h1 class="text-4xl md:text-5xl font-black tracking-tight">ElevenLabs vs LOVO</h1>
+      <p class="max-w-3xl mx-auto text-slate-300">Choose <strong class="text-white">ElevenLabs</strong> when voice generation itself is the main product. Choose <strong class="text-white">LOVO</strong> when you want voiceovers inside a broader video-production workflow with editing, subtitles, scripts, and visual assets in the same workspace.</p>
+    </section>
 
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "ElevenLabs vs Lovo Comparison",
-      "url": "https://coshuma.com/compare/elevenlabs-vs-lovo.html",
-      "description": "Compare ElevenLabs and Lovo by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "ElevenLabs", "url": "https://coshuma.com/tool/elevenlabs.html"},
-        {"@type": "SoftwareApplication", "name": "Lovo", "url": "https://coshuma.com/tool/lovo.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+    <section class="grid md:grid-cols-2 gap-5">
+      <article class="rounded-3xl bg-[#131520] border border-purple-500/30 p-6 space-y-5">
+        <div>
+          <div class="text-xs font-bold text-purple-300 uppercase tracking-wider">Best fit: ElevenLabs</div>
+          <h2 class="text-2xl font-black mt-1">Audio-first voice generation and cloning</h2>
+        </div>
+        <ul class="space-y-2 text-sm text-slate-300">
+          <li>✓ Free plan with 10k credits per month</li>
+          <li>✓ Starter $6/month; Creator $22/month standard price</li>
+          <li>✓ Instant voice cloning starts on Starter</li>
+          <li>✓ Professional voice cloning on Creator</li>
+          <li>✓ Text-to-speech, speech-to-text, sound effects, music, dubbing, and Studio tools</li>
+        </ul>
+        <a data-cta="affiliate" data-tool-id="elevenlabs" href="https://try.elevenlabs.io/ldc2xmh2x2t5" target="_blank" rel="sponsored noopener noreferrer" class="block w-full py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center shadow-lg">Try ElevenLabs via verified partner link →</a>
+        <a href="https://elevenlabs.io/pricing" target="_blank" rel="noopener noreferrer" class="block text-center text-xs text-slate-400 hover:text-white">Check ElevenLabs official pricing</a>
+      </article>
+
+      <article class="rounded-3xl bg-[#131520] border border-blue-500/30 p-6 space-y-5">
+        <div>
+          <div class="text-xs font-bold text-blue-300 uppercase tracking-wider">Best fit: LOVO</div>
+          <h2 class="text-2xl font-black mt-1">Voiceover plus all-in-one video creation</h2>
+        </div>
+        <ul class="space-y-2 text-sm text-slate-300">
+          <li>✓ 500+ voices across 100 languages on LOVO's current public site</li>
+          <li>✓ Genny combines voice generation with a timeline video editor</li>
+          <li>✓ Auto subtitles, AI script writing, AI images, and voice cloning</li>
+          <li>✓ 14-day Pro trial with no card required</li>
+          <li>✓ Trial projects can be shared, but LOVO says downloads are disabled during the trial</li>
+        </ul>
+        <a href="https://lovo.ai/" target="_blank" rel="noopener noreferrer" class="block w-full py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center shadow-lg">Start LOVO's official free trial →</a>
+        <a href="https://lovo.ai/pricing" target="_blank" rel="noopener noreferrer" class="block text-center text-xs text-slate-400 hover:text-white">Check LOVO official pricing</a>
+      </article>
+    </section>
+
+    <section class="rounded-3xl bg-[#131520] border border-[#222538] p-6 space-y-5">
+      <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-2">
+        <div>
+          <div class="text-xs font-bold uppercase tracking-wider text-emerald-300">Fast buying decision</div>
+          <h2 class="text-2xl font-black">Pick based on the workflow, not a generic rating</h2>
+        </div>
+        <div class="text-xs text-slate-500">Public vendor information checked Sep 3, 2026</div>
       </div>
-    </header>
-
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
+      <div class="grid md:grid-cols-3 gap-4 text-sm">
+        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]">
+          <div class="font-bold text-white mb-1">You mainly need TTS or cloned voices</div>
+          <p class="text-slate-400">Start with ElevenLabs. Its current pricing page exposes a free tier and clear upgrade path, making it easier to test the voice stack before paying.</p>
         </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">ElevenLabs vs Lovo</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Voice & Speech AI tool.
-        </p>
-      </div>
-
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
+        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]">
+          <div class="font-bold text-white mb-1">You need finished videos, not just audio</div>
+          <p class="text-slate-400">LOVO is the more natural evaluation target because Genny bundles voiceover with editing, subtitles, AI writing, and visual-generation tools.</p>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose ElevenLabs if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Lovo if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
-      </div>
-
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/elevenlabs.html" class="hover:text-purple-300">ElevenLabs</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/lovo.html" class="hover:text-blue-300">Lovo</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">Varies</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">ElevenLabs Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ AI Voice Cloning</div>
-<div>✓ Text-to-Speech</div>
-<div>✓ Sound Effects Generator</div>
-<div>✓ Multi-lingual Support</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Lovo Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ 500+ AI voices</div>
-<div>✓ Advanced voice cloning</div>
-<div>✓ Integrated Genny video editor</div>
-<div>✓ High-quality text-to-speech</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://try.elevenlabs.io/ldc2xmh2x2t5" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get ElevenLabs →</a>
-          <a href="https://lovo.ai/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Lovo →</a>
+        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]">
+          <div class="font-bold text-white mb-1">You are testing before committing</div>
+          <p class="text-slate-400">ElevenLabs has a $0 plan. LOVO advertises a 14-day Pro trial without card details, although project downloads are restricted during that trial.</p>
         </div>
       </div>
-    </main>
+    </section>
 
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
+    <section class="rounded-3xl bg-[#131520] border border-[#222538] p-6 space-y-5">
+      <h2 class="text-2xl font-black">Current public pricing and trial snapshot</h2>
+      <div class="grid md:grid-cols-2 gap-5 text-sm">
+        <div class="rounded-2xl bg-[#181a29] border border-purple-500/20 p-5 space-y-3">
+          <h3 class="font-black text-purple-200">ElevenLabs</h3>
+          <div class="grid grid-cols-2 gap-2 text-xs">
+            <div class="p-3 rounded-xl bg-black/20"><div class="text-slate-500">Free</div><div class="font-black text-white">$0/mo</div></div>
+            <div class="p-3 rounded-xl bg-black/20"><div class="text-slate-500">Starter</div><div class="font-black text-white">$6/mo</div></div>
+            <div class="p-3 rounded-xl bg-black/20"><div class="text-slate-500">Creator</div><div class="font-black text-white">$22/mo</div></div>
+            <div class="p-3 rounded-xl bg-black/20"><div class="text-slate-500">Pro</div><div class="font-black text-white">$99/mo</div></div>
+          </div>
+          <p class="text-xs text-slate-500">ElevenLabs currently advertises a first-month Creator discount to $11. Vendor promotions can change, so verify the checkout page before purchase.</p>
+        </div>
+        <div class="rounded-2xl bg-[#181a29] border border-blue-500/20 p-5 space-y-3">
+          <h3 class="font-black text-blue-200">LOVO</h3>
+          <p class="text-slate-300">LOVO currently promotes a <strong class="text-white">14-day Pro trial</strong> with no payment or card details required. Its help center identifies Free, Basic, Pro, Pro+, and Enterprise tiers and states Basic/Pro/Pro+ include 2/5/20 voice-generation hours per month respectively.</p>
+          <p class="text-xs text-slate-500">LOVO's exact paid dollar prices were not hard-coded here because the current public pages available to our verification flow did not expose a reliable up-to-date price table. Use the official pricing link above for the live amount.</p>
+        </div>
       </div>
-    </footer>
-  </body>
+    </section>
+
+    <section class="rounded-3xl bg-gradient-to-r from-purple-950/50 to-blue-950/50 border border-purple-500/20 p-6 text-center space-y-4">
+      <h2 class="text-2xl font-black">Want to test the audio-first option now?</h2>
+      <p class="text-sm text-slate-300 max-w-2xl mx-auto">The ElevenLabs button below uses COSHUMA's verified customer-facing partner URL. COSHUMA may earn a commission from an eligible signup or purchase, at no extra cost to you. LOVO remains an official non-affiliate link until a verified COSHUMA revenue URL exists.</p>
+      <div class="grid sm:grid-cols-2 gap-3 max-w-2xl mx-auto">
+        <a data-cta="affiliate" data-tool-id="elevenlabs" href="https://try.elevenlabs.io/ldc2xmh2x2t5" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white">Open ElevenLabs partner offer →</a>
+        <a href="https://lovo.ai/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white">Open LOVO official trial →</a>
+      </div>
+    </section>
+
+    <section class="text-xs text-slate-500 leading-relaxed">
+      <p><strong class="text-slate-400">Evidence used:</strong> ElevenLabs official pricing page; LOVO official product/Genny pages; LOVO Help Center trial and subscription articles. Prices and plan limits can change after publication, so confirm the vendor checkout before paying.</p>
+    </section>
+  </main>
+
+  <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
+    <div class="max-w-5xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Independent comparison with affiliate disclosure.</div>
+  </footer>
+</body>
 </html>


### PR DESCRIPTION
Replace the generic programmatic comparison with a current buyer-intent page. Keep LOVO official-only because no verified COSHUMA revenue URL exists, move the verified ElevenLabs partner CTA into high-intent positions, add affiliate click attribution, and ground pricing/trial copy in current official vendor sources. No paid services or guessed referral parameters.