### PR TITLE
Optimize HelpDesk vs HighLevel revenue path

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/helpdesk-vs-gohighlevel.html
+++ b/projects/GlobalSaaSHub/public/compare/helpdesk-vs-gohighlevel.html
@@ -3,34 +3,27 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>HelpDesk vs GoHighLevel Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of HelpDesk vs GoHighLevel. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
-
+    <title>HelpDesk vs HighLevel (2026): Support Desk vs All-in-One CRM | COSHUMA</title>
+    <meta name="description" content="HelpDesk vs HighLevel: compare focused customer-support ticketing with an all-in-one CRM, marketing and automation platform, including current pricing and buyer fit." />
     <link rel="canonical" href="https://coshuma.com/compare/helpdesk-vs-gohighlevel.html" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/compare/helpdesk-vs-gohighlevel.html" />
-    <meta property="og:title" content="HelpDesk vs GoHighLevel Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare HelpDesk and GoHighLevel by pricing, features, and verified public information." />
-
+    <meta property="og:title" content="HelpDesk vs HighLevel (2026) | COSHUMA" />
+    <meta property="og:description" content="Choose HelpDesk for a focused support operation, or HighLevel for CRM, funnels, automation and multi-account growth workflows." />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebPage",
-      "name": "HelpDesk vs GoHighLevel Comparison",
+      "name": "HelpDesk vs HighLevel",
       "url": "https://coshuma.com/compare/helpdesk-vs-gohighlevel.html",
-      "description": "Compare HelpDesk and GoHighLevel by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
+      "description": "A decision-focused comparison of HelpDesk and HighLevel.",
+      "isPartOf": {"@type": "WebSite", "name": "COSHUMA", "url": "https://coshuma.com/"},
       "about": [
         {"@type": "SoftwareApplication", "name": "HelpDesk", "url": "https://coshuma.com/tool/helpdesk.html"},
-        {"@type": "SoftwareApplication", "name": "GoHighLevel", "url": "https://coshuma.com/tool/gohighlevel.html"}
+        {"@type": "SoftwareApplication", "name": "HighLevel", "url": "https://coshuma.com/tool/gohighlevel.html"}
       ]
     }
     </script>
-    
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -44,129 +37,123 @@
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div>
+          <span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Explore AI & SaaS tools</a>
       </div>
     </header>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
+    <main class="max-w-5xl mx-auto px-4 py-12 w-full space-y-8">
+      <section class="text-center space-y-4">
+        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Buyer guide · Updated September 4, 2026</div>
+        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">HelpDesk vs HighLevel</h1>
+        <p class="text-slate-300 text-base max-w-3xl mx-auto leading-relaxed">These products overlap around customer conversations, but the buying decision is different. <strong class="text-white">HelpDesk</strong> is a focused ticketing and support workspace. <strong class="text-white">HighLevel</strong> combines CRM, pipelines, websites, funnels, booking, email/SMS marketing and automation for businesses and agencies.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-2xl mx-auto pt-2">
+          <a href="https://www.helpdesk.com/pricing/" target="_blank" rel="noopener noreferrer" class="py-4 px-5 rounded-xl border border-purple-500/40 bg-purple-500/10 hover:bg-purple-500/20 font-extrabold text-sm text-purple-200 text-center transition-all">Try HelpDesk free for 14 days →</a>
+          <a data-cta="affiliate" data-tool-id="gohighlevel" data-cta-source="compare_helpdesk_highlevel_hero" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="py-4 px-5 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center shadow-lg transition-all">Try HighLevel free for 14 days →</a>
         </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">HelpDesk vs GoHighLevel</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Chatbots & Support tool.
-        </p>
-      </div>
+        <p class="text-[11px] text-slate-500 max-w-2xl mx-auto leading-relaxed">HelpDesk states that its 14-day trial does not require a credit card. HighLevel currently advertises a 14-day trial on its standard pricing page. COSHUMA earns a commission if you purchase through the HighLevel partner link, at no extra cost to you.</p>
+      </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
+      <section class="p-6 md:p-8 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-5">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+          <h2 class="text-2xl font-bold text-white">Fast decision</h2>
+          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md self-start">Official vendor data checked Sep 4, 2026</span>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose HelpDesk if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-3">
+            <h3 class="font-bold text-purple-300 text-lg">Choose HelpDesk if...</h3>
+            <ul class="text-sm text-slate-300 leading-7">
+              <li>✓ Your main job is managing support tickets and shared inboxes.</li>
+              <li>✓ You want a per-user support product rather than an agency operating system.</li>
+              <li>✓ Built-in AI Agent allowances, routing and reporting matter.</li>
+              <li>✓ You want to test support workflows without entering a card.</li>
+            </ul>
           </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose GoHighLevel if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-3">
