### PR TITLE
Optimize Sudowrite vs Jasper buyer conversion

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/sudowrite-vs-jasper.html
+++ b/projects/GlobalSaaSHub/public/compare/sudowrite-vs-jasper.html
@@ -3,34 +3,29 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Sudowrite vs Jasper Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Sudowrite vs Jasper. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
-
+    <title>Sudowrite vs Jasper (2026): Fiction Writing vs Marketing AI | COSHUMA</title>
+    <meta name="description" content="Sudowrite vs Jasper in 2026: compare fiction-first writing tools, marketing workflows, current pricing and trials. Start Sudowrite through COSHUMA's verified affiliate link." />
     <link rel="canonical" href="https://coshuma.com/compare/sudowrite-vs-jasper.html" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/compare/sudowrite-vs-jasper.html" />
-    <meta property="og:title" content="Sudowrite vs Jasper Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Sudowrite and Jasper by pricing, features, and verified public information." />
+    <meta property="og:title" content="Sudowrite vs Jasper (2026): Fiction Writing vs Marketing AI" />
+    <meta property="og:description" content="Choose Sudowrite for fiction-first drafting and story development; choose Jasper for on-brand marketing workflows and team use." />
 
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebPage",
-      "name": "Sudowrite vs Jasper Comparison",
+      "name": "Sudowrite vs Jasper (2026)",
       "url": "https://coshuma.com/compare/sudowrite-vs-jasper.html",
-      "description": "Compare Sudowrite and Jasper by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
+      "description": "Buyer-focused comparison of Sudowrite and Jasper for fiction writing versus marketing workflows.",
+      "isPartOf": {"@type": "WebSite", "name": "COSHUMA", "url": "https://coshuma.com/"},
       "about": [
         {"@type": "SoftwareApplication", "name": "Sudowrite", "url": "https://coshuma.com/tool/sudowrite.html"},
         {"@type": "SoftwareApplication", "name": "Jasper", "url": "https://coshuma.com/tool/jasper.html"}
       ]
     }
     </script>
-    
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -44,129 +39,115 @@
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div>
+          <span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
     <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
+      <section class="text-center space-y-4">
+        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Buyer guide · Updated September 3, 2026</div>
         <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Sudowrite vs Jasper</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best AI Copywriting tool.
-        </p>
-      </div>
+        <p class="text-slate-300 text-base max-w-3xl mx-auto leading-relaxed">These products overlap on AI writing, but they are built for different jobs. Sudowrite is purpose-built for fiction and long-form creative writing. Jasper is built around brand-controlled marketing content, agents and team workflows.</p>
+      </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
+      <section class="p-6 rounded-3xl bg-gradient-to-br from-purple-500/10 to-indigo-500/5 border border-purple-500/30 space-y-5">
+        <div>
+          <h2 class="text-2xl font-black text-white">Fast decision</h2>
+          <p class="text-slate-300 mt-2 leading-relaxed"><strong class="text-white">Pick Sudowrite</strong> if the work is novels, scenes, story development, rewriting prose or overcoming writer's block. <strong class="text-white">Pick Jasper</strong> if the work is on-brand marketing content, reusable brand knowledge, marketing agents and collaboration across a business team.</p>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Sudowrite if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Jasper if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <a data-cta="affiliate" data-tool-id="sudowrite" data-cta-source="compare-hero" href="https://www.sudowrite.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Try Sudowrite free →</a>
+          <a data-cta="official" data-tool-id="jasper" data-cta-source="compare-hero" href="https://www.jasper.ai/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">View Jasper pricing →</a>
         </div>
-      </div>
+        <p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn a commission when you subscribe to Sudowrite through the verified partner link, at no extra cost to you. Jasper is linked to its official pricing page because COSHUMA does not currently have a verified Jasper affiliate URL.</p>
+      </section>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/sudowrite.html" class="hover:text-purple-300">Sudowrite</a>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
+        <h2 class="text-xl font-bold text-white">What you are actually buying</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/30 space-y-3">
+            <div class="text-purple-300 font-extrabold">Sudowrite</div>
+            <div class="text-2xl font-black text-white">Fiction-first AI writing partner</div>
+            <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+              <li>Designed around creative writing rather than general business copy.</li>
+              <li>Helps generate, rewrite and expand scenes while preserving a writer-led workflow.</li>
+              <li>All paid tiers include the feature set; plan differences mainly change monthly credit volume and rollover rules.</li>
+              <li>Official pricing currently starts at $10/month when billed annually.</li>
+            </ul>
           </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/jasper.html" class="hover:text-blue-300">Jasper</a>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/30 space-y-3">
+            <div class="text-blue-300 font-extrabold">Jasper</div>
+            <div class="text-2xl font-black text-white">Marketing AI platform</div>
+            <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+              <li>Built for on-brand marketing production rather than novel-writing depth.</li>
+              <li>Pro includes Canvas, marketing agents and brand customization controls.</li>
+              <li>Business adds more complex workflows, governance and team-scale capabilities.</li>
+              <li>Official pricing currently lists Pro at $69/month per seat on monthly billing.</li>
+            </ul>
           </div>
         </div>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
