### PR TITLE
Monetize newly approved Unbounce partner path

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/make-com-vs-unbounce.html
+++ b/projects/GlobalSaaSHub/public/compare/make-com-vs-unbounce.html
@@ -3,34 +3,29 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Make.com vs Unbounce Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Make.com vs Unbounce. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
-
+    <title>Make.com vs Unbounce: Automation or Landing Pages? (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Make.com vs Unbounce for 2026: choose Make for multi-app automation or Unbounce for landing-page conversion optimization. Includes verified partner CTAs for both tools." />
     <link rel="canonical" href="https://coshuma.com/compare/make-com-vs-unbounce.html" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/compare/make-com-vs-unbounce.html" />
-    <meta property="og:title" content="Make.com vs Unbounce Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Make.com and Unbounce by pricing, features, and verified public information." />
+    <meta property="og:title" content="Make.com vs Unbounce: Automation or Landing Pages? (2026)" />
+    <meta property="og:description" content="A practical buyer decision: workflow automation with Make.com vs landing-page conversion optimization with Unbounce." />
 
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebPage",
-      "name": "Make.com vs Unbounce Comparison",
+      "name": "Make.com vs Unbounce",
       "url": "https://coshuma.com/compare/make-com-vs-unbounce.html",
-      "description": "Compare Make.com and Unbounce by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
+      "description": "Compare Make.com and Unbounce by the job you need to accomplish: workflow automation or landing-page conversion optimization.",
+      "isPartOf": {"@type": "WebSite", "name": "GlobalSaaSHub", "url": "https://coshuma.com/"},
       "about": [
         {"@type": "SoftwareApplication", "name": "Make.com", "url": "https://coshuma.com/tool/make-com.html"},
         {"@type": "SoftwareApplication", "name": "Unbounce", "url": "https://coshuma.com/tool/unbounce.html"}
       ]
     }
     </script>
-    
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -43,130 +38,77 @@
   <body class="min-h-screen flex flex-col justify-between">
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div><span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span></a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
+    <main class="max-w-5xl mx-auto px-4 py-12 w-full space-y-7">
+      <section class="text-center space-y-4">
+        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Buyer-intent comparison · checked September 4, 2026</div>
         <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Make.com vs Unbounce</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Coding & Dev Tools tool.
-        </p>
-      </div>
+        <p class="text-slate-400 text-base max-w-3xl mx-auto">This is not a feature-for-feature substitute decision. Pick <strong class="text-white">Make.com</strong> when the bottleneck is moving data and automating work across apps. Pick <strong class="text-white">Unbounce</strong> when the bottleneck is building, testing, and optimizing campaign landing pages.</p>
+      </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Make.com if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Unbounce if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
-      </div>
-
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/make-com.html" class="hover:text-purple-300">Make.com</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/unbounce.html" class="hover:text-blue-300">Unbounce</a>
-          </div>
+      <section class="grid md:grid-cols-2 gap-4">
+        <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
+          <div class="text-xs font-extrabold uppercase tracking-wider text-purple-300">Choose Make.com</div>
+          <h2 class="text-2xl font-black text-white">Automate the workflow behind the funnel</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">Make is the better fit when you need visual scenarios that connect apps, route data, trigger follow-up actions, and orchestrate AI or operational processes.</p>
+          <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+            <li>Visual workflow automation across many apps and APIs</li>
+            <li>Free plan currently includes 1,000 credits per month</li>
+            <li>Paid plans expand automation and AI capacity</li>
+          </ul>
+          <a data-cta="affiliate" data-tool-id="make-com" data-cta-source="compare-hero" href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="block px-6 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center transition-all">Explore Make.com via verified partner link →</a>
         </div>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
+        <div class="p-6 rounded-3xl bg-[#131520] border border-blue-500/30 space-y-4">
+          <div class="text-xs font-extrabold uppercase tracking-wider text-blue-300">Choose Unbounce</div>
+          <h2 class="text-2xl font-black text-white">Improve the landing page itself</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">Unbounce is the stronger fit when your main problem is creating campaign landing pages quickly, running A/B tests, and using AI-assisted optimization to improve conversion performance.</p>
+          <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+            <li>14-day free trial with no credit card required</li>
+            <li>Starter currently listed at $29; Build $99; Experiment $149; Optimize $249</li>
+            <li>COSHUMA partner link gives 20% off the first 3 months or 35% off the first annual subscription</li>
+          </ul>
+          <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="compare-hero" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="block px-6 py-3.5 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center transition-all">Start Unbounce free trial + partner discount →</a>
         </div>
