### PR TITLE
Monetize Brand24 vs Triple Whale buyer path

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/brand24-vs-triple-whale.html
+++ b/projects/GlobalSaaSHub/public/compare/brand24-vs-triple-whale.html
@@ -3,34 +3,27 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Brand24 vs Triple Whale Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Brand24 vs Triple Whale. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
-
+    <title>Brand24 vs Triple Whale (2026): Social Listening vs Ecommerce Analytics | COSHUMA</title>
+    <meta name="description" content="Brand24 vs Triple Whale: compare social listening, sentiment monitoring, ecommerce attribution, pricing approach, and which platform fits your growth workflow." />
     <link rel="canonical" href="https://coshuma.com/compare/brand24-vs-triple-whale.html" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/compare/brand24-vs-triple-whale.html" />
-    <meta property="og:title" content="Brand24 vs Triple Whale Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Brand24 and Triple Whale by pricing, features, and verified public information." />
-
+    <meta property="og:title" content="Brand24 vs Triple Whale (2026) | COSHUMA" />
+    <meta property="og:description" content="Choose Brand24 for social listening and reputation monitoring, or Triple Whale for ecommerce analytics and attribution." />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebPage",
-      "name": "Brand24 vs Triple Whale Comparison",
+      "name": "Brand24 vs Triple Whale",
       "url": "https://coshuma.com/compare/brand24-vs-triple-whale.html",
-      "description": "Compare Brand24 and Triple Whale by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
+      "description": "A decision-focused comparison of Brand24 and Triple Whale.",
+      "isPartOf": {"@type": "WebSite", "name": "COSHUMA", "url": "https://coshuma.com/"},
       "about": [
         {"@type": "SoftwareApplication", "name": "Brand24", "url": "https://coshuma.com/tool/brand24.html"},
         {"@type": "SoftwareApplication", "name": "Triple Whale", "url": "https://coshuma.com/tool/triple-whale.html"}
       ]
     }
     </script>
-    
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -44,129 +37,108 @@
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div>
+          <span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Explore AI & SaaS tools</a>
       </div>
     </header>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
+    <main class="max-w-5xl mx-auto px-4 py-12 w-full space-y-8">
+      <section class="text-center space-y-4">
+        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Buyer guide · Updated September 4, 2026</div>
         <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Brand24 vs Triple Whale</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Productivity & SaaS tool.
-        </p>
-      </div>
-
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
+        <p class="text-slate-300 text-base max-w-3xl mx-auto leading-relaxed">These tools solve different growth problems. <strong class="text-white">Brand24</strong> is built to find and analyze online conversations about a brand, product, competitor, or keyword. <strong class="text-white">Triple Whale</strong> is built to unify ecommerce performance data, attribution, and operating analytics.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-2xl mx-auto pt-2">
+          <a data-cta="affiliate" data-tool-id="brand24" data-cta-source="compare_brand24_triplewhale_hero_brand24" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="py-4 px-5 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center shadow-lg transition-all">Try Brand24 free for 14 days →</a>
+          <a href="https://www.triplewhale.com/pricing" target="_blank" rel="noopener noreferrer" class="py-4 px-5 rounded-xl border border-blue-500/40 bg-blue-500/10 hover:bg-blue-500/20 font-extrabold text-sm text-blue-200 text-center transition-all">Check Triple Whale pricing →</a>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Brand24 if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
+        <p class="text-[11px] text-slate-500 max-w-2xl mx-auto">Brand24's official pricing page states that its 14-day trial does not require a credit card. Triple Whale has a free plan; paid pricing scales by business revenue tier.</p>
+      </section>
+
+      <section class="p-6 md:p-8 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-5">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+          <h2 class="text-2xl font-bold text-white">Fast decision</h2>
+          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md self-start">Official vendor data checked Sep 4, 2026</span>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-3">
+            <h3 class="font-bold text-purple-300 text-lg">Choose Brand24 if...</h3>
+            <ul class="text-sm text-slate-300 leading-7">
+              <li>✓ You need brand, product, or competitor mention monitoring.</li>
+              <li>✓ Sentiment analysis and reputation signals matter.</li>
+              <li>✓ PR, social, or marketing teams need alerts and coverage context.</li>
+              <li>✓ You want to test the workflow before paying.</li>
+            </ul>
           </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Triple Whale if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-3">
+            <h3 class="font-bold text-blue-300 text-lg">Choose Triple Whale if...</h3>
+            <ul class="text-sm text-slate-300 leading-7">
+              <li>✓ You operate an ecommerce business and need unified performance data.</li>
+              <li>✓ Attribution, ROAS, first-party data, and post-purchase surveys matter.</li>
+              <li>✓ Your team wants ecommerce dashboards plus an AI operator workflow.</li>
+              <li>✓ You need a free analytics entry point before evaluating paid tiers.</li>
+            </ul>
           </div>
         </div>