+      <section class="space-y-4">
+        <h2 class="text-xl font-bold text-white">Current pricing and trial context</h2>
+        <div class="overflow-hidden rounded-2xl border border-[#222538] bg-[#131520]">
+          <div class="grid grid-cols-3 text-xs sm:text-sm font-bold bg-[#181a29] border-b border-[#222538]">
+            <div class="p-4 text-slate-400">Product</div>
+            <div class="p-4 text-slate-400">Starting paid price</div>
+            <div class="p-4 text-slate-400">Trial / entry path</div>
           </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
+          <div class="grid grid-cols-3 text-xs sm:text-sm border-b border-[#222538]">
+            <div class="p-4 font-bold text-white">Sudowrite</div>
+            <div class="p-4 text-slate-300">$10/mo annual · $19/mo monthly for Hobby &amp; Student</div>
+            <div class="p-4 text-slate-300">Free trial promoted on the live pricing page; no credit card required.</div>
           </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
+          <div class="grid grid-cols-3 text-xs sm:text-sm">
+            <div class="p-4 font-bold text-white">Jasper</div>
+            <div class="p-4 text-slate-300">Pro $69/mo/seat on monthly billing; annual billing advertises ~20% savings</div>
+            <div class="p-4 text-slate-300">7-day Pro trial on Jasper's official pricing page.</div>
           </div>
         </div>
+        <p class="text-xs text-slate-500 leading-relaxed">Sudowrite's live pricing page currently shows Hobby &amp; Student at $10/month annually, Professional at $22/month annually and Max at $44/month annually. Jasper's live pricing page currently shows Pro at $69/month per seat on monthly billing and Business at custom pricing. Prices and trial terms can change, so recheck the vendor checkout before paying.</p>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Sudowrite Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ AI story generation</div>
-<div>✓ Brainstorming tools</div>
-<div>✓ Character development</div>
-<div>✓ Rewrite & expand text</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Jasper Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Versatile AI content generation</div>
-<div>✓ Supports 25+ languages</div>
-<div>✓ Brand voice customization</div>
-<div>✓ SEO-friendly content optimization</div>
-            </div>
-          </div>
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-3">
+          <h2 class="text-lg font-bold text-emerald-400">Sudowrite is the better fit when...</h2>
+          <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+            <li>You are drafting a novel, screenplay, short story or other fiction.</li>
+            <li>Scene generation, brainstorming, rewrite and prose development matter more than brand governance.</li>
+            <li>You want a low-friction free trial before choosing a paid creative-writing plan.</li>
+            <li>You prefer a tool whose product positioning is specifically centered on writers.</li>
+          </ul>
         </div>
+        <div class="p-5 rounded-2xl bg-blue-500/5 border border-blue-500/20 space-y-3">
+          <h2 class="text-lg font-bold text-blue-300">Jasper is the better fit when...</h2>
+          <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+            <li>Your output is marketing copy, campaigns and branded business content.</li>
+            <li>You need Brand Voices, Knowledge assets, Audiences or marketing agents.</li>
+            <li>You are buying for a team rather than a single fiction writer.</li>
+            <li>Business-grade workflow and governance matter more than fiction-specific writing assistance.</li>
+          </ul>
+        </div>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://www.sudowrite.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Sudowrite →</a>
-          <a href="https://www.jasper.ai/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Jasper →</a>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-4">
+        <h2 class="text-xl font-bold text-white">Bottom line</h2>
+        <p class="text-slate-300 leading-relaxed">For fiction, Sudowrite is the more direct purchase because the product, workflow and pricing are built around writers. For marketing teams, Jasper is the more relevant comparison because its core value is brand-controlled content and marketing automation rather than story craft.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <a data-cta="affiliate" data-tool-id="sudowrite" data-cta-source="compare-bottom" href="https://www.sudowrite.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start Sudowrite through COSHUMA →</a>
+          <a data-cta="official" data-tool-id="jasper" data-cta-source="compare-bottom" href="https://www.jasper.ai/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Check Jasper's live pricing →</a>
         </div>
-      </div>
+      </section>
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI SaaS buyer guides.</div>
     </footer>
+
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
Revenue-focused rewrite of the Sudowrite vs Jasper comparison page.

- replaces placeholder/`Not rated` copy with a clear fiction-vs-marketing buying decision
- uses the verified Sudowrite affiliate URL from the partner welcome email
- keeps Jasper on a non-affiliate official pricing link because no verified Jasper revenue URL exists
- adds top and bottom tracked Sudowrite CTAs via `/affiliate-attribution.js`
- refreshes current vendor pricing/trial context against official Sudowrite and Jasper pages
- adds explicit affiliate disclosure and avoids unsupported conversion claims

No paid services or subscription changes.