### PR TITLE
Monetize CartStack comparison CTAs

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/cartstack-vs-aweber.html
+++ b/projects/GlobalSaaSHub/public/compare/cartstack-vs-aweber.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CartStack vs AWeber Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of CartStack vs AWeber. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+    <meta name="description" content="Compare CartStack vs AWeber for abandoned-cart recovery and email marketing. See buyer-fit differences, current CartStack trial terms, and a verified CartStack referral route." />
 
     <link rel="canonical" href="https://coshuma.com/compare/cartstack-vs-aweber.html" />
     <meta property="og:type" content="article" />
@@ -60,7 +60,7 @@
         </div>
         <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">CartStack vs AWeber</h1>
         <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Email & Outreach tool.
+          Compare a cart-recovery platform with a general email-marketing platform, then choose the workflow that matches your revenue goal.
         </p>
       </div>
 
@@ -71,32 +71,30 @@
             <span>🧠 Decision Summary & Evidence</span>
           </h2>
           <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
+            ✓ Publicly Available Data (CartStack refreshed: September 4, 2026)
           </span>
         </div>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
           <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
             <div class="font-bold text-purple-300">Choose CartStack if:</div>
             <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
+              You need abandoned-cart and browse recovery through automated email, SMS, browser push, and on-site retention tools rather than a general newsletter workflow.
             </p>
             <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
+              Source: CartStack official product and pricing pages (checked September 4, 2026)
             </div>
           </div>
           <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
             <div class="font-bold text-blue-300">Choose AWeber if:</div>
             <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
+              You want a broader email-marketing platform for newsletters, subscriber management, automated sequences, and landing pages.
             </p>
             <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
+              Source: Existing COSHUMA vendor baseline (August 31, 2026)
             </div>
           </div>
         </div>
       </div>
-
-
 
       <!-- 2-Column Comparison Table -->
       <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
@@ -113,21 +111,19 @@
 
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
           <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
+            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Primary job</div>
+            <div class="text-sm font-black text-amber-400">Recover abandoned revenue</div>
           </div>
           <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
+            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Primary job</div>
+            <div class="text-sm font-black text-amber-400">Email marketing & audience nurture</div>
           </div>
         </div>
 
-
-
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
           <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">Contact for pricing</div>
+            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing / Trial</div>
+            <div class="text-base font-extrabold text-emerald-400">From $29/mo; 14-day risk-free trial, no card</div>
           </div>
           <div>
             <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
@@ -140,26 +136,27 @@
             <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">CartStack Features</div>
             <div class="space-y-1.5 text-xs text-slate-300">
               <div>✓ Targeted Remarketing Emails</div>
-<div>✓ SMS Text Re-engagement Campaigns</div>
-<div>✓ Browser Push Notifications</div>
-<div>✓ Abandoned Cart Recovery for Retailers</div>
+              <div>✓ SMS Text Re-engagement Campaigns</div>
+              <div>✓ Browser Push Notifications</div>
+              <div>✓ Abandoned Cart Recovery for Retailers</div>
             </div>
           </div>
           <div>
             <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">AWeber Features</div>
             <div class="space-y-1.5 text-xs text-slate-300">
               <div>✓ Email Campaign Creation</div>
-<div>✓ Automated Email Sequences</div>
-<div>✓ Landing Page Builder</div>
-<div>✓ Subscriber Management & Segmentation</div>
+              <div>✓ Automated Email Sequences</div>
+              <div>✓ Landing Page Builder</div>
+              <div>✓ Subscriber Management & Segmentation</div>
             </div>
           </div>
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://www.cartstack.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get CartStack →</a>
+          <a data-cta="affiliate" data-tool-id="cartstack" data-cta-source="compare_cartstack_aweber" href="http://www.cartstack.com/?afmc=wb" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Start CartStack 14-Day Trial →</a>
           <a href="https://www.aweber.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get AWeber →</a>
         </div>
+        <p class="text-[10px] text-slate-500 text-center leading-relaxed">Affiliate disclosure: the CartStack button uses COSHUMA's verified referral link. COSHUMA may earn a commission from an attributed signup or purchase, at no extra cost to you. The AWeber button is an official non-affiliate destination unless otherwise stated.</p>
       </div>
     </main>
 
@@ -168,5 +165,6 @@
         &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
       </div>
     </footer>
+    <script src="/affiliate-attribution.js"></script>
   </body>
 </html>

--- a/projects/GlobalSaaSHub/public/compare/cartstack-vs-convertkit.html
+++ b/projects/GlobalSaaSHub/public/compare/cartstack-vs-convertkit.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CartStack vs Kit (formerly ConvertKit) Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of CartStack vs Kit (formerly ConvertKit). Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+    <meta name="description" content="Compare CartStack vs Kit (formerly ConvertKit) for abandoned-cart recovery versus creator email marketing. See current CartStack trial terms and a verified CartStack referral route." />
 
     <link rel="canonical" href="https://coshuma.com/compare/cartstack-vs-convertkit.html" />
     <meta property="og:type" content="article" />