+      </section>
 
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">Fast decision table</h2>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm min-w-[680px]">
+            <thead><tr class="text-left border-b border-[#222538]"><th class="py-3 pr-4 text-slate-400">Decision factor</th><th class="py-3 px-4 text-purple-300">Make.com</th><th class="py-3 pl-4 text-blue-300">Unbounce</th></tr></thead>
+            <tbody class="text-slate-300">
+              <tr class="border-b border-[#222538]"><td class="py-4 pr-4 font-bold text-white">Primary job</td><td class="py-4 px-4">App, data, AI, and process automation</td><td class="py-4 pl-4">Landing-page creation and conversion optimization</td></tr>
+              <tr class="border-b border-[#222538]"><td class="py-4 pr-4 font-bold text-white">Best buyer</td><td class="py-4 px-4">Ops teams, automation builders, agencies, technical marketers</td><td class="py-4 pl-4">Performance marketers, paid-media teams, agencies</td></tr>
+              <tr class="border-b border-[#222538]"><td class="py-4 pr-4 font-bold text-white">Free entry</td><td class="py-4 px-4">Free plan with 1,000 credits/month</td><td class="py-4 pl-4">14-day free trial, no credit card required</td></tr>
+              <tr class="border-b border-[#222538]"><td class="py-4 pr-4 font-bold text-white">AI angle</td><td class="py-4 px-4">AI automation and app orchestration</td><td class="py-4 pl-4">AI optimization, AI copy help, MCP-assisted page workflows</td></tr>
+              <tr><td class="py-4 pr-4 font-bold text-white">Choose it when</td><td class="py-4 px-4">The work after a form submit or trigger is the bottleneck</td><td class="py-4 pl-4">The page, offer presentation, testing, or conversion rate is the bottleneck</td></tr>
+            </tbody>
+          </table>
         </div>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Make.com Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Visual Drag & Drop</div>
-<div>✓ 3000+ Integrations</div>
-<div>✓ Advanced Branching</div>
-<div>✓ JSON Parsing</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Unbounce Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Drag-and-Drop Page Builder</div>
-<div>✓ A/B Testing & Optimization</div>
-<div>✓ AI-Powered Copy Generation</div>
-<div>✓ Conversion Rate Smart Features</div>
-            </div>
-          </div>
+      <section class="p-7 rounded-3xl bg-purple-500/5 border border-purple-500/30 space-y-4">
+        <h2 class="text-2xl font-black text-white">The practical answer: many teams use both</h2>
+        <p class="text-sm text-slate-300 leading-relaxed">A common stack is Unbounce for the acquisition page and Make.com for what happens after the lead converts—for example, sending form data to a CRM, enriching a lead, alerting sales, or triggering an onboarding sequence. If that is your workflow, the tools are complementary rather than competing.</p>
+        <div class="grid sm:grid-cols-2 gap-3">
+          <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="compare-final" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center transition-all">Try Unbounce with partner discount →</a>
+          <a data-cta="affiliate" data-tool-id="make-com" data-cta-source="compare-final" href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center transition-all">Explore Make.com →</a>
         </div>
+        <p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn commissions from qualifying purchases through these verified partner links. Unbounce partner terms, discount, 90-day cookie, and 25% first-year reward were confirmed in the Unbounce partner welcome email received September 4, 2026 KST. Product facts were checked against the current official Unbounce and Make pricing/product pages.</p>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Make.com →</a>
-          <a href="https://unbounce.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Unbounce →</a>
-        </div>
-      </div>
+      <section class="grid sm:grid-cols-2 gap-3 text-sm">
+        <a href="/tool/make-com.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all text-center font-bold text-white">Read the Make.com buyer guide →</a>
+        <a href="/tool/unbounce.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-blue-500/40 transition-all text-center font-bold text-white">Read the Unbounce buyer guide →</a>
+      </section>
     </main>
 
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
+    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Buyer-intent SaaS comparisons. All rights reserved.</div></footer>
+    <script src="/affiliate-attribution.js"></script>
   </body>
 </html>

