### PR TITLE
Optimize Murf AI buyer conversion landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/murf-ai.html
+++ b/projects/GlobalSaaSHub/public/tool/murf-ai.html
@@ -3,169 +3,112 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Murf AI Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="An AI voice generator that provides realistic text-to-speech voices for various applications, empowering voice-over creators.... Discover features, pricing (See official pricing), and official links for Murf AI on GlobalSaaSHub." />
+    <title>Murf AI Pricing, Free Plan & Voice Generator Review (2026) | COSHUMA</title>
+    <meta name="description" content="Murf AI pricing guide for 2026: compare the $0 Free plan, Creator from $19/month billed annually, Business from $66/month, 200+ voices, and a verified COSHUMA partner link." />
     <link rel="canonical" href="https://coshuma.com/tool/murf-ai.html" />
-    
-    <!-- Open Graph SEO Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/murf-ai.html" />
-    <meta property="og:title" content="Murf AI Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="An AI voice generator that provides realistic text-to-speech voices for various applications, empowering voice-over creators.... Check rating, pricing, and features." />
-
-    <!-- JSON-LD Structured Data for Google Indexing -->
+    <meta property="og:title" content="Murf AI Pricing, Free Plan & Voice Generator Review (2026) | COSHUMA" />
+    <meta property="og:description" content="Compare Murf AI's current Free, Creator, Business and Enterprise paths before choosing a plan." />
     <script type="application/ld+json">
     {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "Murf AI",
-      "operatingSystem": "Web",
-      "applicationCategory": "Voice & Speech AI",
-      "description": "An AI voice generator that provides realistic text-to-speech voices for various applications, empowering voice-over creators."
+      "@context":"https://schema.org",
+      "@type":"SoftwareApplication",
+      "name":"Murf AI",
+      "operatingSystem":"Web",
+      "applicationCategory":"MultimediaApplication",
+      "url":"https://murf.ai/",
+      "description":"AI voice platform for text-to-speech voiceovers, multilingual content, dubbing, translation and voice APIs."
     }
     </script>