+            <h3 class="font-bold text-blue-300 text-lg">Choose HighLevel if...</h3>
+            <ul class="text-sm text-slate-300 leading-7">
+              <li>✓ You need CRM, pipelines, forms, calendars, funnels and automation in one platform.</li>
+              <li>✓ You run an agency and need multiple client sub-accounts.</li>
+              <li>✓ Marketing follow-up and lead conversion are as important as support.</li>
+              <li>✓ You may want SaaS Mode, rebilling or advanced API access later.</li>
+            </ul>
           </div>
         </div>
-      </div>
+      </section>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/helpdesk.html" class="hover:text-purple-300">HelpDesk</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/gohighlevel.html" class="hover:text-blue-300">GoHighLevel</a>
-          </div>
+      <section class="p-6 md:p-8 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
+        <h2 class="text-2xl font-bold text-white">What you are actually buying</h2>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm min-w-[700px]">
+            <thead>
+              <tr class="text-left border-b border-[#2b2e42]">
+                <th class="py-3 pr-4 text-slate-400">Decision point</th>
+                <th class="py-3 px-4 text-purple-300">HelpDesk</th>
+                <th class="py-3 pl-4 text-blue-300">HighLevel</th>
+              </tr>
+            </thead>
+            <tbody class="text-slate-300">
+              <tr class="border-b border-[#222538]"><td class="py-4 pr-4 font-bold text-white">Primary job</td><td class="py-4 px-4">Customer support ticketing & shared inbox</td><td class="py-4 pl-4">CRM, marketing, sales & automation</td></tr>
+              <tr class="border-b border-[#222538]"><td class="py-4 pr-4 font-bold text-white">Pricing model</td><td class="py-4 px-4">Per support user</td><td class="py-4 pl-4">Flat platform tier with users/contacts included</td></tr>
+              <tr class="border-b border-[#222538]"><td class="py-4 pr-4 font-bold text-white">Agency use</td><td class="py-4 px-4">Support teams and departments</td><td class="py-4 pl-4">Sub-accounts, client operations and SaaS workflows</td></tr>
+              <tr><td class="py-4 pr-4 font-bold text-white">Trial</td><td class="py-4 px-4">14 days, no credit card required</td><td class="py-4 pl-4">14 days on standard pricing page</td></tr>
+            </tbody>
+          </table>
         </div>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-5">
+        <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/25 space-y-4">
           <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
+            <div class="text-xs uppercase tracking-wider font-bold text-purple-300">HelpDesk pricing snapshot</div>
+            <div class="text-2xl font-black text-white mt-2">From $19/user/mo</div>
+            <div class="text-xs text-slate-400 mt-1">Essential: $19 annually or $25 month-to-month.</div>
           </div>
+          <p class="text-sm text-slate-300 leading-relaxed">HelpDesk currently lists Essential at $19/user/month billed annually and Growth at $79/user/month billed annually. Monthly billing is $25 and $99 respectively. Enterprise is custom. AI resolutions are included by plan, with extra usage available separately.</p>
+          <a href="https://www.helpdesk.com/pricing/" target="_blank" rel="noopener noreferrer" class="block rounded-xl border border-purple-500/40 bg-purple-500/10 hover:bg-purple-500/20 px-5 py-3 text-center text-sm font-extrabold text-purple-200">See HelpDesk pricing →</a>
+        </div>
+        <div class="p-6 rounded-3xl bg-[#131520] border border-blue-500/25 space-y-4">
           <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
