### PR TITLE
Optimize Decktopus buyer-intent affiliate landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/decktopus.html
+++ b/projects/GlobalSaaSHub/public/tool/decktopus.html
@@ -3,29 +3,26 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Decktopus Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Decktopus is an AI-powered presentation tool that automatically crafts stunning decks, empowering users to create professional presentations in minute... Discover features, pricing (See official pricing), and official links for Decktopus on GlobalSaaSHub." />
+    <title>Decktopus AI Review & Pricing (2026): Is It Worth It? | COSHUMA</title>
+    <meta name="description" content="Decktopus AI buyer guide for 2026: current Pro pricing, free signup credits, AI presentation generation, brand import, PPT/PDF export and Loop rehearsal. Start through COSHUMA's verified affiliate link." />
     <link rel="canonical" href="https://coshuma.com/tool/decktopus.html" />
-    
-    <!-- Open Graph SEO Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/decktopus.html" />
-    <meta property="og:title" content="Decktopus Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Decktopus is an AI-powered presentation tool that automatically crafts stunning decks, empowering users to create professional presentations in minute... Check rating, pricing, and features." />
+    <meta property="og:title" content="Decktopus AI Review & Pricing (2026)" />
+    <meta property="og:description" content="A buyer-focused Decktopus guide covering current pricing, signup credits, AI deck creation, branding, export and presentation rehearsal." />
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
-      "name": "Decktopus",
+      "name": "Decktopus AI",
+      "url": "https://decktopus.com/",
       "operatingSystem": "Web",
-      "applicationCategory": "Design & Graphics",
-      "description": "Decktopus is an AI-powered presentation tool that automatically crafts stunning decks, empowering users to create professional presentations in minutes. Leverage customizable templates and integrated forms for effective lead generation and impactful visual storytelling."
+      "applicationCategory": "BusinessApplication",
+      "description": "AI presentation platform that generates complete decks from a topic or file, applies branding, exports to PPT/PDF/PNG and includes presentation rehearsal tools."
     }
     </script>
 
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,134 +33,129 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div>
+          <span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
-          <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=decktopus.com&sz=128" alt="Decktopus logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
-            <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Design & Graphics</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Decktopus</h1>
-            </div>
-          </div>
+    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
+      <section class="text-center space-y-4">
+        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Buyer guide · Updated September 3, 2026</div>
+        <div class="flex justify-center"><img src="https://www.google.com/s2/favicons?domain=decktopus.com&sz=128" alt="Decktopus logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" /></div>
+        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Decktopus AI</h1>
+        <p class="text-slate-300 text-base max-w-3xl mx-auto leading-relaxed">Decktopus is built for people who want an AI to create the structure, content and design of a presentation together, then help them rehearse the delivery. It is a stronger fit when speed and presentation readiness matter more than manually designing every slide.</p>
+      </section>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
+      <section class="p-6 rounded-3xl bg-gradient-to-br from-purple-500/10 to-indigo-500/5 border border-purple-500/30 space-y-5">
+        <div>
+          <h2 class="text-2xl font-black text-white">Best reason to try it</h2>
+          <p class="text-slate-300 mt-2 leading-relaxed">New users currently receive free signup credits that are enough to create a 3-slide presentation before paying. Decktopus does <strong class="text-white">not</strong> advertise a permanent free plan, so treat the signup credits as a product test rather than a free tier.</p>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <a data-cta="affiliate" data-tool-id="decktopus" data-cta-source="tool-hero" href="https://www.decktopus.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Try Decktopus with signup credits →</a>
+          <a data-cta="official" data-tool-id="decktopus" data-cta-source="tool-hero" href="https://www.decktopus.com/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Check live pricing →</a>
+        </div>
+        <p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn a commission when you purchase Decktopus through the verified partner link, at no extra cost to you.</p>
+      </section>
+
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
+        <h2 class="text-xl font-bold text-white">What you are actually buying</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/30 space-y-2">
+            <div class="text-purple-300 font-extrabold">AI deck generation</div>
+            <p class="text-sm text-slate-300 leading-relaxed">Enter a topic or upload a file and Decktopus generates the presentation structure, copy and design together rather than starting from a blank slide.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/30 space-y-2">
+            <div class="text-purple-300 font-extrabold">Brand import</div>
+            <p class="text-sm text-slate-300 leading-relaxed">Paste a website URL and Decktopus can pull the brand colors, fonts and logo into the presentation workflow automatically.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/30 space-y-2">
+            <div class="text-purple-300 font-extrabold">PPT, PDF and PNG export</div>
+            <p class="text-sm text-slate-300 leading-relaxed">Paid plans support common presentation export formats, which matters if the final deck must leave the web app or be edited elsewhere.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/30 space-y-2">
+            <div class="text-purple-300 font-extrabold">Loop rehearsal</div>
+            <p class="text-sm text-slate-300 leading-relaxed">Decktopus also includes presentation practice tools that simulate audience questions and provide feedback on delivery, pacing and clarity.</p>
           </div>
         </div>
