### PR TITLE
Optimize GetGenie vs Inkfluence buyer conversion

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/getgenie-vs-inkfluence-ai.html
+++ b/projects/GlobalSaaSHub/public/compare/getgenie-vs-inkfluence-ai.html
@@ -1,172 +1,110 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>GetGenie vs Inkfluence AI Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of GetGenie vs Inkfluence AI. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>GetGenie vs Inkfluence AI: SEO Content vs AI Book Publishing (2026) | GlobalSaaSHub</title>
+  <meta name="description" content="GetGenie vs Inkfluence AI compared for real buying intent: SEO content workflows versus AI book creation and publishing. See current public pricing and choose the right fit." />
+  <link rel="canonical" href="https://coshuma.com/compare/getgenie-vs-inkfluence-ai.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/getgenie-vs-inkfluence-ai.html" />
+  <meta property="og:title" content="GetGenie vs Inkfluence AI (2026)" />
+  <meta property="og:description" content="Choose GetGenie for SEO-led content production or Inkfluence AI for AI-assisted book and ebook creation." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"WebPage",
+    "name":"GetGenie vs Inkfluence AI",
+    "url":"https://coshuma.com/compare/getgenie-vs-inkfluence-ai.html",
+    "description":"Buyer-focused comparison of GetGenie and Inkfluence AI.",
+    "isPartOf":{"@type":"WebSite","name":"GlobalSaaSHub","url":"https://coshuma.com/"},
+    "about":[
+      {"@type":"SoftwareApplication","name":"GetGenie","url":"https://coshuma.com/tool/getgenie.html"},
+      {"@type":"SoftwareApplication","name":"Inkfluence AI","url":"https://coshuma.com/tool/inkfluence-ai.html"}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9} h1,h2,h3{font-family:'Outfit',sans-serif}
+  </style>
+</head>
+<body class="min-h-screen">
+  <header class="border-b border-[#222538] bg-[#07080c]/90 py-4 px-6">
+    <div class="max-w-5xl mx-auto flex items-center justify-between">
+      <a href="/" class="font-extrabold text-white">GlobalSaaSHub</a>
+      <a href="/" class="text-xs font-bold text-purple-300">← All tools</a>
+    </div>
+  </header>
 
