### PR TITLE
Optimize Framer vs Unbounce revenue path

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/framer-vs-unbounce.html
+++ b/projects/GlobalSaaSHub/public/compare/framer-vs-unbounce.html
@@ -3,25 +3,24 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Framer vs Unbounce Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Framer vs Unbounce. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
-
+    <title>Framer vs Unbounce: Pricing, CRO & Best Fit (2026) | COSHUMA</title>
+    <meta name="description" content="Framer vs Unbounce buyer guide for 2026. Compare website-building flexibility, landing-page optimization, current pricing, free-trial terms and the best fit for each workflow." />
     <link rel="canonical" href="https://coshuma.com/compare/framer-vs-unbounce.html" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/compare/framer-vs-unbounce.html" />
-    <meta property="og:title" content="Framer vs Unbounce Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Framer and Unbounce by pricing, features, and verified public information." />
+    <meta property="og:title" content="Framer vs Unbounce: Pricing, CRO & Best Fit (2026) | COSHUMA" />
+    <meta property="og:description" content="Choose Framer for flexible marketing sites and design workflows; choose Unbounce when dedicated landing-page testing and conversion workflows are the priority." />
 
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebPage",
-      "name": "Framer vs Unbounce Comparison",
+      "name": "Framer vs Unbounce: Pricing, CRO & Best Fit (2026)",
       "url": "https://coshuma.com/compare/framer-vs-unbounce.html",
-      "description": "Compare Framer and Unbounce by pricing, features, and verified public information.",
+      "description": "A current buyer guide comparing Framer and Unbounce by site-building workflow, landing-page optimization, pricing and trial terms.",
       "isPartOf": {
         "@type": "WebSite",
-        "name": "GlobalSaaSHub",
+        "name": "COSHUMA",
         "url": "https://coshuma.com/"
       },
       "about": [
@@ -30,7 +29,7 @@
       ]
     }
     </script>
-    
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -41,132 +40,121 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
+    <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+      <div class="max-w-6xl mx-auto flex items-center justify-between gap-4">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div>
+          <span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← All AI & SaaS Tools</a>
       </div>
     </header>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
+    <main class="max-w-5xl mx-auto px-4 py-12 w-full space-y-8">
+      <section class="text-center space-y-4">
+        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">LANDING PAGES · WEBSITE BUILDING · CRO</div>
         <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Framer vs Unbounce</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Coding & Dev Tools tool.
+        <p class="text-slate-300 text-base max-w-3xl mx-auto leading-relaxed">
+          Framer and Unbounce overlap around landing pages, but they solve different primary problems. Framer is a flexible visual website platform for polished marketing sites. Unbounce is purpose-built for campaign landing pages, A/B testing and conversion optimization.
         </p>
