### PR TITLE
Optimize vidIQ vs OutlierKit revenue comparison

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/vidiq-vs-outlierkit.html
+++ b/projects/GlobalSaaSHub/public/compare/vidiq-vs-outlierkit.html
@@ -1,172 +1,124 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>VidIQ vs OutlierKit Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of VidIQ vs OutlierKit. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>vidIQ vs OutlierKit (2026): YouTube SEO vs Competitor Research | COSHUMA</title>
+  <meta name="description" content="Compare vidIQ vs OutlierKit for YouTube growth in 2026. See which is better for SEO, publishing optimization, outlier research, competitor intelligence, free access and creator workflows." />
+  <link rel="canonical" href="https://coshuma.com/compare/vidiq-vs-outlierkit.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/vidiq-vs-outlierkit.html" />
+  <meta property="og:title" content="vidIQ vs OutlierKit (2026) | COSHUMA" />
+  <meta property="og:description" content="A buyer-focused comparison of vidIQ and OutlierKit for YouTube SEO, content ideas, competitor research and channel growth." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"WebPage",
+    "name":"vidIQ vs OutlierKit (2026)",
+    "url":"https://coshuma.com/compare/vidiq-vs-outlierkit.html",
+    "description":"Buyer-focused comparison of vidIQ and OutlierKit for YouTube creators.",
+    "isPartOf":{"@type":"WebSite","name":"COSHUMA","url":"https://coshuma.com/"},
+    "about":[
+      {"@type":"SoftwareApplication","name":"vidIQ","url":"https://coshuma.com/tool/vidiq.html"},
+      {"@type":"SoftwareApplication","name":"OutlierKit","url":"https://coshuma.com/tool/outlierkit.html"}
+    ]
+  }
+  </script>
+  <script defer src="/affiliate-attribution.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}
+    h1,h2,h3{font-family:'Outfit',sans-serif}
+  </style>
+</head>
+<body class="min-h-screen flex flex-col justify-between">
+  <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+    <div class="max-w-6xl mx-auto flex items-center justify-between">
+      <a href="/" class="flex items-center gap-3">
+        <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div>
+        <span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span>
+      </a>
+      <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20">← All tools</a>
+    </div>
+  </header>
 
