### PR TITLE
Align COSHUMA homepage SEO branding

### DIFF
--- a/projects/GlobalSaaSHub/index.html
+++ b/projects/GlobalSaaSHub/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    
+
     <!-- Auto-recovery script for stale browser script cache errors -->
     <script>
       window.addEventListener('error', function(e) {
@@ -21,25 +21,26 @@
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="google-site-verification" content="google0f306d6dc6fa9ff6" />
-    <title>GlobalSaaSHub | Premier AI & B2B SaaS Tool Directory</title>
+    <title>COSHUMA | Compare AI & SaaS Pricing, Reviews & Alternatives</title>
 
-    <meta name="description" content="Compare AI and SaaS tools by pricing, features, alternatives, and best-fit use cases. Explore buyer-focused reviews and side-by-side software comparisons." />
+    <meta name="description" content="Compare AI and SaaS tools by pricing, trials, use cases, strengths, alternatives and verified public information before you subscribe." />
     <link rel="canonical" href="https://coshuma.com/" />
-    
+
     <!-- Open Graph SEO Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/" />
-    <meta property="og:title" content="GlobalSaaSHub | Premier AI & B2B SaaS Tool Directory" />
-    <meta property="og:description" content="Compare AI and SaaS tools by pricing, features, alternatives, and best-fit use cases. Explore buyer-focused reviews and side-by-side software comparisons." />
+    <meta property="og:site_name" content="COSHUMA" />
+    <meta property="og:title" content="COSHUMA | Compare AI & SaaS Pricing, Reviews & Alternatives" />
+    <meta property="og:description" content="Compare AI and SaaS tools by pricing, trials, use cases, strengths, alternatives and verified public information before you subscribe." />
 
     <!-- JSON-LD Structured Data for Google Indexing -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebSite",
-      "name": "GlobalSaaSHub",
+      "name": "COSHUMA",
       "url": "https://coshuma.com/",
-      "description": "Compare AI and SaaS tools by pricing, features, alternatives, and best-fit use cases. Explore buyer-focused reviews and side-by-side software comparisons."
+      "description": "Independent AI and SaaS decision guides covering pricing, trials, use cases, alternatives and verified public information."
     }
     </script>
 
@@ -48,13 +49,13 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;550;700;900&family=Inter:wght@300;400;600;800&display=swap" rel="stylesheet">
   </head>
-  <body style="background-color: #090a0f; color: #ffffff; margin: 0; padding: 0;">
+  <body style="background-color: #08090d; color: #ffffff; margin: 0; padding: 0;">
     <div id="root">
       <!-- Static fallback content for search and AI crawlers before the app hydrates. -->
-      <div style="padding: 40px; max-width: 800px; margin: 0 auto; text-align: center;">
-        <h1 style="font-size: 28px; font-weight: 800; color: #a855f7;">GlobalSaaSHub - AI & SaaS Pricing, Reviews and Comparisons</h1>
-        <p style="font-size: 14px; color: #94a3b8; line-height: 1.6;">
-          Compare AI software, productivity tools, workflow automation, creator platforms and business SaaS by pricing, features, alternatives and best-fit use cases. Use the buyer guides below to reach detailed reviews and side-by-side comparisons without relying on client-side JavaScript.
+      <div style="padding: 40px; max-width: 860px; margin: 0 auto; text-align: center;">
+        <h1 style="font-size: 30px; font-weight: 900; color: #c4b5fd;">COSHUMA — Compare AI & SaaS Before You Subscribe</h1>
+        <p style="font-size: 14px; color: #94a3b8; line-height: 1.7;">
+          Independent buyer guides for AI software and business SaaS. Compare pricing, free trials, use cases, strengths, alternatives and verified public information before choosing a tool.
         </p>
         <nav aria-label="Featured software buyer guides" style="margin-top: 20px; font-size: 13px; line-height: 2;">
           <strong>Popular pricing and review guides:</strong><br />


### PR DESCRIPTION
Updates the GlobalSaaSHub homepage document metadata and crawler fallback to match the newly merged COSHUMA buyer-decision UI. Preserves canonical URL, Google verification, existing featured buyer-guide links, and app entrypoint. Changes title, Open Graph, JSON-LD, description, fallback heading/copy, and background branding only. No paid services or affiliate destinations changed.