### PR TITLE
Optimize Framer vs Make buyer path

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/framer-vs-make-com.html
+++ b/projects/GlobalSaaSHub/public/compare/framer-vs-make-com.html
@@ -3,170 +3,133 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Framer vs Make.com Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Framer vs Make.com. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
-
+    <title>Framer vs Make.com: Website Builder vs Automation Platform (2026) | COSHUMA</title>
+    <meta name="description" content="Compare Framer vs Make.com for 2026. Framer builds and hosts websites; Make automates workflows across apps. See current pricing, buyer fit, and when using both is the better choice." />
     <link rel="canonical" href="https://coshuma.com/compare/framer-vs-make-com.html" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/compare/framer-vs-make-com.html" />
-    <meta property="og:title" content="Framer vs Make.com Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Framer and Make.com by pricing, features, and verified public information." />
-
+    <meta property="og:title" content="Framer vs Make.com: Which One Do You Actually Need?" />
+    <meta property="og:description" content="Buyer-focused comparison of Framer and Make.com with current official pricing, clear use cases, and a practical combined-stack recommendation." />
     <script type="application/ld+json">
     {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "Framer vs Make.com Comparison",
-      "url": "https://coshuma.com/compare/framer-vs-make-com.html",
-      "description": "Compare Framer and Make.com by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "Framer", "url": "https://coshuma.com/tool/framer.html"},
-        {"@type": "SoftwareApplication", "name": "Make.com", "url": "https://coshuma.com/tool/make-com.html"}
+      "@context":"https://schema.org",
+      "@type":"WebPage",
+      "name":"Framer vs Make.com Comparison",
+      "url":"https://coshuma.com/compare/framer-vs-make-com.html",
+      "description":"Compare Framer and Make.com by product role, pricing, buyer fit and combined workflow use cases.",
+      "isPartOf":{"@type":"WebSite","name":"COSHUMA GlobalSaaSHub","url":"https://coshuma.com/"},
+      "about":[
+        {"@type":"SoftwareApplication","name":"Framer","url":"https://www.framer.com/"},
+        {"@type":"SoftwareApplication","name":"Make.com","url":"https://www.make.com/"}
       ]
     }
     </script>
