### PR TITLE
Optimize Vista Social vs Notion buyer conversion

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/vista-social-vs-notion-ai.html
+++ b/projects/GlobalSaaSHub/public/compare/vista-social-vs-notion-ai.html
@@ -3,170 +3,128 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vista Social vs Notion AI Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Vista Social vs Notion AI. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
-
+    <title>Vista Social vs Notion AI: Which Is Better for Social Media vs Team Work? (2026) | GlobalSaaSHub</title>
+    <meta name="description" content="Vista Social vs Notion AI in 2026: compare social media publishing, inbox, analytics, AI, project workflows, pricing, and free-trial options before you choose." />
     <link rel="canonical" href="https://coshuma.com/compare/vista-social-vs-notion-ai.html" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/compare/vista-social-vs-notion-ai.html" />
-    <meta property="og:title" content="Vista Social vs Notion AI Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Vista Social and Notion AI by pricing, features, and verified public information." />
-
+    <meta property="og:title" content="Vista Social vs Notion AI (2026): Social Media Suite or AI Workspace?" />
+    <meta property="og:description" content="Choose Vista Social for social publishing, engagement, reporting and social workflows; choose Notion AI for docs, knowledge, projects and AI-assisted team work." />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebPage",
-      "name": "Vista Social vs Notion AI Comparison",
+      "name": "Vista Social vs Notion AI (2026)",
       "url": "https://coshuma.com/compare/vista-social-vs-notion-ai.html",
-      "description": "Compare Vista Social and Notion AI by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
+      "description": "Buyer-focused comparison of Vista Social and Notion AI for social media operations and AI-powered team work.",
+      "isPartOf": {"@type":"WebSite","name":"GlobalSaaSHub","url":"https://coshuma.com/"},
       "about": [
-        {"@type": "SoftwareApplication", "name": "Vista Social", "url": "https://coshuma.com/tool/vista-social.html"},
-        {"@type": "SoftwareApplication", "name": "Notion AI", "url": "https://coshuma.com/tool/notion-ai.html"}
+        {"@type":"SoftwareApplication","name":"Vista Social","url":"https://coshuma.com/tool/vista-social.html"},
+        {"@type":"SoftwareApplication","name":"Notion AI","url":"https://coshuma.com/tool/notion-ai.html"}
       ]
     }
     </script>
