### PR TITLE
Optimize Vista Social conversion and affiliate attribution

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/vista-social.html
+++ b/projects/GlobalSaaSHub/public/tool/vista-social.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vista Social Pricing: Professional vs Advanced vs Scale (2026) | GlobalSaaSHub</title>
+    <title>Vista Social Pricing: Professional vs Advanced vs Scale (2026) | COSHUMA</title>
     <meta name="description" content="Compare Vista Social Professional, Advanced and Scale pricing, profile limits, 14-day no-card trial, AI social workflows, and the verified COSHUMA referral offer." />
     <link rel="canonical" href="https://coshuma.com/tool/vista-social.html" />
 
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/vista-social.html" />
-    <meta property="og:title" content="Vista Social Pricing: Professional vs Advanced vs Scale (2026)" />
+    <meta property="og:title" content="Vista Social Pricing: Professional vs Advanced vs Scale (2026) | COSHUMA" />
     <meta property="og:description" content="Current Vista Social pricing, plan-fit guidance, 14-day no-card trial and verified COSHUMA referral route." />
 
     <script type="application/ld+json">
@@ -36,10 +36,10 @@
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div>
+          <span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← All AI & SaaS Tools</a>
       </div>
     </header>
 
@@ -61,7 +61,7 @@
           <h2 class="text-2xl font-black text-white">Start on Professional unless you already need agency workflows or higher profile capacity.</h2>
           <p class="text-sm text-slate-300 leading-relaxed">Vista Social's live pricing page currently lists Professional at <strong class="text-white">$79/month</strong>, Advanced at <strong class="text-white">$149/month</strong>, and Scale at <strong class="text-white">$349/month</strong>. All three public plans advertise a 14-day free trial with no credit card required.</p>
           <div class="flex flex-col sm:flex-row gap-3 pt-1">
-            <a data-cta="affiliate" data-tool-id="vista-social" href="https://vistasocial.com?fpr=sangkwon14" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center border border-purple-500 hover:bg-purple-500 transition-all">Start the 14-Day Vista Social Trial →</a>
+            <a data-cta="affiliate" data-tool-id="vista-social" data-cta-source="tool_detail_hero" href="https://vistasocial.com?fpr=sangkwon14" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center border border-purple-500 hover:bg-purple-500 transition-all">Start the 14-Day Vista Social Trial →</a>
             <a data-cta="official" href="https://vistasocial.com/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Check Live Pricing</a>
           </div>
           <p class="text-[11px] text-slate-400 leading-relaxed">Referral note: Vista Social's official affiliate support page says users who register through an affiliate link receive 10% off their first year. Confirm the discount shown at checkout before paying.</p>
@@ -105,7 +105,7 @@
               </ul>
             </div>
           </div>
-          <p class="text-xs text-amber-300/90 leading-relaxed">Seat-count caution: Vista Social's live pricing page currently shows inconsistent included-user counts between its plan table/cards and FAQ copy. Use the live checkout or sales confirmation for the exact number of included users before buying.</p>
+          <p class="text-xs text-amber-300/90 leading-relaxed">Seat-count caution: Vista Social's live pricing page currently shows inconsistent included-user counts between its plan cards/table and FAQ copy. The current plan cards and help-center table show 2 / 4 / 8 included users for Professional / Advanced / Scale. Use the live checkout or sales confirmation as the final source before buying.</p>
         </section>
 
         <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -132,7 +132,7 @@
 
         <section class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] space-y-3">
           <h2 class="text-xl font-bold text-white">Current add-on costs worth noticing</h2>