-    <link rel="canonical" href="https://coshuma.com/compare/getgenie-vs-inkfluence-ai.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/getgenie-vs-inkfluence-ai.html" />
-    <meta property="og:title" content="GetGenie vs Inkfluence AI Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare GetGenie and Inkfluence AI by pricing, features, and verified public information." />
-
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "GetGenie vs Inkfluence AI Comparison",
-      "url": "https://coshuma.com/compare/getgenie-vs-inkfluence-ai.html",
-      "description": "Compare GetGenie and Inkfluence AI by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "GetGenie", "url": "https://coshuma.com/tool/getgenie.html"},
-        {"@type": "SoftwareApplication", "name": "Inkfluence AI", "url": "https://coshuma.com/tool/inkfluence-ai.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+  <main class="max-w-5xl mx-auto px-4 py-12 space-y-8">
+    <section class="text-center space-y-4">
+      <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Buyer guide · verified partner routes</div>
+      <h1 class="text-4xl md:text-6xl font-black text-white">GetGenie vs Inkfluence AI</h1>
+      <p class="max-w-3xl mx-auto text-slate-300">These products solve different jobs. Pick <strong class="text-white">GetGenie</strong> when SEO research, ranking-oriented writing and ongoing site content are the priority. Pick <strong class="text-white">Inkfluence AI</strong> when the goal is to create, export and sell books or ebooks.</p>
+      <div class="grid md:grid-cols-2 gap-3 max-w-3xl mx-auto pt-2">
+        <a data-cta="affiliate" data-tool-id="getgenie" data-cta-source="hero-getgenie" href="https://getgenie.ai?rui=3921" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-white">Try GetGenie free →</a>
+        <a data-cta="affiliate" data-tool-id="inkfluence-ai" data-cta-source="hero-inkfluence" href="https://www.inkfluenceai.com/?ref=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-white">Start Inkfluence AI free →</a>
       </div>
-    </header>
+      <p class="text-[11px] text-slate-500">Affiliate disclosure: GlobalSaaSHub may earn a commission from qualifying purchases through the partner links above, at no extra cost to you.</p>
+    </section>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">GetGenie vs Inkfluence AI</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best SEO & Optimization tool.
-        </p>
+    <section class="grid md:grid-cols-2 gap-5">
+      <article class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
+        <h2 class="text-2xl font-black text-white">Choose GetGenie for SEO content operations</h2>
+        <p class="text-sm text-slate-300">GetGenie combines AI writing with SEO-oriented workflows such as SERP analysis, keyword analysis, topical maps, AI Overview answer building, FAQ generation and rank/page tracking.</p>
+        <ul class="text-sm text-slate-300 space-y-2">
+          <li>✓ Free plan with 2.5K AI words/month</li>
+          <li>✓ Free plan requires no credit card</li>
+          <li>✓ Public monthly tiers currently list Starter $9.99, Writer $19, Pro $49 and Agency $99</li>
+          <li>✓ Better fit for blogs, agencies and teams managing recurring search-led content</li>
+        </ul>
+        <a href="https://getgenie.ai/pricing/" target="_blank" rel="noopener noreferrer" class="text-xs font-bold text-purple-300">Check official GetGenie pricing →</a>
+      </article>
+
+      <article class="p-6 rounded-3xl bg-[#131520] border border-blue-500/30 space-y-4">
+        <h2 class="text-2xl font-black text-white">Choose Inkfluence AI for books and ebooks</h2>
+        <p class="text-sm text-slate-300">Inkfluence AI is positioned around turning a book idea into chapters, editing the result, designing a cover and exporting files for publishing or direct sale.</p>
+        <ul class="text-sm text-slate-300 space-y-2">
+          <li>✓ Free: $0 with 5 chapters plus 5 more monthly</li>
+          <li>✓ Creator: $9.99/month or $89/year</li>
+          <li>✓ Premium: $19.99/month or $179/year</li>
+          <li>✓ PDF, EPUB and DOCX export; vendor states creators retain commercial-use rights</li>
+        </ul>
+        <a href="https://www.inkfluenceai.com/" target="_blank" rel="noopener noreferrer" class="text-xs font-bold text-blue-300">Check official Inkfluence AI pricing →</a>
+      </article>
+    </section>
+
+    <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+      <h2 class="text-2xl font-black text-white">Fast decision</h2>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm text-left">
+          <thead class="text-slate-400"><tr><th class="py-3 pr-4">Buying question</th><th class="py-3 pr-4">GetGenie</th><th class="py-3">Inkfluence AI</th></tr></thead>
+          <tbody class="divide-y divide-[#222538] text-slate-300">
+            <tr><td class="py-3 pr-4">Primary outcome</td><td class="py-3 pr-4">SEO/content production</td><td class="py-3">Books/ebooks</td></tr>
+            <tr><td class="py-3 pr-4">Free entry</td><td class="py-3 pr-4">Yes, no card required</td><td class="py-3">Yes</td></tr>
+            <tr><td class="py-3 pr-4">Core workflow</td><td class="py-3 pr-4">Keywords, SERPs, writing, tracking</td><td class="py-3">Chapters, editing, covers, export</td></tr>
+            <tr><td class="py-3 pr-4">Best fit</td><td class="py-3 pr-4">Marketers, bloggers, SEO teams</td><td class="py-3">Authors, ebook sellers, publishers</td></tr>
+          </tbody>
+        </table>
       </div>
+      <p class="text-xs text-slate-500">Pricing and product facts checked against official vendor pages on September 4, 2026. Vendors may change pricing or limits; confirm the live checkout before purchase.</p>
+    </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose GetGenie if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Inkfluence AI if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
+    <section class="p-6 rounded-3xl bg-gradient-to-r from-purple-500/10 to-blue-500/10 border border-purple-500/20 text-center space-y-4">
+      <h2 class="text-2xl font-black text-white">Ready to choose?</h2>
+      <p class="text-sm text-slate-300">Use the product that matches the job you actually need done. Both routes below are the verified partner URLs already recorded for COSHUMA.</p>
+      <div class="grid md:grid-cols-2 gap-3 max-w-3xl mx-auto">
+        <a data-cta="affiliate" data-tool-id="getgenie" data-cta-source="final-getgenie" href="https://getgenie.ai?rui=3921" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-white">Try GetGenie free →</a>
+        <a data-cta="affiliate" data-tool-id="inkfluence-ai" data-cta-source="final-inkfluence" href="https://www.inkfluenceai.com/?ref=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-white">Start Inkfluence AI free →</a>
       </div>
+    </section>
+  </main>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/getgenie.html" class="hover:text-purple-300">GetGenie</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/inkfluence-ai.html" class="hover:text-blue-300">Inkfluence AI</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">GetGenie Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ AI content generation</div>
-<div>✓ SEO optimization features</div>
-<div>✓ Blog post wizard</div>
-<div>✓ Social media content creation</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Inkfluence AI Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ AI-powered content generation</div>
-<div>✓ Tailored for indie publishers</div>
-<div>✓ Boost writing productivity</div>
-<div>✓ SEO-optimized content suggestions</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://getgenie.ai?rui=3921" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get GetGenie →</a>
-          <a href="https://www.inkfluenceai.com/?ref=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Inkfluence AI →</a>
-        </div>
-      </div>
-    </main>
-
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
-  </body>
+  <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">&copy; 2026 GlobalSaaSHub</footer>
+  <script src="/affiliate-attribution.js" defer></script>
+</body>
 </html>


### PR DESCRIPTION
Revenue-focused, zero-cost update for an under-optimized comparison page.

Evidence checked 2026-09-04:
- GetGenie official pricing currently lists a free no-card plan plus paid monthly tiers beginning at $9.99, with SEO/SERP/keyword/topical-map and tracking features.
- Inkfluence AI official site currently lists Free $0, Creator $9.99/mo or $89/yr, Premium $19.99/mo or $179/yr, with book/ebook creation, exports, and commercial-use rights.
- Both customer-facing partner URLs are already stored as verified approved_tracking routes in the repository.

Changes:
- remove placeholder `Not rated` / `See official pricing` content;
- reposition the comparison around the actual buying decision: SEO content operations vs book/ebook publishing;
- add verified affiliate CTAs above the fold and at the final decision point;
- add `data-tool-id` and `data-cta-source` metadata for both programs;
- load `/affiliate-attribution.js` and add affiliate disclosure;
- keep official pricing links separate from partner URLs.

No paid service, guessed referral parameter, duplicate application, or dashboard/onboarding URL is introduced.