### PR TITLE
Launch marketing agency CRM money hub

### DIFF
--- a/projects/GlobalSaaSHub/index.html
+++ b/projects/GlobalSaaSHub/index.html
@@ -60,7 +60,8 @@
         <nav aria-label="Featured software buyer guides" style="margin-top: 20px; font-size: 13px; line-height: 2;">
           <strong>Best software shortlists:</strong><br />
           <a href="/best/ai-voice-generators.html">Best AI Voice Generators in 2026</a> ·
-          <a href="/best/ai-video-generators.html">Best AI Video Generators in 2026</a><br />
+          <a href="/best/ai-video-generators.html">Best AI Video Generators in 2026</a> ·
+          <a href="/best/crm-for-marketing-agencies.html">Best CRM for Marketing Agencies in 2026</a><br />
           <strong>Popular pricing and review guides:</strong><br />
           <a href="/tool/descript.html">Descript pricing & review</a> ·
           <a href="/tool/elevenlabs.html">ElevenLabs pricing & review</a> ·

--- a/projects/GlobalSaaSHub/public/best/crm-for-marketing-agencies.html
+++ b/projects/GlobalSaaSHub/public/best/crm-for-marketing-agencies.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Best CRM for Marketing Agencies in 2026: HighLevel vs Pipedrive & HubSpot | COSHUMA</title>
+  <meta name="description" content="Compare CRM options for marketing agencies in 2026. See current pricing, client-account fit and the practical differences between HighLevel, Pipedrive and HubSpot." />
+  <link rel="canonical" href="https://coshuma.com/best/crm-for-marketing-agencies.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="COSHUMA" />
+  <meta property="og:title" content="Best CRM for Marketing Agencies in 2026 | COSHUMA" />
+  <meta property="og:description" content="A practical CRM shortlist for agencies, from multi-client operations to straightforward sales pipelines." />
+  <meta property="og:url" content="https://coshuma.com/best/crm-for-marketing-agencies.html" />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"Best CRM for Marketing Agencies in 2026",
+    "dateModified":"2026-09-05",
+    "author":{"@type":"Organization","name":"COSHUMA"},
+    "publisher":{"@type":"Organization","name":"COSHUMA"},
+    "mainEntityOfPage":"https://coshuma.com/best/crm-for-marketing-agencies.html"
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>body{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}</style>
+</head>
+<body class="bg-[#08090d] text-slate-100 antialiased">
+  <header class="border-b border-white/10 bg-[#0c0e14]">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-5 py-4">
+      <a href="/" class="text-xl font-black tracking-tight text-white">COSHUMA</a>
+      <div class="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Independent AI & SaaS buyer guides</div>
+    </div>
+  </header>
+
+  <main class="mx-auto max-w-6xl px-5 py-12 sm:py-16">
+    <nav class="mb-7 text-sm text-slate-500"><a class="hover:text-white" href="/">Home</a> <span class="px-2">/</span> CRM for Marketing Agencies</nav>
+
+    <section class="max-w-4xl">
+      <div class="mb-5 inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">Pricing checked against official vendor pages · Sep 5, 2026</div>
+      <h1 class="text-4xl font-black tracking-[-0.04em] text-white sm:text-6xl">Best CRM for Marketing Agencies in 2026</h1>
+      <p class="mt-5 max-w-3xl text-lg leading-8 text-slate-400">The right CRM depends on how your agency actually works. HighLevel is the strongest fit when you manage multiple client accounts and want CRM, funnels, booking and automation in one system. Pipedrive is simpler when the job is mainly sales pipeline management. HubSpot makes more sense when your team wants a broader sales ecosystem and is comfortable with seat-based pricing.</p>
+    </section>
+
+    <section class="mt-10 grid gap-4 md:grid-cols-3">
+      <div class="rounded-2xl border border-violet-400/30 bg-violet-500/10 p-5">
+        <div class="text-xs font-black uppercase tracking-widest text-violet-300">Best for multi-client agencies</div>
+        <h2 class="mt-2 text-2xl font-black">HighLevel</h2>
+        <p class="mt-2 text-sm leading-6 text-slate-300">CRM, pipelines, calendars, funnels, automations and client sub-accounts in one agency-focused platform.</p>
+        <div class="mt-4 text-sm font-bold text-white">14-day trial · Starter $97/mo</div>
+      </div>
+      <div class="rounded-2xl border border-cyan-400/30 bg-cyan-500/10 p-5">
+        <div class="text-xs font-black uppercase tracking-widest text-cyan-300">Best for a straightforward sales pipeline</div>
+        <h2 class="mt-2 text-2xl font-black">Pipedrive</h2>
+        <p class="mt-2 text-sm leading-6 text-slate-300">A focused sales CRM with lead, deal and activity management plus automation on higher plans.</p>
+        <div class="mt-4 text-sm font-bold text-white">14-day trial · Lite $14/seat/mo yearly</div>
+      </div>
+      <div class="rounded-2xl border border-white/10 bg-white/[0.04] p-5">
+        <div class="text-xs font-black uppercase tracking-widest text-slate-400">Best for a broader sales ecosystem</div>
+        <h2 class="mt-2 text-2xl font-black">HubSpot Sales Hub</h2>
+        <p class="mt-2 text-sm leading-6 text-slate-300">A larger CRM ecosystem with sales automation, reporting and higher-tier controls for growing teams.</p>
+        <div class="mt-4 text-sm font-bold text-white">Starter from $7/seat/mo yearly</div>
+      </div>
+    </section>
+
+    <section class="mt-14">
+      <div class="mb-5">
+        <div class="text-xs font-bold uppercase tracking-[0.2em] text-violet-300">Shortlist</div>
+        <h2 class="mt-2 text-3xl font-black">Choose based on how you make money</h2>
+      </div>
+
+      <article class="rounded-3xl border border-violet-400/25 bg-[#11131a] p-6 sm:p-8">
+        <div class="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div class="max-w-3xl">
+            <div class="text-xs font-black uppercase tracking-widest text-violet-300">#1 · Best for agencies managing multiple clients</div>
+            <h3 class="mt-2 text-3xl font-black">HighLevel</h3>
+            <p class="mt-3 leading-7 text-slate-300">HighLevel's current agency plans are Starter at $97/month, Unlimited at $297/month and Agency Pro at $497/month. Starter supports up to three sub-accounts. Unlimited removes that cap, which is the main reason it becomes more attractive as an agency adds clients. Agency Pro adds SaaS Mode, advanced API access and markup/rebilling features for agencies that want to resell software-style services.</p>
+            <div class="mt-5 grid gap-3 sm:grid-cols-2">
+              <div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Best for</div><div class="mt-1 text-sm text-slate-400">Marketing agencies, local-service agencies, lead-generation businesses and teams managing multiple client accounts</div></div>
+              <div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Watch for</div><div class="mt-1 text-sm text-slate-400">Messaging, phone, AI and other metered services can create usage charges beyond the base subscription</div></div>
+            </div>
+          </div>
+          <div class="w-full shrink-0 space-y-3 lg:w-72">
+            <a data-cta="affiliate" data-tool-id="gohighlevel" data-cta-source="best_crm_marketing_agencies_highlevel" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="block rounded-xl bg-violet-600 px-5 py-4 text-center font-black text-white hover:bg-violet-500">Start the HighLevel Trial →</a>
+            <a href="/tool/gohighlevel.html" class="block rounded-xl border border-white/10 px-5 py-3 text-center text-sm font-bold text-slate-300 hover:bg-white/5">Read the HighLevel buyer guide</a>
+          </div>
+        </div>
+      </article>
+
+      <article class="mt-5 rounded-3xl border border-cyan-400/25 bg-[#11131a] p-6 sm:p-8">
+        <div class="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div class="max-w-3xl">
+            <div class="text-xs font-black uppercase tracking-widest text-cyan-300">#2 · Best for a clean sales pipeline</div>
+            <h3 class="mt-2 text-3xl font-black">Pipedrive</h3>
+            <p class="mt-3 leading-7 text-slate-300">Pipedrive currently offers a 14-day trial with no credit card required. Annual pricing starts at $14 per seat/month for Lite, $39 for Growth and $59 for Premium. It is a better fit than an all-in-one agency suite when your main need is tracking leads, deals, activities and follow-up rather than running client sub-accounts, funnels and marketing operations from the same platform.</p>
+            <div class="mt-5 grid gap-3 sm:grid-cols-2">
+              <div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Best for</div><div class="mt-1 text-sm text-slate-400">Small sales teams, consultants and agencies that already have separate marketing tools</div></div>
+              <div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Watch for</div><div class="mt-1 text-sm text-slate-400">Pricing is per seat, and features such as LeadBooster can involve additional cost depending on plan</div></div>
+            </div>
+          </div>
+          <div class="w-full shrink-0 space-y-3 lg:w-72">
+            <a href="https://www.pipedrive.com/en/pricing" target="_blank" rel="noopener noreferrer" class="block rounded-xl bg-cyan-600 px-5 py-4 text-center font-black text-white hover:bg-cyan-500">View Pipedrive Pricing →</a>
+            <a href="/tool/pipedrive.html" class="block rounded-xl border border-white/10 px-5 py-3 text-center text-sm font-bold text-slate-300 hover:bg-white/5">Read the Pipedrive buyer guide</a>
+          </div>
+        </div>
+      </article>
+
+      <article class="mt-5 rounded-3xl border border-white/10 bg-[#11131a] p-6 sm:p-8">
+        <div class="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div class="max-w-3xl">
+            <div class="text-xs font-black uppercase tracking-widest text-slate-400">#3 · Best for teams already moving toward HubSpot</div>
+            <h3 class="mt-2 text-3xl font-black">HubSpot Sales Hub</h3>
+            <p class="mt-3 leading-7 text-slate-300">HubSpot's current Sales Hub page shows Starter from $7 per seat/month on annual billing and $20 on monthly billing. Professional starts at $90 per seat/month annually or $100 monthly, with a required $1,500 onboarding fee. HubSpot is the better comparison when your agency values a broad CRM ecosystem, deeper sales tooling and a path toward larger-team operations more than client sub-account economics.</p>
+            <div class="mt-5 grid gap-3 sm:grid-cols-2">
+              <div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Best for</div><div class="mt-1 text-sm text-slate-400">Growing sales organizations, teams already using HubSpot products and businesses that want a broad CRM ecosystem</div></div>
+              <div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Watch for</div><div class="mt-1 text-sm text-slate-400">Per-seat costs and required onboarding fees on higher tiers can materially change the total cost</div></div>
+            </div>
+          </div>
+          <div class="w-full shrink-0 lg:w-72">
+            <a href="https://www.hubspot.com/pricing/sales" target="_blank" rel="noopener noreferrer" class="block rounded-xl bg-slate-700 px-5 py-4 text-center font-black text-white hover:bg-slate-600">View HubSpot Sales Pricing →</a>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <section class="mt-14 overflow-hidden rounded-3xl border border-white/10 bg-white/[0.035]">
+      <div class="border-b border-white/10 p-6"><h2 class="text-2xl font-black">Fast comparison</h2><p class="mt-2 text-sm text-slate-400">Public pricing and product positioning checked Sep 5, 2026.</p></div>
+      <div class="overflow-x-auto">
+        <table class="w-full min-w-[820px] text-left text-sm">
+          <thead class="bg-white/[0.03] text-slate-400"><tr><th class="p-4">CRM</th><th class="p-4">Trial / entry</th><th class="p-4">Pricing model</th><th class="p-4">Strongest fit</th><th class="p-4">Key trade-off</th></tr></thead>
+          <tbody class="divide-y divide-white/10">
+            <tr><td class="p-4 font-black">HighLevel</td><td class="p-4">14-day trial · $97/mo Starter</td><td class="p-4">Agency account with sub-accounts</td><td class="p-4">Multi-client agency operations</td><td class="p-4">Higher base price, plus usage-based services</td></tr>
+            <tr><td class="p-4 font-black">Pipedrive</td><td class="p-4">14-day trial · $14/seat/mo yearly</td><td class="p-4">Per seat</td><td class="p-4">Focused sales pipeline</td><td class="p-4">Separate tools may still be needed for broader marketing</td></tr>
+            <tr><td class="p-4 font-black">HubSpot Sales Hub</td><td class="p-4">Starter from $7/seat/mo yearly</td><td class="p-4">Per seat + tiered platform features</td><td class="p-4">Broader CRM and sales ecosystem</td><td class="p-4">Higher-tier seat and onboarding costs</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="mt-14 grid gap-5 lg:grid-cols-2">
+      <div class="rounded-2xl border border-white/10 bg-[#11131a] p-6">
+        <h2 class="text-2xl font-black">How to choose quickly</h2>
+        <div class="mt-4 space-y-3 text-sm leading-6 text-slate-300">
+          <p><strong>Choose HighLevel</strong> when the number of client accounts is central to your business model and you want sales and marketing tools under one roof.</p>
+          <p><strong>Choose Pipedrive</strong> when you mainly need a clean deal pipeline and prefer to keep marketing tools separate.</p>
+          <p><strong>Choose HubSpot</strong> when you want a broader CRM ecosystem and expect to scale into more formal sales operations.</p>
+        </div>
+      </div>
+      <div class="rounded-2xl border border-white/10 bg-[#11131a] p-6">
+        <h2 class="text-2xl font-black">Useful next reads</h2>
+        <div class="mt-4 space-y-3 text-sm font-bold">
+          <a class="block rounded-xl bg-white/[0.04] p-4 hover:bg-white/[0.07]" href="/tool/gohighlevel.html">HighLevel pricing & buyer guide →</a>
+          <a class="block rounded-xl bg-white/[0.04] p-4 hover:bg-white/[0.07]" href="/tool/pipedrive.html">Pipedrive pricing & alternatives →</a>
+          <a class="block rounded-xl bg-white/[0.04] p-4 hover:bg-white/[0.07]" href="/compare/helpdesk-vs-gohighlevel.html">HelpDesk vs HighLevel →</a>
+          <a class="block rounded-xl bg-white/[0.04] p-4 hover:bg-white/[0.07]" href="/compare/chatbot-vs-gohighlevel.html">ChatBot vs HighLevel →</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="mt-10 rounded-2xl border border-amber-400/20 bg-amber-400/[0.06] p-5 text-sm leading-6 text-amber-100/80"><strong>Affiliate disclosure:</strong> COSHUMA may earn a commission if you use the HighLevel partner link on this page and later become a qualifying paying customer, at no extra cost to you. Pipedrive and HubSpot links on this page are standard official links. Partner status does not determine COSHUMA's recommendation.</section>
+
+    <section class="mt-8 text-xs leading-6 text-slate-500"><strong class="text-slate-400">Official sources checked:</strong> HighLevel agency pricing/support documentation, Pipedrive pricing and pricing knowledge base, and HubSpot Sales Hub pricing. Last checked Sep 5, 2026.</section>
+  </main>
+
+  <footer class="border-t border-white/10 px-5 py-8 text-center text-xs text-slate-600">COSHUMA · Independent AI & SaaS buyer guides</footer>
+  <script src="/affiliate-attribution.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
Adds a new buyer-intent shortlist for marketing agencies comparing HighLevel, Pipedrive and HubSpot Sales Hub. HighLevel uses COSHUMA's already-verified partner URL with a dedicated attribution source; Pipedrive and HubSpot remain standard official links. Pricing and plan fit were checked against current official vendor pages on September 5, 2026. Also links the new shortlist from the homepage crawler fallback. No paid services or unverified affiliate URLs are introduced.