-      </div>
+      </section>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/brand24.html" class="hover:text-purple-300">Brand24</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/triple-whale.html" class="hover:text-blue-300">Triple Whale</a>
-          </div>
+      <section class="p-6 md:p-8 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
+        <h2 class="text-2xl font-bold text-white">What you are actually buying</h2>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm min-w-[680px]">
+            <thead>
+              <tr class="text-left border-b border-[#2b2e42]">
+                <th class="py-3 pr-4 text-slate-400">Decision point</th>
+                <th class="py-3 px-4 text-purple-300">Brand24</th>
+                <th class="py-3 pl-4 text-blue-300">Triple Whale</th>
+              </tr>
+            </thead>
+            <tbody class="text-slate-300">
+              <tr class="border-b border-[#222538]"><td class="py-4 pr-4 font-bold text-white">Primary job</td><td class="py-4 px-4">Social listening & media monitoring</td><td class="py-4 pl-4">Ecommerce analytics & attribution</td></tr>
+              <tr class="border-b border-[#222538]"><td class="py-4 pr-4 font-bold text-white">Key signals</td><td class="py-4 px-4">Mentions, reach, sentiment, topics, coverage</td><td class="py-4 pl-4">Revenue, ROAS, attribution, customer & channel data</td></tr>
+              <tr class="border-b border-[#222538]"><td class="py-4 pr-4 font-bold text-white">Best fit</td><td class="py-4 px-4">Brands, agencies, PR & marketing teams</td><td class="py-4 pl-4">Ecommerce founders, growth & performance teams</td></tr>
+              <tr><td class="py-4 pr-4 font-bold text-white">Entry point</td><td class="py-4 px-4">14-day free trial, no credit card</td><td class="py-4 pl-4">Free plan available</td></tr>
+            </tbody>
+          </table>
         </div>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-5">
+        <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/25 space-y-4">
           <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
+            <div class="text-xs uppercase tracking-wider font-bold text-purple-300">Brand24 pricing snapshot</div>
+            <div class="text-2xl font-black text-white mt-2">From $249/mo</div>
+            <div class="text-xs text-slate-400 mt-1">Individual is $249 monthly or $199/mo when billed annually.</div>
           </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
+          <p class="text-sm text-slate-300 leading-relaxed">The official pricing page currently lists Individual, Team, Pro, Business, and Enterprise tiers. Limits scale by keywords, monthly mentions, update frequency, AI features, and support.</p>
+          <a data-cta="affiliate" data-tool-id="brand24" data-cta-source="compare_brand24_triplewhale_pricing_brand24" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="block rounded-xl bg-purple-600 hover:bg-purple-500 px-5 py-3 text-center text-sm font-extrabold text-white">Start Brand24 trial →</a>
         </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
+        <div class="p-6 rounded-3xl bg-[#131520] border border-blue-500/25 space-y-4">
           <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
+            <div class="text-xs uppercase tracking-wider font-bold text-blue-300">Triple Whale pricing snapshot</div>
+            <div class="text-2xl font-black text-white mt-2">Free plan: $0</div>
+            <div class="text-xs text-slate-400 mt-1">Paid plan pricing is tied to GMV/revenue tiers.</div>
           </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
+          <p class="text-sm text-slate-300 leading-relaxed">Triple Whale's pricing page positions Free as an analytics entry point, with Foundation, Automate, and Enterprise for deeper attribution, automation, and measurement. Use its pricing selector for your current GMV tier.</p>
+          <a href="https://www.triplewhale.com/pricing" target="_blank" rel="noopener noreferrer" class="block rounded-xl bg-blue-600 hover:bg-blue-500 px-5 py-3 text-center text-sm font-extrabold text-white">See Triple Whale pricing →</a>
         </div>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Brand24 Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Real-time Brand Monitoring</div>
-<div>✓ Sentiment Analysis</div>
-<div>✓ Influencer Discovery</div>
-<div>✓ Alerts & Notifications</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Triple Whale Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Centralized E-commerce Analytics</div>
-<div>✓ Attribution Modeling</div>
-<div>✓ Real-time Performance Dashboards</div>
-<div>✓ Profit & Loss Reporting</div>
-            </div>
-          </div>
+      <section class="p-6 md:p-8 rounded-3xl bg-gradient-to-br from-purple-950/40 to-[#131520] border border-purple-500/30 space-y-4">
+        <h2 class="text-2xl font-bold text-white">Bottom line</h2>
+        <p class="text-sm md:text-base text-slate-300 leading-relaxed">If the question is <strong class="text-white">“What are people saying about us, where, and with what sentiment?”</strong>, start with Brand24. If the question is <strong class="text-white">“Which ecommerce channels and customer journeys are producing revenue?”</strong>, Triple Whale is the more direct fit. Some ecommerce teams can use both because they measure different parts of the growth loop.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-2">
+          <a data-cta="affiliate" data-tool-id="brand24" data-cta-source="compare_brand24_triplewhale_bottom_brand24" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="py-4 px-5 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center">Try Brand24 via partner link →</a>
+          <a href="/tool/triple-whale.html" class="py-4 px-5 rounded-xl border border-slate-600 hover:bg-slate-800 font-extrabold text-sm text-white text-center">Review Triple Whale details →</a>
         </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://brand24.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Brand24 →</a>
-          <a href="https://triplewhale.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Triple Whale →</a>
-        </div>
-      </div>
+        <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission if you sign up or purchase through the Brand24 partner link, at no extra cost to you. Triple Whale links on this page are standard official links because no COSHUMA tracking link is claimed here.</p>
+      </section>
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS buying guides.</div>
     </footer>
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
Revenue-focused update to the Brand24 vs Triple Whale comparison.

- replaces the generic Brand24 homepage CTA with the verified COSHUMA Brand24 referral URL
- adds CTA-level affiliate attribution sources and disclosure
- updates COSHUMA branding and removes generated `Not rated` filler
- reframes the page around the actual buying decision: social listening vs ecommerce analytics
- refreshes pricing/trial copy against current official vendor pages
- leaves Triple Whale on standard official links because no verified COSHUMA tracking URL is claimed

No paid services or subscription changes.