@@ -60,7 +60,7 @@
         </div>
         <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">CartStack vs Kit (formerly ConvertKit)</h1>
         <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Email & Outreach tool.
+          Compare a cart-recovery platform with a creator-focused email-marketing platform, then choose based on whether your priority is recovering lost orders or growing an audience.
         </p>
       </div>
 
@@ -71,32 +71,30 @@
             <span>🧠 Decision Summary & Evidence</span>
           </h2>
           <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
+            ✓ Publicly Available Data (CartStack refreshed: September 4, 2026)
           </span>
         </div>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
           <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
             <div class="font-bold text-purple-300">Choose CartStack if:</div>
             <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
+              You need abandoned-cart and browse recovery through automated email, SMS, browser push, and on-site retention tools tied directly to ecommerce revenue recovery.
             </p>
             <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
+              Source: CartStack official product and pricing pages (checked September 4, 2026)
             </div>
           </div>
           <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
             <div class="font-bold text-blue-300">Choose Kit (formerly ConvertKit) if:</div>
             <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with Free plan; Creator plan from $33/month for 1,000 subscribers pricing structure and Not rated.
+              Your primary workflow is creator email marketing, newsletters, audience segmentation, automations, landing pages, and subscriber growth.
             </p>
             <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
+              Source: Existing COSHUMA vendor baseline (August 31, 2026)
             </div>
           </div>
         </div>
       </div>
-
-
 
       <!-- 2-Column Comparison Table -->
       <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
@@ -113,21 +111,19 @@
 
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
           <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
+            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Primary job</div>
+            <div class="text-sm font-black text-amber-400">Recover abandoned revenue</div>
           </div>
           <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
+            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Primary job</div>
+            <div class="text-sm font-black text-amber-400">Creator email & audience growth</div>
           </div>
         </div>
 
-
-
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
           <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">Contact for pricing</div>
+            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing / Trial</div>
+            <div class="text-base font-extrabold text-emerald-400">From $29/mo; 14-day risk-free trial, no card</div>
           </div>
           <div>
             <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
@@ -140,26 +136,27 @@
             <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">CartStack Features</div>
             <div class="space-y-1.5 text-xs text-slate-300">
               <div>✓ Targeted Remarketing Emails</div>
-<div>✓ SMS Text Re-engagement Campaigns</div>
-<div>✓ Browser Push Notifications</div>
-<div>✓ Abandoned Cart Recovery for Retailers</div>
+              <div>✓ SMS Text Re-engagement Campaigns</div>
+              <div>✓ Browser Push Notifications</div>
+              <div>✓ Abandoned Cart Recovery for Retailers</div>
             </div>
           </div>
           <div>
             <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Kit (formerly ConvertKit) Features</div>
             <div class="space-y-1.5 text-xs text-slate-300">
               <div>✓ Email marketing automation</div>
-<div>✓ Landing page builder</div>
-<div>✓ Audience segmentation</div>
-<div>✓ AI subject line generation</div>
+              <div>✓ Landing page builder</div>
+              <div>✓ Audience segmentation</div>
+              <div>✓ AI subject line generation</div>
             </div>
           </div>
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://www.cartstack.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get CartStack →</a>
+          <a data-cta="affiliate" data-tool-id="cartstack" data-cta-source="compare_cartstack_kit" href="http://www.cartstack.com/?afmc=wb" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Start CartStack 14-Day Trial →</a>
           <a href="https://kit.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Kit (formerly ConvertKit) →</a>
         </div>
+        <p class="text-[10px] text-slate-500 text-center leading-relaxed">Affiliate disclosure: the CartStack button uses COSHUMA's verified referral link. COSHUMA may earn a commission from an attributed signup or purchase, at no extra cost to you. The Kit button is an official non-affiliate destination unless otherwise stated.</p>
       </div>
     </main>
 
@@ -168,5 +165,6 @@
         &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
       </div>
     </footer>
+    <script src="/affiliate-attribution.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Revenue-focused, zero-cost fix for two CartStack comparison pages.

Evidence checked 2026-09-04:
- CartStack's referral-program welcome email confirms the exact customer-facing referral URL `http://www.cartstack.com/?afmc=wb` and states that users who click it and sign up are credited to the referral account.
- CartStack's official pricing page currently advertises a 14-day risk-free trial with no credit card required and public pricing starting at $29/month.

Changes:
- replace generic CartStack homepage buttons on `cartstack-vs-aweber` and `cartstack-vs-convertkit` with the verified referral URL;
- add `data-cta`, `data-tool-id`, and per-page `data-cta-source` attributes;
- load the existing `/affiliate-attribution.js` script on both pages;
- add transparent affiliate disclosure;
- replace placeholder `Not rated`/`Contact for pricing` CartStack copy with current buyer-intent trial/pricing information and clearer use-case positioning.

AWeber and Kit remain official non-affiliate destinations; no guessed tracking parameters, paid services, or new affiliate applications are introduced.