--- a/projects/GlobalSaaSHub/public/tool/unbounce.html
+++ b/projects/GlobalSaaSHub/public/tool/unbounce.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Unbounce Pricing, Features & Alternatives (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Compare Unbounce pricing, landing-page features, and alternatives. Review Unbounce vs Make.com and explore verified official and partner links on GlobalSaaSHub." />
+    <title>Unbounce Pricing, Free Trial & Partner Discount (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Unbounce pricing, 14-day free trial, landing-page optimization features, and COSHUMA's verified Unbounce partner offer: 20% off the first 3 months or 35% off the first annual subscription." />
     <link rel="canonical" href="https://coshuma.com/tool/unbounce.html" />
 
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/unbounce.html" />
-    <meta property="og:title" content="Unbounce Pricing, Features & Alternatives (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Unbounce features and alternatives, including a direct Unbounce vs Make.com decision path." />
+    <meta property="og:title" content="Unbounce Pricing, Free Trial & Partner Discount (2026)" />
+    <meta property="og:description" content="See current Unbounce pricing and start the 14-day trial through COSHUMA's verified partner link." />
 
     <script type="application/ld+json">
     {
@@ -18,8 +18,13 @@
       "@type": "SoftwareApplication",
       "name": "Unbounce",
       "operatingSystem": "Web",
-      "applicationCategory": "Coding & Dev Tools",
-      "description": "A leading landing page builder that empowers marketers to create high-converting landing pages and pop-ups without any coding required."
+      "applicationCategory": "BusinessApplication",
+      "description": "A landing-page platform for marketers and agencies with no-code page building, A/B testing, AI optimization, and AI-assisted landing-page workflows.",
+      "offers": {
+        "@type": "AggregateOffer",
+        "lowPrice": "29",
+        "priceCurrency": "USD"
+      }
     }
     </script>
 
@@ -43,103 +48,104 @@
       </div>
     </header>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
+    <main class="max-w-5xl mx-auto px-4 py-12 w-full space-y-7">
+      <section class="p-8 md:p-10 rounded-3xl bg-[#131520] border border-purple-500/30 shadow-2xl space-y-7">
+        <div class="flex flex-col md:flex-row md:items-center justify-between gap-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=unbounce.com&sz=128" alt="Unbounce logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=unbounce.com&sz=128" alt="Unbounce logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2"><span>Coding & Dev Tools</span></div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Unbounce Pricing, Features & Alternatives</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">Landing Pages & Conversion Optimization</div>
+              <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Unbounce: pricing, trial & partner offer</h1>
+              <p class="text-slate-400 mt-2 max-w-2xl">Build landing pages without code, run A/B tests, and use AI-assisted optimization. The verified COSHUMA partner link also unlocks a customer discount.</p>
             </div>
           </div>
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold"><span>Not yet editorially rated</span></div>
         </div>
 
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">Unbounce is a landing page builder for marketers who want to create landing pages and pop-ups without coding. This page also provides a direct comparison path to alternatives when you are deciding which workflow fits your needs.</p>
-        </div>
-
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Drag-and-Drop Page Builder</div>
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> A/B Testing & Optimization</div>
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI-Powered Copy Generation</div>
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Conversion Rate Smart Features</div>
+        <div class="grid md:grid-cols-3 gap-3">
+          <div class="p-4 rounded-2xl bg-emerald-500/5 border border-emerald-500/20">
+            <div class="text-[11px] uppercase tracking-wider font-extrabold text-emerald-300">Free entry</div>
+            <div class="text-lg font-black text-white mt-1">14-day trial</div>
+            <div class="text-xs text-slate-400 mt-1">No credit card required on the current official pricing page.</div>
           </div>
-        </div>
-
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>No-code landing page workflow</li>
-              <li>A/B testing and conversion optimization features</li>
-              <li>Landing-page-focused marketing workflow</li>
-            </ul>
+          <div class="p-4 rounded-2xl bg-purple-500/5 border border-purple-500/20">
+            <div class="text-[11px] uppercase tracking-wider font-extrabold text-purple-300">Verified partner discount</div>
+            <div class="text-lg font-black text-white mt-1">20% or 35% off</div>
+            <div class="text-xs text-slate-400 mt-1">20% off the first 3 months or 35% off the first annual subscription through COSHUMA's unique link.</div>
           </div>
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Pricing should be confirmed on the official site before purchase</li>
-              <li>Alternative automation or website workflows may fit some teams better</li>
-            </ul>
+          <div class="p-4 rounded-2xl bg-blue-500/5 border border-blue-500/20">
+            <div class="text-[11px] uppercase tracking-wider font-extrabold text-blue-300">Tracking window</div>
+            <div class="text-lg font-black text-white mt-1">90-day cookie</div>
+            <div class="text-xs text-slate-400 mt-1">Confirmed in the Unbounce partner welcome email received September 4, 2026 KST.</div>
           </div>
         </div>
 
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Unbounce</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/make-com.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=make.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Make.com</span></div><span class="text-[10px] font-extrabold text-emerald-400">Compare</span></a>
-            <a href="/tool/jotform.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=jotform.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Jotform</span></div><span class="text-[10px] font-extrabold text-emerald-400">Compare</span></a>
-            <a href="/tool/webflow.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=webflow.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Webflow</span></div><span class="text-[10px] font-extrabold text-emerald-400">Compare</span></a>
-          </div>
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="tool-hero" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="px-7 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start Unbounce free trial + partner discount →</a>
+          <a data-cta="official" data-tool-id="unbounce" data-cta-source="tool-hero-pricing" href="https://unbounce.com/pricing/" target="_blank" rel="noopener noreferrer" class="px-7 py-4 rounded-xl font-bold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">View official pricing →</a>
         </div>
+        <p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if you become a paying Unbounce customer through the verified partner link. The partner offer and commission terms were confirmed in Unbounce's welcome email; product pricing below is checked against Unbounce's official pricing page.</p>
+      </section>
 
-        <div class="p-6 rounded-2xl bg-purple-500/5 border border-purple-500/30 space-y-4">
-          <div>
-            <div class="text-[11px] uppercase font-extrabold tracking-wider text-purple-300">Decision path</div>
-            <h2 class="text-xl font-bold text-white mt-1">Comparing Unbounce with Make.com?</h2>
-            <p class="text-sm text-slate-300 mt-2 leading-relaxed">Use the side-by-side comparison before choosing. If Make.com fits your workflow, the verified partner link below can credit COSHUMA for a qualifying referral.</p>
-          </div>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <a href="/compare/make-com-vs-unbounce.html" class="px-5 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Compare Unbounce vs Make.com →</a>
-            <a data-cta="affiliate" href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Explore Make.com via Verified Partner Link →</a>
-          </div>
-          <p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if you purchase through this verified partner link.</p>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <div>
+          <div class="text-[11px] uppercase font-extrabold tracking-wider text-purple-300">Current public pricing</div>
+          <h2 class="text-2xl font-black text-white mt-1">Which Unbounce plan fits?</h2>
         </div>
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-xs text-slate-400">Starter</div><div class="text-xl font-black text-emerald-400 mt-1">$29</div><div class="text-[11px] text-slate-500 mt-1">5 pages · up to 500 traffic · 1 user</div></div>
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-xs text-slate-400">Build</div><div class="text-xl font-black text-emerald-400 mt-1">$99</div><div class="text-[11px] text-slate-500 mt-1">For broader landing-page production needs</div></div>
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-xs text-slate-400">Experiment</div><div class="text-xl font-black text-emerald-400 mt-1">$149</div><div class="text-[11px] text-slate-500 mt-1">Adds deeper testing workflows</div></div>
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-xs text-slate-400">Optimize</div><div class="text-xl font-black text-emerald-400 mt-1">$249</div><div class="text-[11px] text-slate-500 mt-1">Includes Smart Traffic AI optimization</div></div>
+        </div>
+        <p class="text-xs text-slate-500">Prices shown in USD as displayed on Unbounce's official pricing page checked September 4, 2026. Unbounce also lists Concierge and Agency plans with sales-assisted pricing. Confirm limits and billing cadence before purchase.</p>
+      </section>
 
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://unbounce.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Unbounce Site</span><span>→</span></a>
+      <section class="grid md:grid-cols-2 gap-4">
+        <div class="p-6 rounded-3xl bg-[#131520] border border-emerald-500/20 space-y-3">
+          <h2 class="text-xl font-bold text-white">Choose Unbounce when...</h2>
+          <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+            <li>Your bottleneck is paid-campaign landing-page conversion, not backend workflow automation.</li>
+            <li>You want drag-and-drop landing pages plus native A/B testing in the same platform.</li>
+            <li>You want Smart Traffic to route visitors among page variants on supported plans.</li>
+            <li>You want to build or manage landing pages from AI assistants through Unbounce's MCP server, which Unbounce says is included across plans and the free trial.</li>
+          </ul>
         </div>
+        <div class="p-6 rounded-3xl bg-[#131520] border border-amber-500/20 space-y-3">
+          <h2 class="text-xl font-bold text-white">Consider an alternative when...</h2>
+          <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+            <li>You mainly need app-to-app automation, data routing, or operational workflows; Make.com is the more direct category fit.</li>
+            <li>You need a general-purpose website/CMS rather than campaign-specific landing pages.</li>
+            <li>Your traffic is very low and you do not expect to use testing or optimization features enough to justify a paid landing-page platform.</li>
+          </ul>
+        </div>
+      </section>
 
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm"><span>🏆 Are you the founder of Unbounce?</span></div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:</p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.</div>
-          <div class="flex flex-col sm:flex-row items-center gap-3"><a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">⚡ Claim Unbounce Profile ($49/yr)</a></div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/unbounce.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Unbounce Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
+      <section class="p-7 rounded-3xl bg-purple-500/5 border border-purple-500/30 space-y-4">
+        <div>
+          <div class="text-[11px] uppercase font-extrabold tracking-wider text-purple-300">High-intent decision path</div>
+          <h2 class="text-2xl font-black text-white mt-1">Unbounce vs Make.com</h2>
+          <p class="text-sm text-slate-300 mt-2">These products solve different bottlenecks. Choose Unbounce for landing-page creation and conversion optimization; choose Make.com for multi-app automation and workflow orchestration.</p>
         </div>
-      </div>
+        <div class="grid sm:grid-cols-3 gap-3">
+          <a href="/compare/make-com-vs-unbounce.html" class="px-5 py-3.5 rounded-xl font-bold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Compare side by side →</a>
+          <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="tool-decision" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 hover:bg-purple-500 text-white text-center transition-all">Try Unbounce with discount →</a>
+          <a data-cta="affiliate" data-tool-id="make-com" data-cta-source="tool-decision" href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3.5 rounded-xl font-extrabold text-sm bg-blue-600 hover:bg-blue-500 text-white text-center transition-all">Explore Make.com →</a>
+        </div>
+      </section>
+
+      <section class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
+        <div class="flex items-center justify-between gap-4">
+          <div class="flex items-center gap-2 text-purple-300 font-bold text-sm"><span>🏆 Are you the founder of Unbounce?</span></div>
+          <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
+        </div>
+        <p class="text-xs text-slate-400 leading-relaxed">Claim this profile to update company information and manage verified profile details. Sponsorship does not guarantee or alter editorial rankings.</p>
+        <a href="/#submit" class="inline-block px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all">Claim Unbounce Profile ($49/yr)</a>
+      </section>
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
       <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
+    <script src="/affiliate-attribution.js"></script>
   </body>
 </html>

--- a/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
+++ b/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
@@ -16,6 +16,11 @@ const verified = {
   shopify: 'https://shopify.pxf.io/7670642-link?sharedid=7670642',
   'vista-social': 'https://vistasocial.com?fpr=sangkwon14',
   bookyourdata: 'https://join.bookyourdata.com/swcyqmumr3s5',
+  unbounce: 'https://unbounce.partnerlinks.io/5ubjnt8lluqi',
+};
+
+const verifiedAt = {
+  unbounce: '2026-09-04T03:52:58+09:00',
 };
 
 for (const file of ['data/tools.json', 'data/tools.next.json']) {
@@ -25,7 +30,7 @@ for (const file of ['data/tools.json', 'data/tools.next.json']) {
     if (!tool.affiliate_url || (tool.affiliate_verified !== true && !verified[tool.id])) continue;
     tool.affiliate_verified = true;
     tool.affiliate_status = 'approved_tracking';
-    tool.affiliate_verified_at ||= '2026-09-01T00:00:00+09:00';
+    tool.affiliate_verified_at ||= verifiedAt[tool.id] || '2026-09-01T00:00:00+09:00';
   }
   fs.writeFileSync(file, `${JSON.stringify(tools, null, 2)}\n`);
 }


### PR DESCRIPTION
Revenue-focused, zero-cost update for GlobalSaaSHub.

Evidence checked 2026-09-04 KST:
- Unbounce Partner Program welcome email confirms COSHUMA is officially approved and provides the exact customer-facing referral URL `https://unbounce.partnerlinks.io/5ubjnt8lluqi`.
- The same email confirms 20% off the first 3 months or 35% off the first annual subscription for referred customers, a 90-day tracking cookie, and a continued 25% reward for the first year of the referred customer's subscription.
- Unbounce's official pricing page currently shows a 14-day free trial with no credit card required and public prices starting at $29 for Starter, then $99 Build, $149 Experiment, and $249 Optimize.

Changes:
- replace the previously non-monetized Unbounce detail page with a buyer-intent landing page using the exact verified partner URL;
- add tracked Unbounce CTAs above the fold and at the final decision point;
- replace the generic Make.com vs Unbounce comparison with a practical workflow-automation-vs-landing-page decision page and verified affiliate CTAs for both approved programs;
- load `/affiliate-attribution.js` on both pages with `data-tool-id` and `data-cta-source` metadata;
- record the exact Unbounce partner URL in `sync_verified_affiliates.mjs` so future syncs do not revert it to a generic homepage.

No paid services, guessed referral parameters, duplicate applications, or generic dashboard/onboarding URLs were used.