### PR TITLE
Fix COSHUMA production bundle sync

### DIFF
--- a/.github/workflows/coshuma-site-deploy.yml
+++ b/.github/workflows/coshuma-site-deploy.yml
@@ -1,0 +1,64 @@
+name: COSHUMA Site Build & Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'projects/GlobalSaaSHub/src/**'
+      - 'projects/GlobalSaaSHub/public/**'
+      - 'projects/GlobalSaaSHub/index.html'
+      - 'projects/GlobalSaaSHub/package.json'
+      - 'projects/GlobalSaaSHub/package-lock.json'
+      - 'projects/GlobalSaaSHub/vite.config.*'
+      - '.github/workflows/coshuma-site-deploy.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: coshuma-site-deploy
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: projects/GlobalSaaSHub/package-lock.json
+
+      - name: Install dependencies
+        working-directory: projects/GlobalSaaSHub
+        run: npm ci
+
+      - name: Build production bundle
+        working-directory: projects/GlobalSaaSHub
+        run: npm run build
+
+      - name: Verify COSHUMA bundle identity
+        run: |
+          set -e
+          test -f projects/GlobalSaaSHub/dist/index.html
+          grep -q 'COSHUMA' projects/GlobalSaaSHub/dist/index.html
+          if grep -q 'GlobalSaaSHub - Premier AI' projects/GlobalSaaSHub/dist/index.html; then
+            echo 'Stale GlobalSaaSHub fallback detected in production bundle.'
+            exit 1
+          fi
+          grep -q 'coshuma.com' projects/GlobalSaaSHub/dist/CNAME
+
+      - name: Publish complete Vite dist to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./projects/GlobalSaaSHub/dist
+          publish_branch: gh-pages
+          force_orphan: true
+          enable_jekyll: false
+          commit_message: 'deploy: sync COSHUMA production bundle from ${{ github.sha }}'

--- a/projects/GlobalSaaSHub/scripts/DEPLOYMENT.md
+++ b/projects/GlobalSaaSHub/scripts/DEPLOYMENT.md
@@ -1,0 +1,14 @@
+# COSHUMA production deployment
+
+`coshuma.com` is served from the repository's `gh-pages` branch.
+
+The production branch must contain the **complete output of `npm run build`**, not a hand-edited `index.html` paired with an older hashed JS/CSS bundle.
+
+Source of truth:
+- UI source: `projects/GlobalSaaSHub/src/`
+- Static/SEO source: `projects/GlobalSaaSHub/public/` and `projects/GlobalSaaSHub/index.html`
+- Production artifact: `projects/GlobalSaaSHub/dist/`
+- Production branch: `gh-pages`
+- Custom domain: `projects/GlobalSaaSHub/public/CNAME` = `coshuma.com`
+
+`.github/workflows/coshuma-site-deploy.yml` rebuilds and publishes the complete Vite `dist` when site source changes. Do not manually sync only individual `gh-pages` HTML files after React/UI changes; doing so can leave `index.html` pointing at a stale hashed application bundle.

--- a/projects/GlobalSaaSHub/scripts/verify_deployed_bundle.py
+++ b/projects/GlobalSaaSHub/scripts/verify_deployed_bundle.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import re
+
+project = Path(__file__).resolve().parents[1]
+dist = project / 'dist'
+index = dist / 'index.html'
+
+if not index.exists():
+    raise SystemExit('dist/index.html missing')
+
+html = index.read_text(encoding='utf-8')
+if 'COSHUMA' not in html:
+    raise SystemExit('COSHUMA brand marker missing from dist/index.html')
+if 'GlobalSaaSHub - Premier AI' in html:
+    raise SystemExit('stale GlobalSaaSHub fallback detected')
+
+asset_refs = re.findall(r'(?:src|href)="(/assets/[^"]+)"', html)
+if not asset_refs:
+    raise SystemExit('No hashed Vite assets referenced by dist/index.html')
+
+for ref in asset_refs:
+    if not (dist / ref.lstrip('/')).exists():
+        raise SystemExit(f'Missing referenced asset: {ref}')
+
+cname = dist / 'CNAME'
+if not cname.exists() or cname.read_text(encoding='utf-8').strip() != 'coshuma.com':
+    raise SystemExit('dist/CNAME missing or incorrect')
+
+print('OK: COSHUMA dist bundle is internally consistent and targets coshuma.com')


### PR DESCRIPTION
Root cause: gh-pages/index.html had current COSHUMA fallback/meta content but still referenced an older hashed Vite JS/CSS bundle, so browsers hydrated into the stale GlobalSaaSHub UI. This adds a dedicated site build/deploy workflow that rebuilds the complete GlobalSaaSHub Vite dist on relevant main changes and publishes the entire dist atomically to gh-pages, plus a bundle integrity guard and deployment-source documentation. No paid services, affiliate URLs, or product data are changed.