### PR TITLE
Optimize Murf AI vs LOVO revenue path

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/murf-ai-vs-lovo.html
+++ b/projects/GlobalSaaSHub/public/compare/murf-ai-vs-lovo.html
@@ -1,172 +1,117 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Murf AI vs Lovo Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Murf AI vs Lovo. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Murf AI vs LOVO (2026): Pricing, Free Trial & Best Fit | COSHUMA</title>
+  <meta name="description" content="Compare Murf AI and LOVO for AI voiceovers, voice cloning and video workflows. See Murf pricing, LOVO's free-trial path, and a verified COSHUMA Murf partner link." />
+  <link rel="canonical" href="https://coshuma.com/compare/murf-ai-vs-lovo.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/murf-ai-vs-lovo.html" />
+  <meta property="og:site_name" content="COSHUMA" />
+  <meta property="og:title" content="Murf AI vs LOVO (2026): Pricing, Free Trial & Best Fit" />
+  <meta property="og:description" content="A practical buyer guide for choosing between Murf AI and LOVO, with current official pricing/trial context and a verified Murf partner path." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"WebPage",
+    "name":"Murf AI vs LOVO Comparison",
+    "url":"https://coshuma.com/compare/murf-ai-vs-lovo.html",
+    "isPartOf":{"@type":"WebSite","name":"COSHUMA","url":"https://coshuma.com/"},
+    "about":[
+      {"@type":"SoftwareApplication","name":"Murf AI","url":"https://coshuma.com/tool/murf-ai.html"},
+      {"@type":"SoftwareApplication","name":"LOVO","url":"https://coshuma.com/tool/lovo.html"}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="/affiliate-attribution.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen bg-[#0b0c10] text-slate-100">
+  <header class="border-b border-[#222538] bg-[#07080c]/90 sticky top-0 z-50 py-4 px-6 backdrop-blur-md">
+    <div class="max-w-5xl mx-auto flex items-center justify-between">
+      <a href="/" class="font-extrabold text-white">COSHUMA</a>
+      <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">← All Tools</a>
+    </div>
+  </header>
 
-    <link rel="canonical" href="https://coshuma.com/compare/murf-ai-vs-lovo.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/murf-ai-vs-lovo.html" />
-    <meta property="og:title" content="Murf AI vs Lovo Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Murf AI and Lovo by pricing, features, and verified public information." />
+  <main class="max-w-5xl mx-auto px-4 py-10 space-y-8">
+    <section class="text-center space-y-4">
+      <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">AI voice buyer comparison · Updated September 2026</div>
+      <h1 class="text-4xl md:text-5xl font-black tracking-tight">Murf AI vs LOVO</h1>
+      <p class="max-w-3xl mx-auto text-slate-300">Choose Murf AI when you want a focused studio-style voiceover workflow with clear public pricing. Choose LOVO when an integrated voice-plus-video workflow in Genny is the stronger fit. Both can be tried before committing to a paid plan.</p>
+      <p class="text-xs text-slate-500 max-w-3xl mx-auto">Affiliate disclosure: the Murf buttons on this page use COSHUMA's verified partner link. COSHUMA may earn a commission from an eligible signup or purchase at no extra cost to you. LOVO buttons are standard official links, not COSHUMA affiliate links.</p>
+    </section>
 
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "Murf AI vs Lovo Comparison",
-      "url": "https://coshuma.com/compare/murf-ai-vs-lovo.html",
-      "description": "Compare Murf AI and Lovo by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "Murf AI", "url": "https://coshuma.com/tool/murf-ai.html"},
-        {"@type": "SoftwareApplication", "name": "Lovo", "url": "https://coshuma.com/tool/lovo.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+    <section class="grid md:grid-cols-2 gap-5">
+      <article class="rounded-3xl bg-[#131520] border border-purple-500/30 p-6 space-y-5">
+        <div>
+          <div class="text-xs font-bold text-purple-300 uppercase tracking-wider">Best fit: Murf AI</div>
+          <h2 class="text-2xl font-black mt-1">Voiceover production with transparent plan pricing</h2>
+        </div>
+        <ul class="space-y-2 text-sm text-slate-300">
+          <li>✓ 200+ AI voices and 30+ languages/accents on current Studio plans</li>
+          <li>✓ Free plan at $0 with no credit card required</li>
+          <li>✓ Creator from $19/month billed annually</li>
+          <li>✓ Business from $66/month billed annually</li>
+        </ul>
+        <a data-cta="affiliate" data-tool-id="murf-ai" data-cta-source="compare_murf_lovo_hero_murf" href="https://get.murf.ai/fqac0vixj0qs" target="_blank" rel="sponsored noopener noreferrer" class="block w-full py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center shadow-lg">Try Murf AI via verified partner link →</a>
+        <a href="/tool/murf-ai.html" class="block text-center text-xs text-slate-400 hover:text-white">See the Murf AI buyer guide</a>
+      </article>
+
+      <article class="rounded-3xl bg-[#131520] border border-blue-500/30 p-6 space-y-5">
+        <div>
+          <div class="text-xs font-bold text-blue-300 uppercase tracking-wider">Best fit: LOVO</div>
+          <h2 class="text-2xl font-black mt-1">Voice generation plus Genny video creation</h2>
+        </div>
+        <ul class="space-y-2 text-sm text-slate-300">
+          <li>✓ 500+ AI voices listed in COSHUMA's current product data</li>
+          <li>✓ Voice cloning and text-to-speech workflows</li>
+          <li>✓ Integrated Genny video editor</li>
+          <li>✓ Official 14-day Pro trial with no payment or card details required</li>
+        </ul>
+        <a href="https://lovo.ai/pricing" target="_blank" rel="noopener noreferrer" class="block w-full py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center shadow-lg">Check LOVO plans & trial →</a>
+        <a href="/tool/lovo.html" class="block text-center text-xs text-slate-400 hover:text-white">See the LOVO buyer guide</a>
+      </article>
+    </section>
+
+    <section class="rounded-3xl bg-[#131520] border border-[#222538] p-6 space-y-5">
+      <h2 class="text-2xl font-black">Fast decision guide</h2>
+      <div class="grid md:grid-cols-3 gap-4 text-sm">
+        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white mb-1">Lowest-friction test</div><p class="text-slate-400">Murf publishes a $0 Studio plan with no card required. LOVO's official help center says new users receive a 14-day Pro trial with no payment or card details required.</p></div>
+        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white mb-1">Mostly voiceovers?</div><p class="text-slate-400">Murf is the cleaner choice when the job is primarily voice production and you want plan limits and annual pricing visible before signup.</p></div>
+        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white mb-1">Need video in the same workspace?</div><p class="text-slate-400">LOVO is more compelling when Genny's integrated video editor matters as much as text-to-speech and cloning.</p></div>
       </div>
-    </header>
+    </section>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Murf AI vs Lovo</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Voice & Speech AI tool.
-        </p>
+    <section class="rounded-3xl bg-[#131520] border border-[#222538] p-6 space-y-4">
+      <h2 class="text-2xl font-black">Current pricing & trial context</h2>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead><tr class="text-left border-b border-[#2a2d3d]"><th class="py-3 pr-4">Product</th><th class="py-3 pr-4">Free entry</th><th class="py-3 pr-4">Paid plan context</th><th class="py-3">Best for</th></tr></thead>
+          <tbody class="text-slate-300">
+            <tr class="border-b border-[#222538]"><td class="py-4 pr-4 font-bold text-white">Murf AI</td><td class="py-4 pr-4">$0, no card</td><td class="py-4 pr-4">Creator from $19/mo and Business from $66/mo when billed annually</td><td class="py-4">Focused studio voice production</td></tr>
+            <tr><td class="py-4 pr-4 font-bold text-white">LOVO</td><td class="py-4 pr-4">14-day Pro trial, no payment/card details</td><td class="py-4 pr-4">Check the official pricing page for the current paid tiers before purchase</td><td class="py-4">Voice + Genny video workflow</td></tr>
+          </tbody>
+        </table>
       </div>
+      <p class="text-xs text-slate-500">Sources checked September 4, 2026: Murf's official pricing page and LOVO's official help center trial documentation. Vendor pricing and limits can change, so confirm the checkout page before paying.</p>
+    </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Murf AI if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Lovo if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
-      </div>
+    <section class="rounded-3xl bg-gradient-to-r from-purple-950/50 to-blue-950/50 border border-purple-500/20 p-6 text-center space-y-4">
+      <h2 class="text-2xl font-black">Want to test Murf first?</h2>
+      <p class="text-sm text-slate-300 max-w-2xl mx-auto">Murf's current free entry removes the card requirement, so it is the lower-risk path if you mainly need AI voice production. Use the verified partner button below so COSHUMA can attribute eligible referrals correctly.</p>
+      <a data-cta="affiliate" data-tool-id="murf-ai" data-cta-source="compare_murf_lovo_bottom_murf" href="https://get.murf.ai/fqac0vixj0qs" target="_blank" rel="sponsored noopener noreferrer" class="inline-block py-3.5 px-6 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white">Open Murf AI free plan →</a>
+      <div class="text-[11px] text-slate-500">Paid partner link. Use only if Murf fits your workflow.</div>
+    </section>
+  </main>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/murf-ai.html" class="hover:text-purple-300">Murf AI</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/lovo.html" class="hover:text-blue-300">Lovo</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Murf AI Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Studio-quality AI voices</div>
-<div>✓ Custom voice cloning</div>
-<div>✓ Speech-to-text editor</div>
-<div>✓ Background music and sound</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Lovo Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ 500+ AI voices</div>
-<div>✓ Advanced voice cloning</div>
-<div>✓ Integrated Genny video editor</div>
-<div>✓ High-quality text-to-speech</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://murf.ai/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Murf AI →</a>
-          <a href="https://lovo.ai/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Lovo →</a>
-        </div>
-      </div>
-    </main>
-
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
-  </body>
+  <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
+    <div class="max-w-5xl mx-auto px-4">&copy; 2026 COSHUMA. Independent buyer guide with affiliate disclosure.</div>
+  </footer>
+</body>
 </html>


### PR DESCRIPTION
Replace the stale generated Murf AI vs LOVO comparison with a current COSHUMA buyer guide. Route Murf clicks through the verified PartnerStack referral URL from the Murf welcome email, add CTA-level attribution, preserve LOVO as an official non-affiliate path, and add current Murf pricing / LOVO trial context from official sources. No paid services or unverified affiliate URLs are introduced.