+            <div class="text-xs uppercase tracking-wider font-bold text-blue-300">HighLevel pricing snapshot</div>
+            <div class="text-2xl font-black text-white mt-2">$97 / $297 / $497 per month</div>
+            <div class="text-xs text-slate-400 mt-1">Starter, Unlimited and Agency Pro.</div>
+          </div>
+          <p class="text-sm text-slate-300 leading-relaxed">Starter includes 3 sub-accounts; Unlimited adds unlimited sub-accounts and basic API access; Agency Pro adds SaaS Mode, automated sub-account creation, markup on rebilled phone/email and advanced API access. Usage-based services and optional add-ons can create additional costs.</p>
+          <a data-cta="affiliate" data-tool-id="gohighlevel" data-cta-source="compare_helpdesk_highlevel_pricing" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="block rounded-xl bg-blue-600 hover:bg-blue-500 px-5 py-3 text-center text-sm font-extrabold text-white">Start HighLevel trial →</a>
+          <p class="text-[11px] text-slate-500 leading-relaxed">Paid link: COSHUMA earns a commission if you purchase through this HighLevel link.</p>
+        </div>
+      </section>
+
+      <section class="p-6 md:p-8 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-bold text-white">Cost logic for a small team</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-slate-300">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20">
+            <h3 class="font-bold text-white mb-2">HelpDesk scales with support seats</h3>
+            <p class="leading-relaxed">A 5-user team on Essential is $95/month on annual billing before any extra AI-resolution usage. That model is straightforward when customer support is the only problem you are solving.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20">
+            <h3 class="font-bold text-white mb-2">HighLevel scales by platform tier</h3>
+            <p class="leading-relaxed">Starter is $97/month and includes unlimited users and contacts, but only 3 sub-accounts. For agencies, the $297 Unlimited plan can become more economical than stacking separate CRM, funnel, automation and client-account tools.</p>
           </div>
         </div>
+      </section>
 
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
+      <section class="p-6 md:p-8 rounded-3xl bg-gradient-to-br from-blue-950/40 to-[#131520] border border-blue-500/30 space-y-4">
+        <h2 class="text-2xl font-bold text-white">Bottom line</h2>
+        <p class="text-sm md:text-base text-slate-300 leading-relaxed">If your team primarily needs to <strong class="text-white">resolve customer requests efficiently</strong>, HelpDesk is the cleaner purchase. If you need to <strong class="text-white">capture leads, manage pipelines, automate follow-up, build funnels and operate multiple client accounts</strong>, HighLevel covers a much broader revenue workflow. They can also coexist when HighLevel runs acquisition and HelpDesk runs a dedicated support operation.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-2">
+          <a href="https://www.helpdesk.com/pricing/" target="_blank" rel="noopener noreferrer" class="py-4 px-5 rounded-xl border border-slate-600 hover:bg-slate-800 font-extrabold text-sm text-white text-center">Review HelpDesk plans →</a>
+          <a data-cta="affiliate" data-tool-id="gohighlevel" data-cta-source="compare_helpdesk_highlevel_bottom" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="py-4 px-5 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center">Try HighLevel via partner link →</a>
         </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">HelpDesk Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Centralized ticketing system</div>
-<div>✓ Streamlined customer support</div>
-<div>✓ Team collaboration features</div>
-<div>✓ Automation and analytics</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">GoHighLevel Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ CRM & Pipeline</div>
-<div>✓ Automated SMS/Email</div>
-<div>✓ Sales Funnels</div>
-<div>✓ AI Chatbots</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://helpdesk.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get HelpDesk →</a>
-          <a href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get GoHighLevel →</a>
-        </div>
-      </div>
+        <p class="text-[11px] text-slate-500 leading-relaxed">Paid link disclosure: COSHUMA may earn a commission if you sign up or purchase through the HighLevel partner link, at no extra cost to you. HelpDesk links on this page are standard official links because no COSHUMA tracking link is claimed here.</p>
+      </section>
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS buying guides.</div>
     </footer>
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
Revenue-focused rewrite of the HelpDesk vs HighLevel comparison.

- keeps HelpDesk on standard official pricing links because no verified COSHUMA tracking URL is claimed
- uses the verified COSHUMA HighLevel partner URL
- adds CTA-level attribution sources and the existing affiliate attribution script
- adds conspicuous paid-link disclosure near HighLevel CTAs
- replaces generated `Not rated` / placeholder pricing copy with current buyer-facing pricing and trial details from official vendor pages
- reframes the comparison around the actual buying decision: focused support desk vs all-in-one CRM/marketing/automation platform
- updates branding to COSHUMA and improves SEO title/description

No paid services or subscription changes.