-    
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
+      body { font-family:'Inter',sans-serif; background:#0b0c10; color:#f1f5f9; }
+      h1,h2,h3 { font-family:'Outfit',sans-serif; }
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+    <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div><span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span></a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← All AI & SaaS Tools</a>
       </div>
     </header>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
+    <main class="max-w-5xl mx-auto px-4 py-10 w-full space-y-7">
+      <section class="p-7 md:p-9 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-6">
+        <div class="text-center space-y-3">
+          <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">WEBSITE BUILDING vs WORKFLOW AUTOMATION</div>
+          <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Framer vs Make.com</h1>
+          <p class="text-slate-300 max-w-3xl mx-auto leading-relaxed">These products are not true substitutes. <strong>Framer</strong> is for designing, publishing and hosting websites. <strong>Make.com</strong> is for automating what happens between apps after a visitor, lead, order or internal event occurs.</p>
+          <p class="text-xs text-slate-500">Pricing and public product details checked September 4, 2026 against the vendors' official pages.</p>
         </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Framer vs Make.com</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Coding & Dev Tools tool.
-        </p>
-      </div>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <article class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/25 space-y-3">
+            <div class="text-xs font-extrabold uppercase text-purple-300">Choose Framer if</div>
+            <h2 class="text-xl font-black text-white">You need to launch the website itself</h2>
+            <ul class="text-sm text-slate-300 space-y-2">
+              <li>✓ You need a visual website builder, CMS and managed hosting.</li>
+              <li>✓ SEO, custom domains and a polished marketing site are the priority.</li>
+              <li>✓ Designers and marketers need to publish without maintaining a separate frontend stack.</li>
+              <li>✓ Your next bottleneck is the page experience, not cross-app automation.</li>
+            </ul>
+            <a data-cta="official" href="https://www.framer.com/pricing" target="_blank" rel="noopener noreferrer" class="block px-5 py-3.5 rounded-xl bg-slate-800 border border-slate-600 hover:bg-slate-700 font-extrabold text-sm text-white text-center">Check Framer Official Pricing →</a>
+          </article>
+
+          <article class="p-5 rounded-2xl bg-gradient-to-br from-blue-500/10 to-purple-500/10 border border-blue-500/30 space-y-3">
+            <div class="text-xs font-extrabold uppercase text-blue-300">Choose Make.com if</div>
+            <h2 class="text-xl font-black text-white">You need the apps behind the site to work together</h2>
+            <ul class="text-sm text-slate-300 space-y-2">
+              <li>✓ Form submissions need to reach a CRM, Sheet, Slack, email tool or database automatically.</li>
+              <li>✓ You want visual no-code automation across 3,000+ apps and services.</li>
+              <li>✓ You need scheduled, branching or API-driven workflows without managing servers.</li>
+              <li>✓ You want to prove a workflow on a permanent free tier before paying.</li>
+            </ul>
+            <a data-cta="affiliate" data-tool-id="make-com" data-cta-source="compare_framer_make_hero" href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="block px-5 py-3.5 rounded-xl bg-gradient-to-r from-blue-600 to-purple-600 hover:brightness-110 font-extrabold text-sm text-white text-center">Start Make.com Free via COSHUMA →</a>
+            <p class="text-[11px] text-slate-400">Affiliate disclosure: COSHUMA may earn a commission if you later become a qualifying paid Make customer through this verified partner link, at no extra cost to you.</p>
+          </article>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Framer if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
+      </section>
+
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <div><h2 class="text-2xl font-black text-white">Current pricing snapshot</h2><p class="text-sm text-slate-400 mt-2">Use these figures as a buying reference and confirm checkout terms, taxes and add-ons before purchase.</p></div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-3">
+            <div class="font-black text-white text-lg">Framer</div>
+            <div class="text-sm text-slate-300 space-y-2">
+              <p><strong class="text-emerald-400">Free:</strong> $0 with a Framer domain and 1 GB bandwidth.</p>
+              <p><strong class="text-emerald-400">Basic:</strong> $10/month on the currently displayed yearly-billing view, with a custom domain, 2 CMS collections and 50 GB bandwidth.</p>
+              <p><strong class="text-emerald-400">Pro:</strong> $30/month on the currently displayed yearly-billing view, with 10 CMS collections, 100 GB bandwidth, redirects, staging and branching previews.</p>
+              <p><strong class="text-slate-200">Enterprise:</strong> custom pricing.</p>
             </div>
+            <p class="text-xs text-slate-500">Framer also lists additional editor and usage-based add-on charges, so team cost can exceed the base site plan.</p>
           </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Make.com if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-3">
+            <div class="font-black text-white text-lg">Make.com at 10,000 credits/month</div>
+            <div class="text-sm text-slate-300 space-y-2">
+              <p><strong class="text-emerald-400">Free:</strong> $0/month with up to 1,000 credits and a 15-minute minimum interval.</p>
+              <p><strong class="text-emerald-400">Core:</strong> $12/month for 10,000 credits, unlimited active scenarios and minute-level scheduling.</p>
+              <p><strong class="text-emerald-400">Pro:</strong> $21/month for 10,000 credits with priority execution and advanced controls.</p>
+              <p><strong class="text-emerald-400">Teams:</strong> $38/month for 10,000 credits with team roles and shared templates.</p>
             </div>
+            <p class="text-xs text-slate-500">Make generally counts module actions as credits, so a multi-step scenario can consume several credits per run.</p>
           </div>
         </div>
-      </div>
+      </section>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/framer.html" class="hover:text-purple-300">Framer</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/make-com.html" class="hover:text-blue-300">Make.com</a>
-          </div>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">The higher-value answer: many teams need both</h2>
+        <p class="text-sm text-slate-300 leading-relaxed">A practical stack is <strong>Framer for the customer-facing site</strong> and <strong>Make.com for the workflow after conversion</strong>. They solve different parts of the funnel, which is why choosing only one can create the wrong trade-off.</p>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-white">Lead capture</div><p class="text-slate-400 text-xs mt-2 leading-relaxed">Build the landing page in Framer, then use Make to route a form submission into a CRM, spreadsheet, email sequence or team alert.</p></div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-white">Content operations</div><p class="text-slate-400 text-xs mt-2 leading-relaxed">Publish the marketing site in Framer while Make moves approved data between content, analytics, support and internal systems.</p></div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-white">Low-risk test</div><p class="text-slate-400 text-xs mt-2 leading-relaxed">Use the free tiers first. Validate the page and the workflow separately before upgrading either product.</p></div>
         </div>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
+      <section class="p-7 rounded-3xl bg-gradient-to-r from-blue-500/10 to-purple-500/10 border border-blue-500/30 text-center space-y-4">
+        <h2 class="text-2xl md:text-3xl font-black text-white">Already have a website? Automate the work behind it.</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto">If your site is already live, Make.com's free tier is the lower-friction next test: connect one real lead or operations workflow, measure the time saved, then upgrade only if the automation proves useful.</p>
+        <div class="flex flex-col sm:flex-row gap-3 justify-center">
+          <a data-cta="affiliate" data-tool-id="make-com" data-cta-source="compare_framer_make_bottom" href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-7 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-blue-600 to-purple-600 text-white hover:brightness-110 transition-all">Start Make.com Free via Verified Partner Link →</a>
+          <a data-cta="official" href="https://www.framer.com/pricing" target="_blank" rel="noopener noreferrer" class="px-7 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 border border-slate-600 text-white hover:bg-slate-700 transition-all">Check Framer Official Plans</a>
         </div>
+        <p class="text-[11px] text-slate-400">COSHUMA's verified Make partner URL uses <code>pc=coshuma</code>. No verified COSHUMA Framer revenue link is used on this page, so Framer buttons remain official non-affiliate links.</p>
+      </section>
 
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Framer Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Interactive prototyping</div>
-<div>✓ Visual website builder</div>
-<div>✓ CMS functionality</div>
-<div>✓ Responsive design capabilities</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Make.com Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Visual Drag & Drop</div>
-<div>✓ 3000+ Integrations</div>
-<div>✓ Advanced Branching</div>
-<div>✓ JSON Parsing</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://framer.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Framer →</a>
-          <a href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Make.com →</a>
-        </div>
-      </div>
+      <section class="p-5 rounded-2xl bg-[#0f1119] border border-[#222538] text-xs text-slate-400 leading-relaxed">
+        <strong class="text-slate-300">Sources checked:</strong> Framer official pricing and billing help pages, Make official pricing, and COSHUMA's verified Make affiliate record on September 4, 2026. Final vendor checkout and current plan terms control.
+      </section>
     </main>
 
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
+    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS decision guides.</div></footer>
   </body>
 </html>


### PR DESCRIPTION
Revenue-focused update for GlobalSaaSHub. Replaces the stale generic comparison with a buyer-intent page that correctly distinguishes Framer (website building) from Make.com (workflow automation), uses current official pricing checked on 2026-09-04, keeps Framer as a non-affiliate official link, and adds tracked Make.com affiliate CTAs using the repository's verified `pc=coshuma` partner URL. No paid services or new affiliate applications.