### PR TITLE
Track DocsBot affiliate CTA attribution

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/docsbot.html
+++ b/projects/GlobalSaaSHub/public/tool/docsbot.html
@@ -33,5 +33,6 @@
       <section class="p-7 rounded-3xl bg-gradient-to-r from-purple-500/10 to-indigo-500/10 border border-purple-500/30 text-center space-y-4"><h2 class="text-2xl md:text-3xl font-black text-white">Test answer quality before buying capacity</h2><p class="text-sm text-slate-300 max-w-2xl mx-auto">The free tier is enough to validate whether your documents produce useful answers before paying for larger source and AI-credit limits.</p><a data-cta="affiliate" data-tool-id="docsbot" href="https://docsbot.ai?via=31kq9q" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white hover:brightness-110 transition-all">Start DocsBot Free via Verified Affiliate Link →</a><div class="text-[11px] text-slate-400">Unique affiliate URL verified from DocsBot's partner welcome email to COSHUMA on September 1, 2026.</div></section>
     </main>
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS decision guides.</div></footer>
+    <script defer src="/affiliate-attribution.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Why
DocsBot already uses COSHUMA's verified affiliate URL on two revenue CTAs, but the page was not loading `/affiliate-attribution.js`, so product-level affiliate click events could not be collected consistently.

## Change
- Load the existing affiliate attribution script on the DocsBot detail page.
- Keep the verified DocsBot tracking URL and existing disclosure unchanged.
- No paid services or new external dependencies.

## Revenue impact
This closes a measurement gap on an already-monetized page so future DocsBot CTA clicks can be attributed using the site's existing analytics path.