### PR TITLE
Monetize CustomGPT vs Notion buyer path

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/customgpt-ai-vs-notion-ai.html
+++ b/projects/GlobalSaaSHub/public/compare/customgpt-ai-vs-notion-ai.html
@@ -1,172 +1,113 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CustomGPT.ai vs Notion AI Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of CustomGPT.ai vs Notion AI. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CustomGPT.ai vs Notion AI (2026): Knowledge Agent or AI Workspace? | COSHUMA</title>
+  <meta name="description" content="CustomGPT.ai vs Notion AI in 2026: compare current pricing, trial terms, private-knowledge agents, Notion workspace AI and the best fit for each workflow." />
+  <link rel="canonical" href="https://coshuma.com/compare/customgpt-ai-vs-notion-ai.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/customgpt-ai-vs-notion-ai.html" />
+  <meta property="og:title" content="CustomGPT.ai vs Notion AI: Which AI Workflow Fits Better? (2026)" />
+  <meta property="og:description" content="Choose CustomGPT.ai for grounded customer or internal knowledge agents; choose Notion AI when AI should live inside a collaborative workspace." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"WebPage",
+    "name":"CustomGPT.ai vs Notion AI (2026)",
+    "url":"https://coshuma.com/compare/customgpt-ai-vs-notion-ai.html",
+    "dateModified":"2026-09-04",
+    "isPartOf":{"@type":"WebSite","name":"COSHUMA","url":"https://coshuma.com/"},
+    "about":[
+      {"@type":"SoftwareApplication","name":"CustomGPT.ai","url":"https://coshuma.com/tool/customgpt-ai.html"},
+      {"@type":"SoftwareApplication","name":"Notion AI","url":"https://coshuma.com/tool/notion-ai.html"}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="/affiliate-attribution.js" defer></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}.glass{background:#131520;border:1px solid #222538}
+  </style>
+</head>
+<body class="min-h-screen">
+  <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+    <div class="max-w-5xl mx-auto flex items-center justify-between">
+      <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-black">C</div><span class="font-extrabold text-lg">COSHUMA</span></a>
+      <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">Browse AI tools</a>
+    </div>
+  </header>
 
-    <link rel="canonical" href="https://coshuma.com/compare/customgpt-ai-vs-notion-ai.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/customgpt-ai-vs-notion-ai.html" />
-    <meta property="og:title" content="CustomGPT.ai vs Notion AI Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare CustomGPT.ai and Notion AI by pricing, features, and verified public information." />
+  <main class="max-w-5xl mx-auto px-4 py-10 space-y-8">
+    <section class="text-center space-y-4">
+      <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">BUYER GUIDE · CHECKED SEPTEMBER 4, 2026</div>
+      <h1 class="text-4xl md:text-6xl font-black tracking-tight">CustomGPT.ai vs Notion AI</h1>
+      <p class="text-slate-300 max-w-3xl mx-auto leading-relaxed">These tools overlap around AI knowledge work, but they are built for different jobs. <strong>CustomGPT.ai</strong> is for deploying grounded AI agents over your own data. <strong>Notion AI</strong> is for using AI inside a collaborative docs, database and project workspace.</p>
+    </section>
 
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "CustomGPT.ai vs Notion AI Comparison",
-      "url": "https://coshuma.com/compare/customgpt-ai-vs-notion-ai.html",
-      "description": "Compare CustomGPT.ai and Notion AI by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "CustomGPT.ai", "url": "https://coshuma.com/tool/customgpt-ai.html"},
-        {"@type": "SoftwareApplication", "name": "Notion AI", "url": "https://coshuma.com/tool/notion-ai.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+    <section class="grid md:grid-cols-2 gap-5">
+      <article class="glass rounded-3xl p-6 space-y-5">
+        <div><div class="text-xs font-bold text-purple-300 mb-2">GROUNDED AI AGENTS</div><h2 class="text-2xl font-black">Choose CustomGPT.ai when the AI itself is the product or service layer</h2></div>
+        <ul class="space-y-2 text-sm text-slate-300">
+          <li>✓ Build custom agents grounded in websites, documents and private business knowledge.</li>
+          <li>✓ Standard currently lists 10 agents, 1,000 queries/month and 5,000 documents per agent.</li>
+          <li>✓ RAG API access is included on the Standard plan.</li>
+          <li>✓ Premium raises usage limits and adds features such as website auto-sync and branding removal.</li>
+        </ul>
+        <div class="rounded-2xl bg-[#181a29] border border-purple-500/20 p-4">
+          <div class="text-sm font-black text-white">Current public pricing</div>
+          <div class="mt-2 text-sm text-slate-300">Standard: <strong>$99/mo</strong> monthly or <strong>$89/mo</strong> billed annually.<br>Premium: <strong>$499/mo</strong> monthly or <strong>$449/mo</strong> billed annually.</div>
+          <div class="mt-2 text-xs text-amber-300">7-day trial. CustomGPT.ai states that the selected plan is charged after the trial unless canceled.</div>
+        </div>
+        <a data-cta="affiliate" data-tool-id="customgpt-ai" data-cta-source="compare_customgpt_notion_customgpt" href="https://customgpt.ai/?fpr=sangkwon-3b18de" target="_blank" rel="sponsored noopener noreferrer" class="block py-4 px-5 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center">Start the CustomGPT.ai 7-Day Trial →</a>
+      </article>
+
+      <article class="glass rounded-3xl p-6 space-y-5">
+        <div><div class="text-xs font-bold text-blue-300 mb-2">AI WORKSPACE</div><h2 class="text-2xl font-black">Choose Notion AI when your team already works in docs, databases and projects</h2></div>
+        <ul class="space-y-2 text-sm text-slate-300">
+          <li>✓ Free and Plus currently include limited trials of Notion AI capabilities.</li>
+          <li>✓ Business includes Notion Agent, AI Meeting Notes and Enterprise Search Beta.</li>
+          <li>✓ The same workspace also covers docs, databases, projects, forms, sites and team collaboration.</li>
+          <li>✓ Custom Agents use separate Notion credits after the free trial period.</li>
+        </ul>
+        <div class="rounded-2xl bg-[#181a29] border border-blue-500/20 p-4">
+          <div class="text-sm font-black text-white">Current public pricing in USD</div>
+          <div class="mt-2 text-sm text-slate-300">Free: <strong>$0/member/mo</strong><br>Plus: <strong>$10/member/mo</strong><br>Business: <strong>$20/member/mo</strong><br>Enterprise: custom pricing.</div>
+          <div class="mt-2 text-xs text-slate-400">Custom Agents are currently listed as free to try and then $10 per 1,000 monthly Notion credits.</div>
+        </div>
+        <a href="https://www.notion.com/pricing" target="_blank" rel="noopener noreferrer" class="block py-4 px-5 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center">View Notion Pricing →</a>
+      </article>
+    </section>
+
+    <section class="glass rounded-3xl p-6 md:p-8 space-y-5">
+      <h2 class="text-2xl font-black">Fast decision: which one should you buy?</h2>
+      <div class="grid md:grid-cols-3 gap-4 text-sm">
+        <div class="rounded-2xl bg-[#181a29] border border-[#2a2d40] p-4"><div class="font-black text-purple-300 mb-2">Customer-facing or embedded AI bot</div><p class="text-slate-300">Pick <strong>CustomGPT.ai</strong> when users need a dedicated AI agent trained on your approved source material rather than a general workspace assistant.</p></div>
+        <div class="rounded-2xl bg-[#181a29] border border-[#2a2d40] p-4"><div class="font-black text-blue-300 mb-2">Docs + projects + AI in one workspace</div><p class="text-slate-300">Pick <strong>Notion AI</strong> when people already create, plan, meet and collaborate in Notion and AI should operate inside that shared workspace.</p></div>
+        <div class="rounded-2xl bg-[#181a29] border border-[#2a2d40] p-4"><div class="font-black text-emerald-300 mb-2">Need both?</div><p class="text-slate-300">They can be complementary: Notion can remain the internal workspace while a separate grounded agent handles a customer or employee knowledge experience.</p></div>
       </div>
-    </header>
+    </section>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">CustomGPT.ai vs Notion AI</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Workflow Automation tool.
-        </p>
+    <section class="glass rounded-3xl p-6 space-y-4">
+      <h2 class="text-xl font-black">Before you start a trial</h2>
+      <div class="grid md:grid-cols-2 gap-4 text-sm text-slate-300">
+        <div><strong class="text-white">CustomGPT.ai:</strong> estimate query volume, source-document volume and the number of agents you actually need. The jump from Standard to Premium is large, so validate the workflow during the trial first.</div>
+        <div><strong class="text-white">Notion AI:</strong> price the entire workspace by member count and check whether you need Business-level AI features or only the limited AI trial on Free/Plus.</div>
       </div>
+    </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose CustomGPT.ai if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Notion AI if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with Free trial; Business plan with Notion AI at $20/user/month pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
-      </div>
+    <section class="rounded-3xl border border-amber-500/20 bg-amber-500/5 p-5 text-xs text-slate-400 leading-relaxed">
+      <strong class="text-amber-300">Affiliate disclosure:</strong> COSHUMA may earn a commission if you sign up through eligible partner links on this page, at no additional cost to you. The Notion link above is a standard official pricing link, not represented here as an affiliate link. Pricing and terms can change; confirm the final checkout terms before subscribing.
+    </section>
 
+    <section class="text-xs text-slate-500 leading-relaxed">
+      <strong class="text-slate-300">Sources checked:</strong> CustomGPT.ai official pricing and affiliate materials; Notion official pricing. Pricing, plan features and trial terms above were re-checked on September 4, 2026.
+    </section>
+  </main>
 
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/customgpt-ai.html" class="hover:text-purple-300">CustomGPT.ai</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/notion-ai.html" class="hover:text-blue-300">Notion AI</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">Subscription plans available</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">Free trial; Business plan with Notion AI at $20/user/month</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">CustomGPT.ai Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Build custom AI agents</div>
-<div>✓ Ground responses in private data</div>
-<div>✓ Implement role-specific agent behavior</div>
-<div>✓ Receive hands-on integration support</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Notion AI Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Inline Writing Help</div>
-<div>✓ Meeting Summaries</div>
-<div>✓ Database Automation</div>
-<div>✓ Custom Prompts</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://customgpt.ai/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get CustomGPT.ai →</a>
-          <a href="https://www.notion.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Notion AI →</a>
-        </div>
-      </div>
-    </main>
-
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
-  </body>
+  <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">© 2026 COSHUMA · Independent AI/SaaS buyer guides</footer>
+</body>
 </html>


### PR DESCRIPTION
Replace the generic CustomGPT.ai homepage CTA with the verified COSHUMA affiliate URL, add affiliate attribution/disclosure, refresh COSHUMA branding, and update buyer guidance using current official CustomGPT.ai and Notion pricing/AI-plan information checked on 2026-09-04.