### PR TITLE
Optimize Speechify vs Murf revenue path

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/speechify-vs-murf-ai.html
+++ b/projects/GlobalSaaSHub/public/compare/speechify-vs-murf-ai.html
@@ -3,170 +3,111 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Speechify vs Murf AI Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Speechify vs Murf AI. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
-
+    <title>Speechify vs Murf AI: Reading Assistant or Voiceover Studio? (2026) | COSHUMA</title>
+    <meta name="description" content="Compare Speechify and Murf AI by use case, current public pricing, free access and buyer fit. Speechify is centered on listening to text and voice assistance; Murf AI is built for generated voiceovers and production." />
     <link rel="canonical" href="https://coshuma.com/compare/speechify-vs-murf-ai.html" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/compare/speechify-vs-murf-ai.html" />
-    <meta property="og:title" content="Speechify vs Murf AI Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Speechify and Murf AI by pricing, features, and verified public information." />
-
+    <meta property="og:site_name" content="COSHUMA" />
+    <meta property="og:title" content="Speechify vs Murf AI: Reading Assistant or Voiceover Studio? (2026)" />
+    <meta property="og:description" content="A practical buyer guide for choosing between text listening and AI voiceover production." />
     <script type="application/ld+json">
     {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "Speechify vs Murf AI Comparison",
-      "url": "https://coshuma.com/compare/speechify-vs-murf-ai.html",
-      "description": "Compare Speechify and Murf AI by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "Speechify", "url": "https://coshuma.com/tool/speechify.html"},
-        {"@type": "SoftwareApplication", "name": "Murf AI", "url": "https://coshuma.com/tool/murf-ai.html"}
+      "@context":"https://schema.org",
+      "@type":"WebPage",
+      "name":"Speechify vs Murf AI",
+      "url":"https://coshuma.com/compare/speechify-vs-murf-ai.html",
+      "description":"Compare Speechify and Murf AI by use case, public pricing and buyer fit.",
+      "isPartOf":{"@type":"WebSite","name":"COSHUMA","url":"https://coshuma.com/"},
+      "about":[
+        {"@type":"SoftwareApplication","name":"Speechify","url":"https://coshuma.com/tool/speechify.html"},
+        {"@type":"SoftwareApplication","name":"Murf AI","url":"https://coshuma.com/tool/murf-ai.html"}
       ]
     }
     </script>