-      </div>
+        <p class="text-[11px] text-slate-500">Pricing and product details checked against official vendor pages on September 4, 2026.</p>
+      </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-5">
+        <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
+          <div class="text-xs font-extrabold uppercase tracking-wider text-purple-300">Choose Framer when</div>
+          <h2 class="text-2xl font-black text-white">Your website is the product surface</h2>
+          <ul class="space-y-2 text-sm text-slate-300 leading-relaxed">
+            <li>✓ You need a polished multi-page marketing site, CMS and responsive visual design.</li>
+            <li>✓ Your design team wants staging, branching and broader website publishing workflows.</li>
+            <li>✓ You want a free plan to prototype before connecting a commercial custom domain.</li>
+          </ul>
+          <a href="https://www.framer.com/pricing" target="_blank" rel="noopener noreferrer" class="block w-full py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center transition-all">View official Framer pricing →</a>
+          <p class="text-[10px] text-slate-500">Standard official link. COSHUMA does not currently treat this Framer URL as an affiliate link.</p>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Framer if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
+
+        <div class="p-6 rounded-3xl bg-[#131520] border border-blue-500/30 space-y-4">
+          <div class="text-xs font-extrabold uppercase tracking-wider text-blue-300">Choose Unbounce when</div>
+          <h2 class="text-2xl font-black text-white">Paid-campaign conversion is the KPI</h2>
+          <ul class="space-y-2 text-sm text-slate-300 leading-relaxed">
+            <li>✓ You need dedicated landing pages without rebuilding your main website.</li>
+            <li>✓ A/B testing, custom scripts, pixels, lead forms and campaign optimization matter more than a full-site design system.</li>
+            <li>✓ You want to validate a real campaign with a 14-day free trial before paying.</li>
+          </ul>
+          <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="compare_framer_unbounce_hero" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="block w-full py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center transition-all">Start Unbounce via COSHUMA →</a>
+          <p class="text-[10px] text-slate-400">Partner offer: the verified COSHUMA referral link currently gives 20% off the first three months or 35% off the first annual subscription. Unbounce says referrals start with a 14-day free trial.</p>
+        </div>
+      </section>
+
+      <section class="p-6 md:p-8 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
+        <div>
+          <div class="text-xs font-extrabold uppercase tracking-wider text-slate-400">Current public pricing</div>
+          <h2 class="text-2xl font-black text-white mt-1">What each platform costs</h2>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-3">
+            <h3 class="font-black text-white text-lg">Framer</h3>
+            <div class="grid grid-cols-2 gap-3 text-sm">
+              <div class="p-3 rounded-xl bg-[#11131c]"><div class="text-slate-400 text-xs">Free</div><div class="font-black text-white">$0</div></div>
+              <div class="p-3 rounded-xl bg-[#11131c]"><div class="text-slate-400 text-xs">Basic</div><div class="font-black text-white">$10/mo*</div></div>
+              <div class="p-3 rounded-xl bg-[#11131c]"><div class="text-slate-400 text-xs">Pro</div><div class="font-black text-white">$30/mo*</div></div>
+              <div class="p-3 rounded-xl bg-[#11131c]"><div class="text-slate-400 text-xs">Enterprise</div><div class="font-black text-white">Custom</div></div>
             </div>
+            <p class="text-[11px] text-slate-400 leading-relaxed">*Framer's official pricing page currently shows these monthly equivalents on the yearly-billing view. Additional editors and add-ons can increase the total cost.</p>
           </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Unbounce if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
+
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-3">
+            <h3 class="font-black text-white text-lg">Unbounce</h3>
+            <div class="grid grid-cols-2 gap-3 text-sm">
+              <div class="p-3 rounded-xl bg-[#11131c]"><div class="text-slate-400 text-xs">Starter</div><div class="font-black text-white">$29/mo</div></div>
+              <div class="p-3 rounded-xl bg-[#11131c]"><div class="text-slate-400 text-xs">Build</div><div class="font-black text-white">$99/mo</div></div>
+              <div class="p-3 rounded-xl bg-[#11131c]"><div class="text-slate-400 text-xs">Experiment</div><div class="font-black text-white">$149/mo</div></div>
+              <div class="p-3 rounded-xl bg-[#11131c]"><div class="text-slate-400 text-xs">Optimize</div><div class="font-black text-white">$249/mo</div></div>
             </div>
+            <p class="text-[11px] text-slate-400 leading-relaxed">Unbounce currently lists lower annual-billing equivalents of $22, $74, $112 and $187 per month for these tiers. Concierge and Agency use custom pricing.</p>
           </div>
         </div>
-      </div>
+      </section>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/framer.html" class="hover:text-purple-300">Framer</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/unbounce.html" class="hover:text-blue-300">Unbounce</a>
-          </div>
+      <section class="p-6 md:p-8 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <div>
+          <div class="text-xs font-extrabold uppercase tracking-wider text-emerald-400">Fast decision</div>
+          <h2 class="text-2xl font-black text-white mt-1">Which one should you buy?</h2>
         </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm text-left min-w-[680px]">
