### PR TITLE
Monetize verified AWeber CTAs across buyer comparisons

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/aweber-vs-moosend.html
+++ b/projects/GlobalSaaSHub/public/compare/aweber-vs-moosend.html
@@ -96,8 +96,6 @@
         </div>
       </div>
 
-
-
       <!-- 2-Column Comparison Table -->
       <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
         <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
@@ -121,8 +119,6 @@
             <div class="text-lg font-black text-amber-400">Not rated</div>
           </div>
         </div>
-
-
 
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
           <div>
@@ -157,9 +153,10 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://www.aweber.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get AWeber →</a>
+          <a data-cta="affiliate" data-tool-id="aweber" data-cta-source="compare_aweber_moosend" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get AWeber →</a>
           <a href="https://moosend.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Moosend →</a>
         </div>
+        <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission when you purchase AWeber through the marked affiliate link, at no additional cost to you. Moosend remains linked to its official site here until a customer-facing tracking URL is independently verified.</p>
       </div>
     </main>
 
@@ -168,5 +165,6 @@
         &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
       </div>
     </footer>
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>

--- a/projects/GlobalSaaSHub/public/compare/convertkit-vs-aweber.html
+++ b/projects/GlobalSaaSHub/public/compare/convertkit-vs-aweber.html
@@ -96,8 +96,6 @@
         </div>
       </div>
 
-
-
       <!-- 2-Column Comparison Table -->
       <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
         <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
@@ -121,8 +119,6 @@
             <div class="text-lg font-black text-amber-400">Not rated</div>
           </div>
         </div>
-
-
 
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
           <div>
@@ -158,8 +154,9 @@
 
         <div class="grid grid-cols-2 gap-4 pt-2">
           <a href="https://kit.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Kit (formerly ConvertKit) →</a>
-          <a href="https://www.aweber.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get AWeber →</a>
+          <a data-cta="affiliate" data-tool-id="aweber" data-cta-source="compare_convertkit_aweber" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get AWeber →</a>
         </div>
+        <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission when you purchase AWeber through the marked affiliate link, at no additional cost to you. Kit remains linked to its official site here unless and until an account-specific customer tracking URL is independently verified.</p>
       </div>
     </main>
 
@@ -168,5 +165,6 @@
         &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
       </div>
     </footer>
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>

--- a/projects/GlobalSaaSHub/public/compare/getresponse-vs-aweber.html
+++ b/projects/GlobalSaaSHub/public/compare/getresponse-vs-aweber.html
@@ -96,8 +96,6 @@
         </div>
       </div>
 
-
-
       <!-- 2-Column Comparison Table -->
       <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
         <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
@@ -121,8 +119,6 @@
             <div class="text-lg font-black text-amber-400">Not rated</div>
           </div>
         </div>
-
-
 
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
           <div>
@@ -158,8 +154,9 @@
 
         <div class="grid grid-cols-2 gap-4 pt-2">
           <a href="https://www.getresponse.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get GetResponse →</a>
-          <a href="https://www.aweber.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get AWeber →</a>
+          <a data-cta="affiliate" data-tool-id="aweber" data-cta-source="compare_getresponse_aweber" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get AWeber →</a>
         </div>
+        <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission when you purchase AWeber through the marked affiliate link, at no additional cost to you. GetResponse remains linked to its official site here unless and until an account-specific customer tracking URL is independently verified.</p>
       </div>
     </main>
 
@@ -168,5 +165,6 @@
         &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
       </div>
     </footer>
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>

--- a/projects/GlobalSaaSHub/public/compare/kit-vs-aweber.html
+++ b/projects/GlobalSaaSHub/public/compare/kit-vs-aweber.html
@@ -96,8 +96,6 @@
         </div>
       </div>
 
-
-
       <!-- 2-Column Comparison Table -->
       <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
         <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
@@ -121,8 +119,6 @@
             <div class="text-lg font-black text-amber-400">Not rated</div>
           </div>
         </div>
-
-
 
         <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
           <div>
@@ -158,8 +154,9 @@
 
         <div class="grid grid-cols-2 gap-4 pt-2">
           <a href="https://www.kit.co/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Kit →</a>
-          <a href="https://www.aweber.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get AWeber →</a>
+          <a data-cta="affiliate" data-tool-id="aweber" data-cta-source="compare_kit_aweber" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get AWeber →</a>
         </div>
+        <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission when you purchase AWeber through the marked affiliate link, at no additional cost to you. Kit remains linked to its official site here unless and until an account-specific customer tracking URL is independently verified.</p>
       </div>
     </main>
 
@@ -168,5 +165,6 @@
         &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
       </div>
     </footer>
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
Revenue-focused, no-cost fix for four high-intent comparison pages. Replaces generic AWeber homepage CTAs with the already-verified customer-facing AWeber affiliate URL used on the AWeber detail page, adds CTA source attribution, sponsored rel, disclosure text, and the existing affiliate-attribution script. Other vendors remain on official URLs unless an account-specific tracking URL is independently verified.