### PR TITLE
Launch AI video generators money hub

### DIFF
--- a/projects/GlobalSaaSHub/index.html
+++ b/projects/GlobalSaaSHub/index.html
@@ -59,7 +59,8 @@
         </p>
         <nav aria-label="Featured software buyer guides" style="margin-top: 20px; font-size: 13px; line-height: 2;">
           <strong>Best software shortlists:</strong><br />
-          <a href="/best/ai-voice-generators.html">Best AI Voice Generators in 2026</a><br />
+          <a href="/best/ai-voice-generators.html">Best AI Voice Generators in 2026</a> ·
+          <a href="/best/ai-video-generators.html">Best AI Video Generators in 2026</a><br />
           <strong>Popular pricing and review guides:</strong><br />
           <a href="/tool/descript.html">Descript pricing & review</a> ·
           <a href="/tool/elevenlabs.html">ElevenLabs pricing & review</a> ·

--- a/projects/GlobalSaaSHub/public/best/ai-video-generators.html
+++ b/projects/GlobalSaaSHub/public/best/ai-video-generators.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Best AI Video Generators in 2026: Pictory, Descript & Fliki | COSHUMA</title>
+  <meta name="description" content="Compare AI video creation tools for creators and teams in 2026. See current public pricing, buyer fit, free starting options, and verified COSHUMA partner paths for Pictory, Descript and Fliki." />
+  <link rel="canonical" href="https://coshuma.com/best/ai-video-generators.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="COSHUMA" />
+  <meta property="og:title" content="Best AI Video Generators in 2026 | COSHUMA" />
+  <meta property="og:description" content="A buyer-first shortlist of AI video tools based on current public pricing, documented capabilities and practical fit." />
+  <meta property="og:url" content="https://coshuma.com/best/ai-video-generators.html" />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"Best AI Video Generators in 2026",
+    "dateModified":"2026-09-05",
+    "author":{"@type":"Organization","name":"COSHUMA"},
+    "publisher":{"@type":"Organization","name":"COSHUMA"},
+    "mainEntityOfPage":"https://coshuma.com/best/ai-video-generators.html"
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>body{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}</style>
+</head>
+<body class="bg-[#08090d] text-slate-100 antialiased">
+  <header class="border-b border-white/10 bg-[#0c0e14]">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-5 py-4">
+      <a href="/" class="text-xl font-black tracking-tight text-white">COSHUMA</a>
+      <div class="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Independent AI & SaaS buyer guides</div>
+    </div>
+  </header>
+
+  <main class="mx-auto max-w-6xl px-5 py-12 sm:py-16">
+    <nav class="mb-7 text-sm text-slate-500"><a class="hover:text-white" href="/">Home</a> <span class="px-2">/</span> Best AI Video Generators</nav>
+
+    <section class="max-w-4xl">
+      <div class="mb-5 inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">Pricing checked against official vendor pages · Sep 5, 2026</div>
+      <h1 class="text-4xl font-black tracking-[-0.04em] text-white sm:text-6xl">Best AI Video Generators in 2026</h1>
+      <p class="mt-5 max-w-3xl text-lg leading-8 text-slate-400">Choose by workflow. Pictory is the strongest starting point for turning scripts and long-form content into publishable videos. Descript is better when editing recorded audio/video is the main job. Fliki is an easy free starting point for script-to-video experimentation. Rankings are based on documented capabilities, public pricing and buyer fit—not fabricated user ratings.</p>
+    </section>
+
+    <section class="mt-10 grid gap-4 md:grid-cols-3">
+      <div class="rounded-2xl border border-violet-400/30 bg-violet-500/10 p-5">
+        <div class="text-xs font-black uppercase tracking-widest text-violet-300">Best for text & content repurposing</div>
+        <h2 class="mt-2 text-2xl font-black">Pictory</h2>
+        <p class="mt-2 text-sm leading-6 text-slate-300">Script-to-video, text-based editing, captions, stock assets, AI voices and long-form content summarization in one workflow.</p>
+        <div class="mt-4 text-sm font-bold text-white">14-day trial · Starter $25/mo yearly</div>
+      </div>
+      <div class="rounded-2xl border border-cyan-400/30 bg-cyan-500/10 p-5">
+        <div class="text-xs font-black uppercase tracking-widest text-cyan-300">Best for editing recorded media</div>
+        <h2 class="mt-2 text-2xl font-black">Descript</h2>
+        <p class="mt-2 text-sm leading-6 text-slate-300">Text-based video and podcast editing with transcription, captions, screen recording and AI-assisted cleanup.</p>
+        <div class="mt-4 text-sm font-bold text-white">Free $0 · Creator $12/editor/mo yearly</div>
+      </div>
+      <div class="rounded-2xl border border-white/10 bg-white/[0.04] p-5">
+        <div class="text-xs font-black uppercase tracking-widest text-slate-400">Best free script-to-video start</div>
+        <h2 class="mt-2 text-2xl font-black">Fliki</h2>
+        <p class="mt-2 text-sm leading-6 text-slate-300">Free plan with no credit card, script/blog/PPT-to-video workflows, stock media and multilingual AI voices.</p>
+        <div class="mt-4 text-sm font-bold text-white">Free forever · 3 credits/mo</div>
+      </div>
+    </section>
+
+    <section class="mt-14">
+      <div class="mb-5"><div class="text-xs font-bold uppercase tracking-[0.2em] text-violet-300">Shortlist</div><h2 class="mt-2 text-3xl font-black">Pick by workflow, not by tool count</h2></div>
+
+      <article class="rounded-3xl border border-violet-400/25 bg-[#11131a] p-6 sm:p-8">
+        <div class="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div class="max-w-3xl">
+            <div class="text-xs font-black uppercase tracking-widest text-violet-300">#1 · Best for text-to-video & repurposing</div>
+            <h3 class="mt-2 text-3xl font-black">Pictory</h3>
+            <p class="mt-3 leading-7 text-slate-300">Pictory currently shows a 14-day free trial. Annual pricing starts at Starter $25/month, Professional $35/month and Team $119/month. The product combines script-to-video, automatic subtitles, text-based editing, stock media and AI voice options, making it a strong fit for marketers and creators converting written or long-form content into video.</p>
+            <div class="mt-5 grid gap-3 sm:grid-cols-2"><div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Best for</div><div class="mt-1 text-sm text-slate-400">Blog-to-video, script-to-video, content repurposing, marketers and social video workflows</div></div><div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Watch for</div><div class="mt-1 text-sm text-slate-400">Annual headline prices require yearly billing; monthly prices are higher</div></div></div>
+          </div>
+          <div class="w-full shrink-0 space-y-3 lg:w-72">
+            <a data-cta="affiliate" data-tool-id="pictory" data-cta-source="best_ai_video_generators_pictory" href="https://pictory.ai?fpr=sangkwon-an23" target="_blank" rel="sponsored noopener noreferrer" class="block rounded-xl bg-violet-600 px-5 py-4 text-center font-black text-white hover:bg-violet-500">Try Pictory Free →</a>
+            <a href="/tool/pictory.html" class="block rounded-xl border border-white/10 px-5 py-3 text-center text-sm font-bold text-slate-300 hover:bg-white/5">Read Pictory buyer guide</a>
+          </div>
+        </div>
+      </article>
+
+      <article class="mt-5 rounded-3xl border border-cyan-400/25 bg-[#11131a] p-6 sm:p-8">
+        <div class="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div class="max-w-3xl">
+            <div class="text-xs font-black uppercase tracking-widest text-cyan-300">#2 · Best for text-based editing of recorded media</div>
+            <h3 class="mt-2 text-3xl font-black">Descript</h3>
+            <p class="mt-3 leading-7 text-slate-300">Descript offers a $0 Free plan. Its current annual plan view lists Creator at $12 per editor/month and Pro at $24 per editor/month. It is strongest when you already have recordings and want transcription-driven video/audio editing, screen recording, captions, filler-word cleanup and AI voice tools in the same editor.</p>
+            <div class="mt-5 grid gap-3 sm:grid-cols-2"><div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Best for</div><div class="mt-1 text-sm text-slate-400">Podcasts, interviews, screen recordings, YouTube editing and transcript-first workflows</div></div><div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Watch for</div><div class="mt-1 text-sm text-slate-400">Media/transcription allowances vary by plan and editor seat</div></div></div>
+          </div>
+          <div class="w-full shrink-0 space-y-3 lg:w-72">
+            <a data-cta="affiliate" data-tool-id="descript" data-cta-source="best_ai_video_generators_descript" href="https://get.descript.com/ole5fu20j5sq" target="_blank" rel="sponsored noopener noreferrer" class="block rounded-xl bg-cyan-600 px-5 py-4 text-center font-black text-white hover:bg-cyan-500">Start Descript Free →</a>
+            <a href="/tool/descript.html" class="block rounded-xl border border-white/10 px-5 py-3 text-center text-sm font-bold text-slate-300 hover:bg-white/5">Read Descript buyer guide</a>
+          </div>
+        </div>
+      </article>
+
+      <article class="mt-5 rounded-3xl border border-white/10 bg-[#11131a] p-6 sm:p-8">
+        <div class="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div class="max-w-3xl">
+            <div class="text-xs font-black uppercase tracking-widest text-slate-400">#3 · Best free script-to-video experiment</div>
+            <h3 class="mt-2 text-3xl font-black">Fliki</h3>
+            <p class="mt-3 leading-7 text-slate-300">Fliki's official pricing page currently offers a free plan with no credit card, 3 credits per month, 300 voices across 80+ languages, 720p exports and script/blog/PPT-to-video workflows. Paid plan prices can vary with monthly/yearly selection, so this guide sends buyers to the official plan page for current checkout pricing.</p>
+            <div class="mt-5 grid gap-3 sm:grid-cols-2"><div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Best for</div><div class="mt-1 text-sm text-slate-400">Testing AI video quickly, multilingual voice/video workflows, lightweight social content</div></div><div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Watch for</div><div class="mt-1 text-sm text-slate-400">Free exports are limited to 720p and include a Fliki watermark</div></div></div>
+          </div>
+          <div class="w-full shrink-0 space-y-3 lg:w-72">
+            <a data-cta="affiliate" data-tool-id="fliki" data-cta-source="best_ai_video_generators_fliki" href="https://fliki.ai?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="block rounded-xl bg-slate-700 px-5 py-4 text-center font-black text-white hover:bg-slate-600">Start Fliki Free →</a>
+            <a href="/tool/fliki.html" class="block rounded-xl border border-white/10 px-5 py-3 text-center text-sm font-bold text-slate-300 hover:bg-white/5">Read Fliki buyer guide</a>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <section class="mt-14 overflow-hidden rounded-3xl border border-white/10 bg-white/[0.035]">
+      <div class="border-b border-white/10 p-6"><h2 class="text-2xl font-black">Fast comparison</h2><p class="mt-2 text-sm text-slate-400">Public pricing and documented product positioning checked Sep 5, 2026.</p></div>
+      <div class="overflow-x-auto"><table class="w-full min-w-[760px] text-left text-sm"><thead class="bg-white/[0.03] text-slate-400"><tr><th class="p-4">Tool</th><th class="p-4">Free start</th><th class="p-4">Entry paid plan</th><th class="p-4">Strongest fit</th><th class="p-4">Next step</th></tr></thead><tbody class="divide-y divide-white/10"><tr><td class="p-4 font-black">Pictory</td><td class="p-4">14-day trial</td><td class="p-4">Starter $25/mo yearly</td><td class="p-4">Text-to-video & repurposing</td><td class="p-4"><a class="font-bold text-violet-300" href="/tool/pictory.html">Buyer guide →</a></td></tr><tr><td class="p-4 font-black">Descript</td><td class="p-4">Free $0</td><td class="p-4">Creator $12/editor/mo yearly</td><td class="p-4">Recorded media editing</td><td class="p-4"><a class="font-bold text-cyan-300" href="/tool/descript.html">Buyer guide →</a></td></tr><tr><td class="p-4 font-black">Fliki</td><td class="p-4">Free · no card</td><td class="p-4">Check current plan toggle</td><td class="p-4">Fast script-to-video tests</td><td class="p-4"><a class="font-bold text-slate-300" href="/tool/fliki.html">Buyer guide →</a></td></tr></tbody></table></div>
+    </section>
+
+    <section class="mt-14 grid gap-5 lg:grid-cols-2">
+      <div class="rounded-2xl border border-white/10 bg-[#11131a] p-6"><h2 class="text-2xl font-black">How COSHUMA verifies this guide</h2><ul class="mt-4 space-y-3 text-sm leading-6 text-slate-300"><li><strong>Pricing:</strong> checked against official Pictory, Descript and Fliki pricing pages.</li><li><strong>Affiliate destinations:</strong> all three outbound partner URLs are already verified in the COSHUMA project data.</li><li><strong>Ranking:</strong> based on buyer fit and public product information, not paid placement or fabricated ratings.</li><li><strong>Updates:</strong> pricing and plan limits can change, so checkout terms should be rechecked before purchase.</li></ul></div>
+      <div class="rounded-2xl border border-white/10 bg-[#11131a] p-6"><h2 class="text-2xl font-black">Continue your research</h2><div class="mt-4 space-y-3 text-sm font-bold"><a class="block rounded-xl bg-white/[0.04] p-4 hover:bg-white/[0.07]" href="/compare/fliki-vs-tubebuddy.html">Fliki vs TubeBuddy →</a><a class="block rounded-xl bg-white/[0.04] p-4 hover:bg-white/[0.07]" href="/compare/descript-vs-tubebuddy.html">Descript vs TubeBuddy →</a><a class="block rounded-xl bg-white/[0.04] p-4 hover:bg-white/[0.07]" href="/tool/pictory.html">Pictory pricing & buyer guide →</a><a class="block rounded-xl bg-white/[0.04] p-4 hover:bg-white/[0.07]" href="/best/ai-voice-generators.html">Best AI Voice Generators →</a></div></div>
+    </section>
+
+    <section class="mt-10 rounded-2xl border border-amber-400/20 bg-amber-400/[0.06] p-5 text-sm leading-6 text-amber-100/80"><strong>Affiliate disclosure:</strong> COSHUMA may earn a commission when you use certain partner links on this page, at no extra cost to you. Partner status does not guarantee a positive recommendation. Pricing and product terms can change after our check date.</section>
+    <section class="mt-8 text-xs leading-6 text-slate-500"><strong class="text-slate-400">Official sources checked:</strong> Pictory pricing (pictory.ai/pricing), Descript pricing (descript.com/pricing) and Fliki pricing (fliki.ai/pricing). Last checked Sep 5, 2026.</section>
+  </main>
+  <footer class="border-t border-white/10 px-5 py-8 text-center text-xs text-slate-600">COSHUMA · Independent AI & SaaS buyer guides</footer>
+  <script src="/affiliate-attribution.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
Adds COSHUMA's second buyer-intent Best X money hub focused on AI video creation. It ranks by workflow fit, uses current official pricing, includes transparent verification/disclosure, links into existing detail/comparison pages, and routes Pictory, Descript and Fliki through already-verified COSHUMA partner URLs with distinct attribution sources. Also links the new hub from the homepage crawler fallback. No paid services or unverified affiliate URLs are introduced.