-    
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
+      body { font-family: 'Inter', sans-serif; background:#0b0c10; color:#f1f5f9; }
+      h1,h2,h3 { font-family:'Outfit',sans-serif; }
     </style>
   </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+  <body class="min-h-screen bg-[#0b0c10]">
+    <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div><span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span></a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">← All tools</a>
       </div>
     </header>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
+    <main class="max-w-5xl mx-auto px-4 py-12 space-y-8">
+      <section class="text-center space-y-4">
+        <div class="inline-flex items-center px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Buyer guide · Updated September 4, 2026</div>
+        <h1 class="text-4xl md:text-6xl font-black tracking-tight">Vista Social vs Notion AI</h1>
+        <p class="text-lg text-slate-300 max-w-3xl mx-auto">These tools overlap on AI and workflow, but they solve different buying problems. <strong>Vista Social</strong> is built around social publishing, engagement, reporting and campaign operations. <strong>Notion AI</strong> is built around docs, knowledge, projects and AI-assisted team work.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-2xl mx-auto pt-2">
+          <a data-cta="affiliate" data-tool-id="vista-social" data-cta-source="hero" href="https://vistasocial.com?fpr=sangkwon14" target="_blank" rel="sponsored noopener noreferrer" class="py-4 px-5 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white shadow-lg">Try Vista Social free for 14 days →</a>
+          <a data-cta="official" data-tool-id="notion-ai" data-cta-source="hero" href="https://www.notion.com/pricing" target="_blank" rel="noopener noreferrer" class="py-4 px-5 rounded-xl bg-slate-800 hover:bg-slate-700 font-extrabold text-sm text-white border border-slate-600">See Notion pricing →</a>
         </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Vista Social vs Notion AI</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Workflow Automation tool.
-        </p>
-      </div>
+        <p class="text-[11px] text-slate-500">Disclosure: the Vista Social button is an affiliate link. If you become a paying customer, GlobalSaaSHub may earn a commission at no extra cost to you.</p>
+      </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Vista Social if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-5">
+        <article class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-3">
+          <div class="text-purple-300 text-xs font-black uppercase tracking-wider">Choose Vista Social when</div>
+          <h2 class="text-2xl font-black">Your work starts with social channels</h2>
+          <ul class="text-sm text-slate-300 space-y-2">
+            <li>✓ You schedule and publish across multiple social profiles.</li>
+            <li>✓ Your team handles comments, messages, reviews and approvals.</li>
+            <li>✓ You need social analytics, reporting, listening or DM automation.</li>
+            <li>✓ You want campaign projects and tasks to live close to social content.</li>
+          </ul>
+        </article>
+        <article class="p-6 rounded-3xl bg-[#131520] border border-blue-500/30 space-y-3">
+          <div class="text-blue-300 text-xs font-black uppercase tracking-wider">Choose Notion AI when</div>
+          <h2 class="text-2xl font-black">Your work starts with knowledge and projects</h2>
+          <ul class="text-sm text-slate-300 space-y-2">
+            <li>✓ Your team lives in docs, databases, project pages and internal knowledge.</li>
+            <li>✓ You want AI to generate, summarize, search and act on workspace context.</li>
+            <li>✓ Meeting notes, enterprise search and team knowledge matter more than social inboxes.</li>
+            <li>✓ You want a general collaboration workspace rather than a dedicated social suite.</li>
+          </ul>
+        </article>
+      </section>
+
+      <section class="p-6 md:p-8 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
+        <h2 class="text-2xl font-black">Pricing snapshot</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
+            <h3 class="font-black text-lg text-purple-200">Vista Social</h3>
+            <p class="text-sm text-slate-300">Professional is $79/month, Advanced $149/month, and Scale $349/month on monthly billing. Annual billing is discounted. Professional includes 15 social profiles and 2 users.</p>
+            <p class="text-sm font-bold text-emerald-400">14-day free trial · no credit card required</p>
+            <a href="https://vistasocial.com/pricing" target="_blank" rel="noopener noreferrer" class="text-xs text-purple-300 underline">Verify live Vista Social pricing</a>
           </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Notion AI if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with Free trial; Business plan with Notion AI at $20/user/month pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
-      </div>
-
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/vista-social.html" class="hover:text-purple-300">Vista Social</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/notion-ai.html" class="hover:text-blue-300">Notion AI</a>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
+            <h3 class="font-black text-lg text-blue-200">Notion</h3>
+            <p class="text-sm text-slate-300">Current public US pricing shows Free at $0, Plus at $10 per seat/month, Business at $20 per seat/month, and Enterprise by quote. Free and Plus include limited Notion AI trials; Business adds deeper AI workspace capabilities such as Notion Agent and AI Meeting Notes.</p>
+            <p class="text-sm font-bold text-emerald-400">Free plan available</p>
+            <a href="https://www.notion.com/pricing" target="_blank" rel="noopener noreferrer" class="text-xs text-blue-300 underline">Verify live Notion pricing</a>
           </div>
         </div>
+        <p class="text-[11px] text-slate-500">Prices and included limits can change. Check the vendor pricing page before purchase.</p>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
+      <section class="p-6 md:p-8 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black">What you are really buying</h2>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm min-w-[680px]">
+            <thead><tr class="text-left border-b border-[#2a2d3e]"><th class="py-3 pr-4">Decision factor</th><th class="py-3 pr-4 text-purple-300">Vista Social</th><th class="py-3 text-blue-300">Notion AI</th></tr></thead>
+            <tbody class="text-slate-300">
+              <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold">Primary job</td><td class="py-3 pr-4">Run social media operations</td><td class="py-3">Run team knowledge and project work</td></tr>
+              <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold">Publishing & scheduling</td><td class="py-3 pr-4">Core product capability</td><td class="py-3">Not a social publishing suite</td></tr>
+              <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold">Social inbox / engagement</td><td class="py-3 pr-4">Core capability</td><td class="py-3">Not the core use case</td></tr>
+              <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold">Docs & knowledge base</td><td class="py-3 pr-4">Supporting workflow</td><td class="py-3">Core capability</td></tr>
+              <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold">AI</td><td class="py-3 pr-4">Ask Vista, AI content/replies, AI knowledge</td><td class="py-3">Agent, writing, search, meeting notes, workspace context</td></tr>
+              <tr><td class="py-3 pr-4 font-bold">Best fit</td><td class="py-3 pr-4">Agencies, social teams, multi-brand operators</td><td class="py-3">Teams centralizing docs, projects and knowledge</td></tr>
+            </tbody>
+          </table>
         </div>
+      </section>
 
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">Free trial; Business plan with Notion AI at $20/user/month</div>
-          </div>
+      <section class="p-7 rounded-3xl bg-gradient-to-br from-purple-900/40 to-blue-900/20 border border-purple-500/30 text-center space-y-4">
+        <h2 class="text-2xl md:text-3xl font-black">Short answer</h2>
+        <p class="text-slate-200 max-w-3xl mx-auto">If the outcome you are buying is <strong>better social publishing, engagement and reporting</strong>, Vista Social is the direct fit. If the outcome is <strong>one AI-enabled workspace for docs, projects and company knowledge</strong>, choose Notion.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-2xl mx-auto pt-2">
+          <a data-cta="affiliate" data-tool-id="vista-social" data-cta-source="final-decision" href="https://vistasocial.com?fpr=sangkwon14" target="_blank" rel="sponsored noopener noreferrer" class="py-4 px-5 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white shadow-lg">Start Vista Social's 14-day trial →</a>
+          <a data-cta="official" data-tool-id="notion-ai" data-cta-source="final-decision" href="https://www.notion.com/pricing" target="_blank" rel="noopener noreferrer" class="py-4 px-5 rounded-xl bg-slate-800 hover:bg-slate-700 font-extrabold text-sm text-white border border-slate-600">Compare Notion plans →</a>
         </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Vista Social Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ AI-powered social media management</div>
-<div>✓ Content publishing and scheduling</div>
-<div>✓ Engagement tracking and analytics</div>
-<div>✓ Team collaboration workflows</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Notion AI Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Inline Writing Help</div>
-<div>✓ Meeting Summaries</div>
-<div>✓ Database Automation</div>
-<div>✓ Custom Prompts</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a data-cta="affiliate" href="https://vistasocial.com?fpr=sangkwon14" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Vista Social →</a>
-          <a href="https://www.notion.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Notion AI →</a>
-        </div>
-      </div>
+      </section>
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Independent software comparison.</div>
     </footer>
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## What changed
- replace low-value autogenerated comparison copy with a buyer-intent social-media-vs-workspace decision guide
- use the already verified Vista Social referral URL from the affiliate program email
- add high-intent Vista Social CTAs with product/source attribution metadata
- keep Notion links official/non-affiliate
- load the shared affiliate attribution script
- refresh pricing and free-trial copy against current official vendor pages

## Revenue rationale
This page already had a verified Vista Social referral route but weak copy and incomplete click attribution. The update moves the verified revenue CTA into high-intent positions while preserving transparent non-affiliate treatment for Notion.

No paid services or new subscriptions are introduced.