-    <link rel="canonical" href="https://coshuma.com/compare/vidiq-vs-outlierkit.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/vidiq-vs-outlierkit.html" />
-    <meta property="og:title" content="VidIQ vs OutlierKit Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare VidIQ and OutlierKit by pricing, features, and verified public information." />
+  <main class="max-w-5xl mx-auto px-4 py-10 w-full space-y-8">
+    <section class="text-center space-y-4">
+      <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">YouTube growth comparison · checked Sep 4, 2026</div>
+      <h1 class="text-4xl md:text-6xl font-black text-white tracking-tight">vidIQ vs OutlierKit</h1>
+      <p class="text-slate-300 max-w-3xl mx-auto text-base md:text-lg">The practical difference: <strong class="text-white">vidIQ helps optimize and publish YouTube videos</strong>, while <strong class="text-white">OutlierKit goes deeper on outlier, niche and competitor research</strong>. Pick based on the bottleneck in your channel.</p>
+    </section>
 
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "VidIQ vs OutlierKit Comparison",
-      "url": "https://coshuma.com/compare/vidiq-vs-outlierkit.html",
-      "description": "Compare VidIQ and OutlierKit by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "VidIQ", "url": "https://coshuma.com/tool/vidiq.html"},
-        {"@type": "SoftwareApplication", "name": "OutlierKit", "url": "https://coshuma.com/tool/outlierkit.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+    <section class="grid grid-cols-1 md:grid-cols-2 gap-5">
+      <article class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
+        <div class="flex items-center justify-between gap-3">
+          <h2 class="text-2xl font-black text-white">Choose vidIQ if…</h2>
+          <span class="text-xs font-bold text-emerald-300 bg-emerald-500/10 px-3 py-1 rounded-full">Free tier</span>
+        </div>
+        <p class="text-sm text-slate-300 leading-relaxed">You want an everyday YouTube workflow for keyword research, SEO guidance, titles/descriptions, competitor overlays, thumbnails, publishing optimization and AI-assisted channel decisions.</p>
+        <ul class="text-sm text-slate-300 space-y-2">
+          <li>✓ Free plan with limited access to popular tools</li>
+          <li>✓ Keyword and competitor research inside the YouTube workflow</li>
+          <li>✓ AI Coach, thumbnail, clipping and script tools use monthly AI credits</li>
+          <li>✓ Browser extension adds real-time SEO and upload optimization</li>
+        </ul>
+        <a data-cta="affiliate" data-tool-id="vidiq" data-cta-source="compare_vidiq_outlierkit_vidiq" href="https://vidiq.com/coshuma" target="_blank" rel="sponsored noopener noreferrer" class="block w-full py-4 px-5 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center shadow-lg">Start vidIQ via verified partner link →</a>
+        <a href="https://vidiq.com/plans/" target="_blank" rel="noopener noreferrer" class="block text-center text-xs text-slate-400 hover:text-white">Check current vidIQ plans</a>
+      </article>
+
+      <article class="p-6 rounded-3xl bg-[#131520] border border-blue-500/30 space-y-4">
+        <div class="flex items-center justify-between gap-3">
+          <h2 class="text-2xl font-black text-white">Choose OutlierKit if…</h2>
+          <span class="text-xs font-bold text-emerald-300 bg-emerald-500/10 px-3 py-1 rounded-full">10-credit trial</span>
+        </div>
+        <p class="text-sm text-slate-300 leading-relaxed">Your bigger problem is deciding <em>what to make next</em>: finding outlier videos, low-competition/high-RPM keywords, competitor patterns and niche-wide opportunities before production starts.</p>
+        <ul class="text-sm text-slate-300 space-y-2">
+          <li>✓ Trial includes 10 credits and does not require a credit card</li>
+          <li>✓ Hobby: $199/year · 100 credits/month</li>
+          <li>✓ Pro: $299/year · 500 credits/month · Competitor Studio + MCP/API</li>
+          <li>✓ Max: $999/year · 2,000 credits/month · agency-scale research</li>
+        </ul>
+        <a data-cta="affiliate" data-tool-id="outlierkit" data-cta-source="compare_vidiq_outlierkit_outlierkit" href="https://outlierkit.com/?ref=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="block w-full py-4 px-5 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center shadow-lg">Start OutlierKit via verified partner link →</a>
+        <a href="https://outlierkit.com/app/pricing" target="_blank" rel="noopener noreferrer" class="block text-center text-xs text-slate-400 hover:text-white">Check current OutlierKit pricing</a>
+      </article>
+    </section>
+
+    <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+      <h2 class="text-2xl font-black text-white">Fast decision table</h2>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm min-w-[680px]">
+          <thead><tr class="text-left border-b border-[#2b2e42]"><th class="py-3 pr-4 text-slate-400">Need</th><th class="py-3 pr-4 text-purple-300">vidIQ</th><th class="py-3 text-blue-300">OutlierKit</th></tr></thead>
+          <tbody class="text-slate-300">
+            <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold text-white">YouTube SEO & upload optimization</td><td class="py-3 pr-4">Stronger fit</td><td class="py-3">Secondary</td></tr>
+            <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold text-white">Outlier video discovery</td><td class="py-3 pr-4">Competitor tools available</td><td class="py-3">Core workflow</td></tr>
+            <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold text-white">Niche-wide competitor intelligence</td><td class="py-3 pr-4">Useful creator intel</td><td class="py-3">Competitor Studio on Pro/Max</td></tr>
+            <tr class="border-b border-[#222538]"><td class="py-3 pr-4 font-bold text-white">Free access</td><td class="py-3 pr-4">Free tier</td><td class="py-3">10-credit no-card trial</td></tr>
+            <tr><td class="py-3 pr-4 font-bold text-white">Best for</td><td class="py-3 pr-4">Ongoing optimization & publishing</td><td class="py-3">Research-first content strategy</td></tr>
+          </tbody>
+        </table>
       </div>
-    </header>
+    </section>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">VidIQ vs OutlierKit</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Video & Shorts Gen tool.
-        </p>
+    <section class="p-6 rounded-3xl bg-gradient-to-br from-purple-500/10 to-blue-500/10 border border-purple-500/20 space-y-4">
+      <h2 class="text-2xl font-black text-white">COSHUMA pick by workflow</h2>
+      <p class="text-slate-300 text-sm leading-relaxed">If you are still learning YouTube SEO, titles, thumbnails and publishing discipline, start with <strong class="text-white">vidIQ</strong>. If you already publish consistently but struggle to identify promising topics and competitors, test <strong class="text-white">OutlierKit</strong>. Some serious creators may use both because the products solve different parts of the workflow.</p>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <a data-cta="affiliate" data-tool-id="vidiq" data-cta-source="compare_vidiq_outlierkit_bottom_vidiq" href="https://vidiq.com/coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center">Try vidIQ →</a>
+        <a data-cta="affiliate" data-tool-id="outlierkit" data-cta-source="compare_vidiq_outlierkit_bottom_outlierkit" href="https://outlierkit.com/?ref=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center">Try OutlierKit →</a>
       </div>
+      <p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if you purchase through verified partner links on this page, at no added cost to you. Pricing and product limits can change; confirm final details on each vendor's site before purchase.</p>
+    </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose VidIQ if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose OutlierKit if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
-      </div>
+    <section class="text-xs text-slate-500 leading-relaxed">
+      <strong class="text-slate-400">Evidence checked Sep 4, 2026:</strong> vidIQ official plans and help documentation; OutlierKit official pricing and affiliate pages; COSHUMA's verified affiliate records. No editorial star ratings or unverified revenue claims are used.
+    </section>
+  </main>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/vidiq.html" class="hover:text-purple-300">VidIQ</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/outlierkit.html" class="hover:text-blue-300">OutlierKit</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">Free plan available</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">VidIQ Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ YouTube keyword research</div>
-<div>✓ AI video optimization</div>
-<div>✓ Competitor analysis</div>
-<div>✓ AI content generation (titles, scripts)</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">OutlierKit Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ AI-powered trend analysis</div>
-<div>✓ Viral video idea generation</div>
-<div>✓ YouTube audience insights</div>
-<div>✓ Content strategy assistance</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://vidiq.com/coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get VidIQ →</a>
-          <a href="https://outlierkit.com/?ref=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get OutlierKit →</a>
-        </div>
-      </div>
-    </main>
-
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
-  </body>
+  <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
+    <div class="max-w-6xl mx-auto px-4">© 2026 COSHUMA. Independent software comparison.</div>
+  </footer>
+</body>
 </html>


### PR DESCRIPTION
Revenue-first, zero-cost CRO update for an existing buyer-intent comparison page.

Changes:
- replaces generic auto-generated comparison copy and `Not rated` placeholders with a clear SEO/publishing-vs-research decision framework
- preserves the exact verified vidIQ affiliate route `https://vidiq.com/coshuma`
- preserves the exact verified OutlierKit affiliate route `https://outlierkit.com/?ref=sangkwon`
- adds source-level `data-cta-source` attribution to top and bottom CTAs for both vendors
- loads `/affiliate-attribution.js`
- aligns branding with COSHUMA
- refreshes OutlierKit plan/trial facts from the official pricing page checked Sep 4, 2026
- refreshes vidIQ free-tier/features language from official plans/help pages checked Sep 4, 2026
- adds explicit affiliate disclosure and avoids unsupported ratings/revenue claims

Evidence:
- Gmail welcome email confirms `vidiq.com/coshuma` is the unique affiliate link and commissions are recurring.
- Repository verified affiliate records and merged PR #101 preserve `https://outlierkit.com/?ref=sangkwon` as approved tracking.
- Official product evidence: https://vidiq.com/plans/, https://support.vidiq.com/en/articles/13928456-features-credits-by-plan, https://outlierkit.com/app/pricing, https://outlierkit.com/p/affiliate.

No paid services or guessed tracking links introduced.