+            <thead class="text-xs uppercase text-slate-400 border-b border-[#2a2d3d]">
+              <tr><th class="py-3 pr-4">Need</th><th class="py-3 pr-4">Better first choice</th><th class="py-3">Why</th></tr>
+            </thead>
+            <tbody class="divide-y divide-[#222538] text-slate-300">
+              <tr><td class="py-4 pr-4">Full marketing website</td><td class="py-4 pr-4 font-bold text-purple-300">Framer</td><td class="py-4">Broader site design, CMS and publishing workflow.</td></tr>
+              <tr><td class="py-4 pr-4">Dedicated paid-ad landing pages</td><td class="py-4 pr-4 font-bold text-blue-300">Unbounce</td><td class="py-4">Campaign-first builder with landing-page conversion tooling.</td></tr>
+              <tr><td class="py-4 pr-4">Native A/B testing as the core workflow</td><td class="py-4 pr-4 font-bold text-blue-300">Unbounce</td><td class="py-4">Experiment and Optimize plans are positioned around testing and conversion improvement.</td></tr>
+              <tr><td class="py-4 pr-4">Design-led startup or portfolio site</td><td class="py-4 pr-4 font-bold text-purple-300">Framer</td><td class="py-4">Stronger fit when visual site design is more important than campaign operations.</td></tr>
+              <tr><td class="py-4 pr-4">Agency landing-page service</td><td class="py-4 pr-4 font-bold text-blue-300">Unbounce</td><td class="py-4">Agency-oriented campaign workflows, custom tiers and client landing-page use cases.</td></tr>
+            </tbody>
+          </table>
         </div>
+      </section>
 
+      <section class="p-6 md:p-8 rounded-3xl bg-gradient-to-br from-blue-950/60 to-purple-950/40 border border-blue-500/30 space-y-5 text-center">
+        <div class="text-xs font-extrabold uppercase tracking-wider text-blue-300">Low-risk test path</div>
+        <h2 class="text-2xl md:text-3xl font-black text-white">Test Unbounce with one real campaign before committing</h2>
+        <p class="text-sm text-slate-300 max-w-3xl mx-auto leading-relaxed">Use one existing paid campaign, rebuild its landing page, connect the real form or conversion goal, and compare conversion performance during the trial. If you do not have a campaign worth testing, Framer's free plan is the lower-pressure place to prototype a general website first.</p>
+        <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="compare_framer_unbounce_bottom" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="inline-block py-4 px-7 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white shadow-lg transition-all">Start the 14-day Unbounce trial →</a>
+        <p class="text-[10px] text-slate-400 max-w-2xl mx-auto">Affiliate disclosure: COSHUMA may earn a commission if you become a paying Unbounce customer through this verified partner link, at no extra cost to you. Unbounce's welcome email to COSHUMA states a minimum 25% commission for the first year and a 90-day tracking cookie.</p>
+      </section>
 
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Framer Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Interactive prototyping</div>
-<div>✓ Visual website builder</div>
-<div>✓ CMS functionality</div>
-<div>✓ Responsive design capabilities</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Unbounce Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Drag-and-Drop Page Builder</div>
-<div>✓ A/B Testing & Optimization</div>
-<div>✓ AI-Powered Copy Generation</div>
-<div>✓ Conversion Rate Smart Features</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://framer.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Framer →</a>
-          <a href="https://unbounce.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Unbounce →</a>
-        </div>
-      </div>
+      <section class="p-5 rounded-2xl bg-[#11131c] border border-[#222538] text-xs text-slate-400 leading-relaxed space-y-2">
+        <p><strong class="text-slate-300">Source freshness:</strong> Framer pricing was checked on the official Framer pricing page. Unbounce pricing and trial terms were checked on the official Unbounce pricing/plan pages. Partner discount, commission and cookie details were checked against the Unbounce partner welcome email sent to COSHUMA on September 3, 2026.</p>
+        <p>Vendor pricing and limits can change. Confirm the final checkout amount before purchasing.</p>
+      </section>
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">© 2026 COSHUMA · Independent AI & SaaS buying guides</div>
     </footer>
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Revenue goal
Convert an existing high-intent Framer vs Unbounce comparison page from generic directory copy into a current buyer guide while routing Unbounce clicks through the verified COSHUMA partner URL.

## What changed
- Replaces generic `https://unbounce.com/` CTA with verified `https://unbounce.partnerlinks.io/5ubjnt8lluqi`
- Adds distinct hero/bottom affiliate attribution sources
- Adds `/affiliate-attribution.js` and sponsored disclosure
- Updates Framer and Unbounce pricing/trial copy using current official vendor pages checked 2026-09-04
- Adds the partner discount disclosed in Unbounce's 2026-09-03 welcome email (20% off first 3 months or 35% off first annual subscription)
- Keeps Framer on a normal official pricing link because no verified Framer affiliate URL is available

## Safety
No paid services, no guessed tracking URLs, no dashboard/onboarding URL used as a revenue link.