-
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
+      body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}
+      h1,h2,h3{font-family:'Outfit',sans-serif}
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+    <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div><span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span></a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← All AI & SaaS Tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
+    <main class="max-w-5xl mx-auto px-4 py-10 w-full space-y-7">
+      <section class="p-7 md:p-9 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-7">
+        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-5">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=murf.ai&sz=128" alt="Murf AI logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
-            <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Voice & Speech AI</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Murf AI</h1>
+            <img src="https://www.google.com/s2/favicons?domain=murf.ai&sz=128" alt="Murf AI logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
+            <div><div class="text-xs font-bold text-purple-300 mb-2">AI VOICE · TEXT TO SPEECH · VOICEOVER</div><h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Murf AI Pricing & Buyer Guide</h1><p class="text-slate-400 mt-2 text-sm">Updated September 4, 2026</p></div>
+          </div>
+          <div class="flex flex-wrap gap-2"><span class="px-3 py-2 rounded-xl text-xs font-extrabold bg-emerald-500/10 border border-emerald-500/20 text-emerald-300">Free $0 · no card</span><span class="px-3 py-2 rounded-xl text-xs font-extrabold bg-purple-500/10 border border-purple-500/20 text-purple-300">Verified partner link</span></div>
+        </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-[1.4fr_.8fr] gap-6 items-start border-t border-[#222538] pt-6">
+          <div class="space-y-4">
+            <h2 class="text-2xl md:text-3xl font-black text-white">Test the voice quality for free. Pay only when your output volume justifies it.</h2>
+            <p class="text-slate-300 leading-relaxed">Murf is built for creating AI voiceovers without recording a voice actor. Its current Studio pricing starts with a permanent Free plan, then moves to Creator for regular individual voiceover work and Business for higher-usage teams.</p>
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm">
+              <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-white">200+ voices</div><div class="text-xs text-slate-400 mt-1">Styles and tonalities across the current Studio plans</div></div>
+              <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-white">30+ languages</div><div class="text-xs text-slate-400 mt-1">The pricing table currently lists 30+ languages and accents</div></div>
+              <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-white">Commercial rights</div><div class="text-xs text-slate-400 mt-1">Included on the Creator plan in the current pricing table</div></div>
             </div>
           </div>
-
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
+          <div class="p-5 rounded-2xl bg-gradient-to-br from-purple-500/10 to-indigo-500/10 border border-purple-500/30 space-y-4">
+            <div class="text-sm font-extrabold text-white">Lowest-risk path</div>
+            <p class="text-xs text-slate-300 leading-relaxed">Start with Free to check pronunciation, pacing and voice fit. If you need ongoing production and downloads, Creator is the practical paid starting point at $19/month when billed annually.</p>
+            <a data-cta="affiliate" data-tool-id="murf-ai" data-cta-source="tool_murf_hero" href="https://get.murf.ai/fqac0vixj0qs" target="_blank" rel="sponsored noopener noreferrer" class="block w-full px-5 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center hover:brightness-110 transition-all">Try Murf AI via Verified Partner Link →</a>
+            <a data-cta="official" href="https://murf.ai/pricing" target="_blank" rel="noopener noreferrer" class="block w-full px-5 py-3 rounded-xl font-bold text-xs bg-slate-800 border border-slate-600 text-white text-center hover:bg-slate-700 transition-all">Check Murf's Live Pricing</a>
+            <p class="text-[11px] text-slate-400 leading-relaxed"><strong class="text-slate-300">Affiliate disclosure:</strong> COSHUMA may earn a commission on eligible paid subscriptions through the partner link. Murf states that its affiliate program does not provide an audience discount.</p>
           </div>
         </div>
+      </section>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">An AI voice generator that provides realistic text-to-speech voices for various applications, empowering voice-over creators.</p>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <div><h2 class="text-2xl font-black text-white">Murf Studio pricing snapshot</h2><p class="text-sm text-slate-400 mt-2">Current annual-billing prices checked September 4, 2026. Billing cadence and product surface can change the amount shown at checkout.</p></div>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          <article class="p-5 rounded-2xl bg-[#181a29] border border-emerald-500/25 space-y-3"><div class="text-xs font-bold text-emerald-400 uppercase">Free</div><h3 class="text-2xl font-black text-white">$0/mo</h3><div class="text-xs text-slate-400">No credit card required. Best for initial voice-quality testing and short experiments.</div></article>
+          <article class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/30 space-y-3"><div class="text-xs font-bold text-purple-300 uppercase">Creator</div><h3 class="text-2xl font-black text-white">$19/mo</h3><div class="text-xs text-slate-400">$228 billed annually. 100 projects, 24 hours/year of voice generation, 1 editor, 200+ voices, unlimited downloads, Canva integration and commercial rights.</div><a data-cta="affiliate" data-tool-id="murf-ai" data-cta-source="tool_murf_creator" href="https://get.murf.ai/fqac0vixj0qs" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex text-xs font-extrabold text-purple-300 hover:text-purple-200">Open Murf through COSHUMA →</a></article>
+          <article class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/30 space-y-3"><div class="text-xs font-bold text-blue-300 uppercase">Business</div><h3 class="text-2xl font-black text-white">$66/mo</h3><div class="text-xs text-slate-400">$792 billed annually. Positioned by Murf as the advanced plan for higher-usage business needs.</div></article>
+          <article class="p-5 rounded-2xl bg-[#181a29] border border-[#334155] space-y-3"><div class="text-xs font-bold text-slate-300 uppercase">Enterprise</div><h3 class="text-2xl font-black text-white">Custom</h3><div class="text-xs text-slate-400">For custom usage, enterprise security/support, collaboration, SSO and negotiated requirements.</div></article>
         </div>
+        <div class="p-4 rounded-2xl bg-amber-500/5 border border-amber-500/20 text-xs text-amber-100 leading-relaxed"><strong>Pricing caution:</strong> Murf exposes separate Studio, Dub and API pricing surfaces. Do not assume a Studio subscription automatically includes every dubbing or API allowance. Verify the exact product and billing cadence before paying.</div>
+      </section>
 
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Studio-quality AI voices</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Custom voice cloning</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Speech-to-text editor</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Background music and sound</div>
-          </div>
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-5">
+        <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-4"><h2 class="text-xl font-black text-white">Good fit if you create</h2><ul class="text-sm text-slate-300 space-y-2.5"><li>✓ YouTube narration and explainer voiceovers</li><li>✓ Marketing, advertising and product-demo audio</li><li>✓ eLearning, training and presentation narration</li><li>✓ Podcasts, audiobooks and other spoken content</li><li>✓ Multilingual voice content that needs consistent delivery</li></ul></div>
+        <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-4"><h2 class="text-xl font-black text-white">Check before upgrading</h2><ul class="text-sm text-slate-300 space-y-2.5"><li>• Annual pricing is lower than monthly billing, so compare the actual renewal commitment</li><li>• Voice-generation limits matter more than the headline monthly price for frequent creators</li><li>• Voice cloning, AI translation and enterprise controls can depend on tier or add-on</li><li>• API usage has its own character-based pricing and limits</li><li>• Dubbing uses a separate credit-based product path</li></ul></div>
+      </section>
+
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">What you can do with Murf</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 text-sm">
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white">Text to speech</div><p class="text-xs text-slate-400 mt-2 leading-relaxed">Generate production-ready narration from a script using AI voices and voice controls.</p></div>
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white">Voice control</div><p class="text-xs text-slate-400 mt-2 leading-relaxed">Adjust delivery with voice styles, tonalities and controls designed for natural narration.</p></div>
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white">Translation & dubbing</div><p class="text-xs text-slate-400 mt-2 leading-relaxed">Murf also offers AI translation and a separate dubbing workflow for localization needs.</p></div>
+          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white">Voice API</div><p class="text-xs text-slate-400 mt-2 leading-relaxed">Developers can access a separate text-to-speech API with its own free-trial and usage limits.</p></div>
         </div>
+      </section>
 
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-purple-500/25 space-y-5">
+        <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Partner transparency</div>
+        <h2 class="text-2xl font-black text-white">COSHUMA's Murf link is an approved personal referral route</h2>
+        <p class="text-sm text-slate-300 leading-relaxed">Murf's PartnerStack welcome email sent to COSHUMA supplied the exact customer-facing referral URL used on this page and states that signups through it are credited to the account. Murf's official affiliate page currently advertises a 20% recurring commission for paid referrals for up to 24 months, with a 90-day attribution window.</p>
+        <p class="text-xs text-slate-400">The commission is paid by Murf; COSHUMA does not add a fee to the visitor's purchase. Murf currently says it does not provide a special affiliate discount to referred users.</p>
+      </section>
 
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5"><h2 class="text-2xl font-black text-white">Compare before you decide</h2><div class="grid grid-cols-1 sm:grid-cols-2 gap-4"><a href="/tool/elevenlabs.html" class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">Murf AI vs ElevenLabs path</div><div class="text-xs text-slate-400 mt-1">Compare Murf's creator voiceover workflow with another verified voice-AI partner option.</div></a><a href="/tool/pictory.html" class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">Need full video generation?</div><div class="text-xs text-slate-400 mt-1">Pictory is a separate verified partner path for turning scripts and content into videos.</div></a></div></section>
 
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Murf AI</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/elevenlabs.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=elevenlabs.io&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">ElevenLabs</span></div><span class="text-[10px] font-extrabold text-emerald-400">Varies</span></a>
-<a href="/tool/lovo.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=lovo.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Lovo</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/synthflow-ai.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=synthflow.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Synthflow AI</span></div><span class="text-[10px] font-extrabold text-emerald-400">Varies by paid referral plan</span></a>
-          </div>
-        </div>
+      <section class="p-7 rounded-3xl bg-gradient-to-r from-purple-500/10 to-indigo-500/10 border border-purple-500/30 text-center space-y-4"><h2 class="text-2xl md:text-3xl font-black text-white">Start with one real script</h2><p class="text-sm text-slate-300 max-w-2xl mx-auto">Use the Free plan to test a script you actually plan to publish. Upgrade only after the voice, pronunciation and workflow are good enough to replace manual recording or paid voiceover work.</p><a data-cta="affiliate" data-tool-id="murf-ai" data-cta-source="tool_murf_bottom" href="https://get.murf.ai/fqac0vixj0qs" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white hover:brightness-110 transition-all">Try Murf AI via Verified Partner Link →</a></section>
 
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://murf.ai/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Murf AI Site</span><span>→</span></a>
-          <a data-cta="affiliate" data-tool-id="murf-ai" href="https://get.murf.ai/fqac0vixj0qs" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Try Murf AI via Verified Partner Link</span><span>→</span></a>
-        </div>
-        <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission when eligible purchases are attributed through the verified Murf AI partner link, at no extra cost to you.</p>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Murf AI?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Murf AI Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/murf-ai.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Murf AI Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
-      </div>
+      <section class="p-5 rounded-2xl bg-[#0b0c10] border border-[#222538] text-xs text-slate-400 leading-relaxed"><strong class="text-slate-300">Source transparency:</strong> Pricing and plan features were checked against Murf's official pricing page on September 4, 2026. Product capabilities were cross-checked against Murf's official text-to-speech/help pages. Affiliate rate, duration, attribution window and discount policy come from Murf's official affiliate program page; COSHUMA's exact referral URL comes from Murf's PartnerStack welcome email.</section>
     </main>
 
-    <!-- Footer -->
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
-    </footer>
+    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS decision guides.</div></footer>
   </body>
 </html>
-


### PR DESCRIPTION
Refresh the Murf AI revenue page around current official pricing and buyer intent, keep the verified PartnerStack referral URL, add CTA-source attribution, unify COSHUMA branding, and remove distracting legacy founder-claim content. No paid services or new affiliate applications involved.