### PR TITLE
Optimize BoldSign buyer conversion and affiliate attribution

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/boldsign.html
+++ b/projects/GlobalSaaSHub/public/tool/boldsign.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>BoldSign Pricing, Free Trial & Docusign Alternative (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Compare current BoldSign pricing displays, its 30-day free trial, unlimited-envelope Business plan, audit trails, API options, and Docusign alternative considerations before you buy." />
+    <title>BoldSign Pricing, Free Plan & Docusign Alternative (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Compare BoldSign's current free plan, 30-day trial, unlimited-envelope Business plan and Docusign-alternative positioning before you choose an e-signature tool." />
     <link rel="canonical" href="https://coshuma.com/tool/boldsign.html" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/boldsign.html" />
-    <meta property="og:title" content="BoldSign Pricing, Free Trial & Docusign Alternative (2026)" />
-    <meta property="og:description" content="Research BoldSign pricing displays, unlimited-envelope plans, audit trails, API options and Docusign alternative considerations before choosing an e-signature platform." />
+    <meta property="og:title" content="BoldSign Pricing, Free Plan & Docusign Alternative (2026)" />
+    <meta property="og:description" content="Buyer-focused BoldSign guide with current public pricing signals, free entry options, unlimited-envelope positioning and verified partner access." />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -18,7 +18,7 @@
       "operatingSystem": "Web",
       "applicationCategory": "BusinessApplication",
       "url": "https://coshuma.com/tool/boldsign.html",
-      "description": "Electronic-signature software with templates, audit trails, integrations and API workflows."
+      "description": "Electronic-signature software for contracts, onboarding, approvals, templates, audit trails and API workflows."
     }
     </script>
     <script src="https://cdn.tailwindcss.com"></script>
@@ -43,88 +43,98 @@
 
     <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
       <section class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-6">
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
-          <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=boldsign.com&sz=128" alt="BoldSign logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
-            <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">E-signature software</div>
-              <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">BoldSign Pricing & Review</h1>
-              <p class="text-slate-400 text-sm mt-2">Buyer-focused summary checked September 1, 2026.</p>
-            </div>
+        <div class="flex items-center gap-5 border-b border-[#222538] pb-6">
+          <img src="https://www.google.com/s2/favicons?domain=boldsign.com&sz=128" alt="BoldSign logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
+          <div>
+            <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">E-signature software</div>
+            <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">BoldSign Pricing & Buyer Guide</h1>
+            <p class="text-slate-400 text-sm mt-2">Current vendor pages and partner guidance checked September 4, 2026.</p>
           </div>
         </div>
 
-        <p class="text-slate-300 leading-relaxed">BoldSign is an electronic-signature platform for sending, tracking and managing documents. Its official site currently advertises a 30-day free trial with no credit card required, along with plans aimed at individual senders, teams and higher-volume workflows.</p>
+        <p class="text-slate-300 leading-relaxed">BoldSign is built for contracts, onboarding, quotes and approvals that need signatures without printing, scanning or chasing documents manually. Its current public pages emphasize a free entry option, a 30-day free trial and an unlimited-envelope Business plan for higher-volume teams.</p>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <a data-cta="affiliate" data-tool-id="boldsign" data-cta-source="boldsign-hero" href="https://boldsign.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-4 px-5 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center shadow-lg transition-all">Try BoldSign via verified partner link →</a>
+          <a data-cta="official" href="https://www.boldsign.com/electronic-signature-pricing/" target="_blank" rel="noopener noreferrer" class="py-4 px-5 rounded-xl bg-slate-800 hover:bg-slate-700 border border-slate-600 font-extrabold text-sm text-white text-center transition-all">Check current official pricing →</a>
+        </div>
 
         <div class="p-4 rounded-2xl bg-amber-500/5 border border-amber-500/20 text-xs text-amber-100 leading-relaxed">
-          Affiliate disclosure: the purple BoldSign button on this page uses a verified partner link. GlobalSaaSHub may earn a commission if you buy through it, at no extra cost to you.
+          Affiliate disclosure: the purple BoldSign buttons use a verified partner link. GlobalSaaSHub may earn a commission if you buy through them, at no extra cost to you.
         </div>
       </section>
 
       <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
         <div class="flex items-center justify-between gap-3 flex-wrap">
-          <h2 class="text-2xl font-bold text-white">Current published pricing signals</h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">Vendor pages checked Sep 1, 2026</span>
+          <h2 class="text-2xl font-bold text-white">Current public pricing signals</h2>
+          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">Checked Sep 4, 2026</span>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-emerald-500/20">
+            <div class="text-xs uppercase tracking-wider text-emerald-300 font-bold">Essential</div>
+            <div class="text-xl font-black text-white mt-1">$0</div>
+            <p class="text-xs text-slate-400 mt-2">Current public pricing shows 25 envelopes/month and 2 templates.</p>
+          </div>
           <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
-            <div class="text-xs uppercase tracking-wider text-slate-400 font-bold">Free trial</div>
-            <div class="text-xl font-black text-white mt-1">30 days</div>
-            <p class="text-xs text-slate-400 mt-2">BoldSign advertises no credit card requirement for the trial.</p>
+            <div class="text-xs uppercase tracking-wider text-slate-300 font-bold">Growth</div>
+            <div class="text-xl font-black text-white mt-1">from $15/user</div>
+            <p class="text-xs text-slate-400 mt-2">Public pricing lists 50 envelopes/month/user and 10 templates.</p>
           </div>
           <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20">
             <div class="text-xs uppercase tracking-wider text-purple-300 font-bold">Business</div>
-            <div class="text-xl font-black text-emerald-400 mt-1">$15–$25/month/user</div>
-            <p class="text-xs text-slate-400 mt-2">BoldSign currently displays both figures depending on billing mode; the plan includes unlimited envelopes and unlimited templates.</p>
+            <div class="text-xl font-black text-emerald-400 mt-1">unlimited envelopes</div>
+            <p class="text-xs text-slate-400 mt-2">BoldSign currently displays billing-cycle variants and unlimited templates.</p>
           </div>
           <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20">
             <div class="text-xs uppercase tracking-wider text-blue-300 font-bold">Premium</div>
-            <div class="text-xl font-black text-emerald-400 mt-1">$99–$138/month</div>
-            <p class="text-xs text-slate-400 mt-2">BoldSign currently displays both figures depending on billing mode; the plan lists 250 envelopes/month, unlimited templates and unlimited users.</p>
+            <div class="text-xl font-black text-emerald-400 mt-1">from $99/month</div>
+            <p class="text-xs text-slate-400 mt-2">Current public pricing shows unlimited users and 250 envelopes/month.</p>
           </div>
         </div>
-        <p class="text-[10px] text-slate-500">Prices are USD figures shown on BoldSign's current public pages and can vary by billing cycle, region, taxes or promotion. Confirm the active checkout price before purchase.</p>
+        <p class="text-[10px] text-slate-500">BoldSign currently shows multiple figures for some plans depending on billing mode. Prices are USD and may vary by billing cycle, taxes, region or promotion. Confirm the live checkout before purchase.</p>
       </section>
 
       <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
-        <h2 class="text-2xl font-bold text-white">BoldSign vs Docusign: what changes for a buyer?</h2>
-        <p class="text-slate-300 text-sm leading-relaxed">For buyers comparing e-signature costs, envelope allocation is a useful distinction: BoldSign's Business plan is currently presented with unlimited envelopes. Docusign's public self-serve pages currently show 100 envelopes per user per year on Standard and Business Pro, but Docusign's displayed dollar prices differ across its public storefronts and market pages. For that reason, this page does not hard-code a single Docusign price—confirm the localized checkout before comparing total cost.</p>
+        <h2 class="text-2xl font-bold text-white">Who is most likely to benefit?</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
           <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">BoldSign may fit better when</div>
+            <div class="font-bold text-purple-300">Strong fit</div>
             <ul class="text-slate-300 text-xs space-y-2 list-disc list-inside">
-              <li>You expect frequent signature requests and want an unlimited-envelope Business plan.</li>
-              <li>You want reusable templates and audit-trail records in an e-signature workflow.</li>
-              <li>You need API or embedded-signing options and want to test with a free developer sandbox.</li>
+              <li>Freelancers sending contracts or client approvals.</li>
+              <li>HR teams collecting onboarding and policy signatures.</li>
+              <li>Sales teams sending quotes, agreements and approvals.</li>
+              <li>Operations teams that want fewer print-sign-scan steps.</li>
+              <li>Higher-volume senders evaluating unlimited-envelope pricing.</li>
             </ul>
           </div>
           <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Verify Docusign directly when</div>
+            <div class="font-bold text-blue-300">Compare alternatives first when</div>
             <ul class="text-slate-300 text-xs space-y-2 list-disc list-inside">
-              <li>Your organization already depends on Docusign-specific integrations or procurement standards.</li>
-              <li>You need a particular enterprise or regional compliance configuration not covered by public plan summaries.</li>
-              <li>Your localized price, envelope volume or negotiated terms could differ from public self-serve pages.</li>
+              <li>Your organization requires a vendor already embedded in procurement or enterprise workflows.</li>
+              <li>You need a specific regional compliance, identity or integration configuration.</li>
+              <li>Your expected envelope volume is low enough that a free tier already covers the use case.</li>
             </ul>
           </div>
         </div>
       </section>
 
       <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
-        <h2 class="text-2xl font-bold text-white">Verified capabilities worth checking</h2>
+        <h2 class="text-2xl font-bold text-white">Why BoldSign is often compared with Docusign</h2>
+        <p class="text-slate-300 text-sm leading-relaxed">The practical buying question is usually less about basic e-signature capability and more about volume, cost predictability and workflow fit. BoldSign's current public material emphasizes unlimited envelopes on Business and positions that model against envelope-limited alternatives. Buyers already committed to Docusign-specific integrations, procurement standards or enterprise contracts should verify switching costs before changing platforms.</p>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-slate-300">
-          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Reusable templates</div>
-          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Downloadable audit trails after signing</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Reusable templates and audit trails</div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Automated reminders and signer authentication</div>
           <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ API and embedded-signing workflows</div>
           <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Free developer sandbox for API testing</div>
         </div>
       </section>
 
       <section class="p-6 rounded-3xl bg-gradient-to-br from-purple-950/40 to-[#131520] border border-purple-500/30 space-y-4 text-center">
-        <h2 class="text-2xl font-black text-white">Check BoldSign's current plan before you buy</h2>
-        <p class="text-slate-300 text-sm max-w-2xl mx-auto">Use the verified partner link to confirm today's trial, billing mode, plan limits and checkout price directly with BoldSign.</p>
+        <h2 class="text-2xl font-black text-white">Need signatures without the print-scan loop?</h2>
+        <p class="text-slate-300 text-sm max-w-2xl mx-auto">Use the verified partner route to test the current BoldSign offer, then confirm the active plan limits and checkout price before paying.</p>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-2xl mx-auto pt-2">
-          <a data-cta="official" href="https://www.boldsign.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-slate-800 hover:bg-slate-700 border border-slate-600 font-extrabold text-xs text-white text-center transition-all">Visit official BoldSign site →</a>
-          <a data-cta="affiliate" data-tool-id="boldsign" href="https://boldsign.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Start BoldSign via verified affiliate link →</a>
+          <a data-cta="official" href="https://www.boldsign.com/electronic-signature-pricing/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-slate-800 hover:bg-slate-700 border border-slate-600 font-extrabold text-xs text-white text-center transition-all">Review official pricing →</a>
+          <a data-cta="affiliate" data-tool-id="boldsign" data-cta-source="boldsign-final" href="https://boldsign.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Start BoldSign via verified affiliate link →</a>
         </div>
       </section>
     </main>
@@ -132,5 +142,6 @@
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
       <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
     </footer>
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
Refresh the BoldSign buyer page using the vendor's current public pricing signals and the latest affiliate guidance. Move the verified partner CTA into the hero, add clear freelancer/HR/sales/operations use cases, preserve a second high-intent CTA, and load the existing affiliate attribution script with CTA-source metadata. No paid services or guessed tracking links are introduced.