+      </section>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">Decktopus is an AI-powered presentation tool that automatically crafts stunning decks, empowering users to create professional presentations in minutes. Leverage customizable templates and integrated forms for effective lead generation and impactful visual storytelling.</p>
-        </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI auto-created presentations</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Customizable design templates</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Integrated lead generation forms</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Slide content suggestions</div>
+      <section class="space-y-4">
+        <h2 class="text-xl font-bold text-white">Current pricing context</h2>
+        <div class="overflow-hidden rounded-2xl border border-[#222538] bg-[#131520]">
+          <div class="grid grid-cols-3 text-xs sm:text-sm font-bold bg-[#181a29] border-b border-[#222538]">
+            <div class="p-4 text-slate-400">Plan / entry path</div>
+            <div class="p-4 text-slate-400">Current public price</div>
+            <div class="p-4 text-slate-400">What matters</div>
+          </div>
+          <div class="grid grid-cols-3 text-xs sm:text-sm border-b border-[#222538]">
+            <div class="p-4 font-bold text-white">Signup test</div>
+            <div class="p-4 text-slate-300">Free credits</div>
+            <div class="p-4 text-slate-300">Enough for a 3-slide presentation; not a permanent free plan.</div>
+          </div>
+          <div class="grid grid-cols-3 text-xs sm:text-sm border-b border-[#222538]">
+            <div class="p-4 font-bold text-white">Pro · monthly</div>
+            <div class="p-4 text-slate-300">$24.99/mo</div>
+            <div class="p-4 text-slate-300">750 AI credits/month, exports, sharing, version history and Loop.</div>
+          </div>
+          <div class="grid grid-cols-3 text-xs sm:text-sm">
+            <div class="p-4 font-bold text-white">Pro · annual</div>
+            <div class="p-4 text-slate-300">$9.99/mo equivalent</div>
+            <div class="p-4 text-slate-300">Billed $119.88/year on the current official pricing page.</div>
           </div>
         </div>
+        <p class="text-xs text-slate-500 leading-relaxed">Decktopus also lists Business and Enterprise options for team and organization needs. Prices, credits and billing terms can change, so verify the vendor checkout before paying.</p>
+      </section>
 
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-3">
+          <h2 class="text-lg font-bold text-emerald-400">Decktopus is a good fit when...</h2>
+          <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+            <li>You regularly turn a topic, outline or document into a presentation.</li>
+            <li>You want AI to handle slide structure and visual direction, not just write text.</li>
+            <li>You need PowerPoint/PDF export and fast sharing.</li>
+            <li>Presentation rehearsal and audience-question practice are useful to you.</li>
+          </ul>
         </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Decktopus</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/quillbot.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=quillbot.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">QuillBot</span></div><span class="text-[10px] font-extrabold text-emerald-400">Free plan available</span></a>
-<a href="/tool/kinsta.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=kinsta.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Kinsta</span></div><span class="text-[10px] font-extrabold text-emerald-400">Pricing details on website</span></a>
-<a href="/tool/reactin.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=reactin.io&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">ReactIn</span></div><span class="text-[10px] font-extrabold text-emerald-400">Tiered subscription plans available</span></a>
-          </div>
+        <div class="p-5 rounded-2xl bg-amber-500/5 border border-amber-500/20 space-y-3">
+          <h2 class="text-lg font-bold text-amber-300">Think twice when...</h2>
+          <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+            <li>You only need occasional slides and want a permanent free tier.</li>
+            <li>You prefer pixel-level manual design control over AI-generated structure.</li>
+            <li>Your workload is heavy enough that monthly AI credits may require top-ups.</li>
+            <li>Your organization needs enterprise governance that should be validated in a sales conversation first.</li>
+          </ul>
         </div>
+      </section>
 
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://decktopus.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Decktopus Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://www.decktopus.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Decktopus via Verified Affiliate Link</span><span>→</span></a>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-4">
+        <h2 class="text-xl font-bold text-white">Bottom line</h2>
+        <p class="text-slate-300 leading-relaxed">Decktopus is most compelling for buyers who value speed from idea to presentable deck. The low-risk entry path is to use the free signup credits first, then pay only if the generated slides, brand import and rehearsal workflow save enough time to justify the subscription.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <a data-cta="affiliate" data-tool-id="decktopus" data-cta-source="tool-bottom" href="https://www.decktopus.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start Decktopus through COSHUMA →</a>
+          <a data-cta="official" data-tool-id="decktopus" data-cta-source="tool-bottom" href="https://www.decktopus.com/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Review the live plans →</a>
         </div>
+      </section>
 
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Decktopus?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Decktopus Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/decktopus.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Decktopus Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
+      <section class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-3">
+        <div class="flex items-center justify-between gap-3 flex-wrap">
+          <div class="text-purple-300 font-bold text-sm">🏆 Are you the founder of Decktopus?</div>
+          <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
         </div>
-
-
-      </div>
+        <p class="text-xs text-slate-400 leading-relaxed">Claim the profile to propose verified company information and use the COSHUMA badge. Sponsorship does not guarantee or change editorial rankings.</p>
+        <a href="/#submit" class="inline-block px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">Claim Decktopus Profile ($49/yr)</a>
+      </section>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI SaaS buyer guides.</div>
     </footer>
+
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>
-


### PR DESCRIPTION
Refresh the Decktopus detail page with current official pricing and product facts, move the verified COSHUMA affiliate CTA into high-intent positions, add product-level click attribution, clarify the free-signup-credit entry path, and preserve non-affiliate official pricing links. No paid services or guessed tracking URLs used.