-          <p class="text-sm text-slate-300 leading-relaxed">The live pricing page currently lists cross-social/web/news Listening from <strong class="text-white">$75/month</strong>, X integration at <strong class="text-white">$29/month</strong>, and Employee Advocacy from <strong class="text-white">$199/month for 25 employees</strong>. These can materially change the total cost for larger teams, so compare the base plan with the exact workflow you need.</p>
+          <p class="text-sm text-slate-300 leading-relaxed">The live pricing page currently lists cross-social/web/news Listening from <strong class="text-white">$75/month</strong> and Employee Advocacy from <strong class="text-white">$199/month for 25 employees</strong>. The pricing page also lists X integration as an optional add-on. These can materially change the total cost for larger teams, so compare the base plan with the exact workflow you need.</p>
         </section>
 
         <section class="space-y-4 pt-2 border-t border-[#222538]">
@@ -147,18 +147,18 @@
         <section class="p-6 rounded-2xl bg-purple-500/10 border border-purple-500/30 space-y-4">
           <h2 class="text-xl font-black text-white">Bottom line</h2>
           <p class="text-sm text-slate-300 leading-relaxed">Professional is the cleanest trial starting point for most small teams. Advanced is the more relevant step for agencies that need stronger approval, reporting and integration workflows. Scale is aimed at higher-volume client management and white-label operations.</p>
-          <a data-cta="affiliate" data-tool-id="vista-social" href="https://vistasocial.com?fpr=sangkwon14" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-6 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center border border-purple-500 hover:bg-purple-500 transition-all">Try Vista Social Through COSHUMA →</a>
-          <p class="text-[11px] text-slate-400 leading-relaxed"><strong class="text-slate-300">Affiliate disclosure:</strong> COSHUMA may earn a commission if you sign up or purchase through the partner link, at no additional cost beyond the offer shown by Vista Social. Pricing and offer details were checked against Vista Social's official pricing and affiliate documentation on September 2, 2026.</p>
+          <a data-cta="affiliate" data-tool-id="vista-social" data-cta-source="tool_detail_bottom" href="https://vistasocial.com?fpr=sangkwon14" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-6 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center border border-purple-500 hover:bg-purple-500 transition-all">Start the Vista Social Trial via COSHUMA →</a>
+          <p class="text-[11px] text-slate-400 leading-relaxed"><strong class="text-slate-300">Affiliate disclosure:</strong> COSHUMA may earn a commission if you sign up or purchase through the partner link, at no additional cost beyond the offer shown by Vista Social. COSHUMA's account-specific welcome email confirms this exact referral URL and states 20% commission on paid signups for up to 12 months; that commission is paid to COSHUMA, not charged to the buyer.</p>
         </section>
 
         <section class="p-5 rounded-2xl bg-[#0b0c10] border border-[#222538] text-xs text-slate-400 leading-relaxed">
-          <strong class="text-slate-300">Source transparency:</strong> Plan prices, trial terms, profile capacities and add-on prices come from Vista Social's official pricing page. Affiliate duration, referral discount and payout rules are documented by Vista Social's official affiliate pages. COSHUMA does not claim personal hands-on testing unless explicitly stated.
+          <strong class="text-slate-300">Source transparency:</strong> Plan prices, trial terms, profile capacities and add-on prices were rechecked against Vista Social's live pricing page and current help-center profile/user table on September 4, 2026. COSHUMA's customer-facing referral URL was independently reverified from the Vista Social FirstPromoter email sent to support@coshuma.com on September 3, 2026. COSHUMA does not claim personal hands-on testing unless explicitly stated.
         </section>
       </div>
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS decision guides.</div>
     </footer>
     <script defer src="/affiliate-attribution.js"></script>
   </body>


### PR DESCRIPTION
Revenue-focused, no-cost update to the verified Vista Social affiliate path.

- Aligns the detail page with COSHUMA branding.
- Rechecks live Vista Social pricing, trial terms and plan capacity on 2026-09-04.
- Preserves the exact customer-facing FirstPromoter referral URL reverified from the 2026-09-03 affiliate email.
- Adds distinct hero/bottom CTA source tags for attribution.
- Documents the vendor's current seat-count inconsistency conservatively instead of guessing.
- No paid services or new affiliate applications.