-    
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
+      body { font-family:'Inter',sans-serif; background:#0b0c10; color:#f1f5f9; }
+      h1,h2,h3 { font-family:'Outfit',sans-serif; }
     </style>
   </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
+  <body class="min-h-screen bg-[#0b0c10]">
+    <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50">
+      <div class="max-w-6xl mx-auto px-5 py-4 flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-9 w-9 rounded-xl bg-purple-600 flex items-center justify-center font-black">C</div>
+          <span class="font-black text-lg">COSHUMA</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 text-purple-300">Browse buyer guides</a>
       </div>
     </header>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
+    <main class="max-w-5xl mx-auto px-5 py-12 space-y-10">
+      <section class="text-center space-y-4">
+        <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold border border-purple-500/20 bg-purple-500/10 text-purple-300">Buyer guide · Updated September 2026</div>
+        <h1 class="text-4xl md:text-6xl font-black tracking-tight">Speechify vs Murf AI</h1>
+        <p class="text-slate-300 max-w-3xl mx-auto leading-relaxed">These products overlap on AI speech, but their strongest buyer use cases are different. Speechify is primarily useful when you want to <strong>listen to text and documents</strong>. Murf AI is a better fit when you need to <strong>produce generated voiceovers</strong> for content, training or marketing.</p>
+      </section>
+
+      <section class="grid md:grid-cols-2 gap-5">
+        <article class="p-6 rounded-3xl bg-[#131520] border border-purple-500/25 space-y-4">
+          <div class="text-xs uppercase tracking-wider text-purple-300 font-bold">Choose Speechify when</div>
+          <h2 class="text-2xl font-black">You want text read aloud</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">Speechify's current consumer product focuses on reading text aloud, scanning and listening, voice typing, AI summaries and chat. Its Premium plan also advertises more than 1,000 natural voices and support for more than 60 languages.</p>
+          <div class="rounded-2xl bg-[#0f1119] p-4 text-sm text-slate-300">
+            <div class="font-bold text-white mb-2">Current public pricing</div>
+            <div>Free: $0 with basic read-aloud features and 10 robotic-style voices. Premium: $29/month on the monthly pricing view. Speechify also advertises a discounted annual option; verify the live checkout before purchase.</div>
+          </div>
+          <a data-cta="official" href="https://speechify.com/pricing/" target="_blank" rel="noopener noreferrer" class="block text-center py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold">Check Speechify pricing →</a>
+        </article>
+
+        <article class="p-6 rounded-3xl bg-[#131520] border border-blue-500/25 space-y-4">
+          <div class="text-xs uppercase tracking-wider text-blue-300 font-bold">Choose Murf AI when</div>
+          <h2 class="text-2xl font-black">You need generated voiceovers</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">Murf AI is positioned around AI voice generation for creators and businesses. Its Studio plans support voiceover production, commercial usage on paid tiers and a free entry point for testing the workflow.</p>
+          <div class="rounded-2xl bg-[#0f1119] p-4 text-sm text-slate-300">
+            <div class="font-bold text-white mb-2">Current public pricing</div>
+            <div>Free: $0 with no credit card required. Creator: $19/month when billed annually. Business: $66/month when billed annually. Murf's free workspace includes limited generation and does not include downloads or commercial rights.</div>
+          </div>
+          <a data-cta="affiliate" data-tool-id="murf-ai" data-cta-source="compare_speechify_murf_hero_murf" href="https://get.murf.ai/fqac0vixj0qs" target="_blank" rel="sponsored noopener noreferrer" class="block text-center py-3.5 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold">Try Murf AI via verified partner link →</a>
+          <p class="text-[11px] text-slate-500">Paid partner link. COSHUMA may earn a commission if an eligible purchase is attributed to this link, at no added cost to you.</p>
+        </article>
+      </section>
+
+      <section class="p-6 md:p-8 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
+        <h2 class="text-2xl font-black">Quick decision table</h2>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm text-left border-collapse">
+            <thead><tr class="border-b border-[#2a2d3c]"><th class="py-3 pr-4">Need</th><th class="py-3 pr-4">Better fit</th><th class="py-3">Why</th></tr></thead>
+            <tbody class="text-slate-300">
+              <tr class="border-b border-[#222538]"><td class="py-4 pr-4">Listen to articles, documents or scanned text</td><td class="py-4 pr-4 font-bold text-purple-300">Speechify</td><td class="py-4">Its core product is built around reading text aloud and listening productivity.</td></tr>
+              <tr class="border-b border-[#222538]"><td class="py-4 pr-4">Create narration, ads, training or marketing audio</td><td class="py-4 pr-4 font-bold text-blue-300">Murf AI</td><td class="py-4">Its Studio product is built around generated voiceovers and production.</td></tr>
+              <tr class="border-b border-[#222538]"><td class="py-4 pr-4">Use AI summaries and chat while consuming documents</td><td class="py-4 pr-4 font-bold text-purple-300">Speechify</td><td class="py-4">Speechify includes these features in its Premium consumer experience.</td></tr>
+              <tr><td class="py-4 pr-4">Test AI voice generation without a card</td><td class="py-4 pr-4 font-bold text-blue-300">Murf AI</td><td class="py-4">Murf advertises a $0 free entry with no credit card required.</td></tr>
+            </tbody>
+          </table>
         </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Speechify vs Murf AI</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Voice & Speech AI tool.
-        </p>
-      </div>
+      </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
+      <section class="p-7 rounded-3xl bg-gradient-to-br from-blue-600/15 to-purple-600/10 border border-blue-500/20 text-center space-y-4">
+        <h2 class="text-2xl md:text-3xl font-black">Best low-risk next step</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto">If your goal is voiceover production, Murf's free entry lets you test the workflow before paying. If your goal is consuming written material faster, start with Speechify's free tier and compare the listening experience first.</p>
+        <div class="flex flex-col sm:flex-row gap-3 justify-center">
+          <a data-cta="affiliate" data-tool-id="murf-ai" data-cta-source="compare_speechify_murf_bottom_murf" href="https://get.murf.ai/fqac0vixj0qs" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm">Test Murf AI →</a>
+          <a data-cta="official" href="https://speechify.com/pricing/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl border border-slate-600 hover:bg-slate-800 font-extrabold text-sm">Explore Speechify →</a>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Speechify if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Murf AI if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
-      </div>
+        <div class="text-[11px] text-slate-500">Murf buttons marked as partner links use COSHUMA's verified referral URL.</div>
+      </section>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/speechify.html" class="hover:text-purple-300">Speechify</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/murf-ai.html" class="hover:text-blue-300">Murf AI</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Speechify Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Text-to-speech conversion</div>
-<div>✓ Natural-sounding audio</div>
-<div>✓ Accessibility tools</div>
-<div>✓ Productivity enhancement</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Murf AI Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Studio-quality AI voices</div>
-<div>✓ Custom voice cloning</div>
-<div>✓ Speech-to-text editor</div>
-<div>✓ Background music and sound</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://speechify.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Speechify →</a>
-          <a href="https://murf.ai/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Murf AI →</a>
-        </div>
-      </div>
+      <section class="text-xs text-slate-500 leading-relaxed border-t border-[#222538] pt-6">
+        <strong class="text-slate-400">Sources checked:</strong> Speechify official pricing for the current Free and Premium reader plans and listed features; Murf AI official pricing for Studio plan pricing, free-entry conditions and plan limits. Prices can change, so confirm the vendor checkout page before purchase.
+      </section>
     </main>
 
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
+    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">© 2026 COSHUMA · Independent AI & SaaS buyer guides</footer>
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
Replace the stale autogenerated comparison with a current buyer guide, preserve Speechify as an official non-affiliate link, route Murf buyer-intent clicks through the verified COSHUMA referral URL, add CTA attribution/disclosure, and refresh pricing/use-case copy from current official vendor pages. No paid services or unverified affiliate URLs added.