### PR TITLE
Launch landing page builders revenue hub

### DIFF
--- a/.github/workflows/coshuma-site-deploy.yml
+++ b/.github/workflows/coshuma-site-deploy.yml
@@ -7,6 +7,7 @@ on:
       - 'projects/GlobalSaaSHub/src/**'
       - 'projects/GlobalSaaSHub/public/**'
       - 'projects/GlobalSaaSHub/scripts/polish_public_copy.py'
+      - 'projects/GlobalSaaSHub/scripts/ensure_best_pages_in_sitemap.py'
       - 'projects/GlobalSaaSHub/index.html'
       - 'projects/GlobalSaaSHub/package.json'
       - 'projects/GlobalSaaSHub/package-lock.json'
@@ -42,6 +43,9 @@ jobs:
       - name: Polish generated public copy
         run: python projects/GlobalSaaSHub/scripts/polish_public_copy.py
 
+      - name: Index buyer-intent hubs in sitemap
+        run: python projects/GlobalSaaSHub/scripts/ensure_best_pages_in_sitemap.py
+
       - name: Build production bundle
         working-directory: projects/GlobalSaaSHub
         run: npm run build
@@ -59,6 +63,14 @@ jobs:
             echo 'Legacy comparison boilerplate detected in production pages.'
             exit 1
           fi
+          for page in projects/GlobalSaaSHub/dist/best/*.html; do
+            [ -e "$page" ] || continue
+            slug=$(basename "$page")
+            if ! grep -q "https://coshuma.com/best/$slug" projects/GlobalSaaSHub/dist/sitemap.xml; then
+              echo "Buyer hub missing from sitemap: $slug"
+              exit 1
+            fi
+          done
           grep -q 'coshuma.com' projects/GlobalSaaSHub/dist/CNAME
 
       - name: Publish complete Vite dist to gh-pages

--- a/projects/GlobalSaaSHub/index.html
+++ b/projects/GlobalSaaSHub/index.html
@@ -61,7 +61,8 @@
           <strong>Best software shortlists:</strong><br />
           <a href="/best/ai-voice-generators.html">Best AI Voice Generators in 2026</a> ·
           <a href="/best/ai-video-generators.html">Best AI Video Generators in 2026</a> ·
-          <a href="/best/crm-for-marketing-agencies.html">Best CRM for Marketing Agencies in 2026</a><br />
+          <a href="/best/crm-for-marketing-agencies.html">Best CRM for Marketing Agencies in 2026</a> ·
+          <a href="/best/landing-page-builders.html">Best Landing Page Builders in 2026</a><br />
           <strong>Popular pricing and review guides:</strong><br />
           <a href="/tool/descript.html">Descript pricing & review</a> ·
           <a href="/tool/elevenlabs.html">ElevenLabs pricing & review</a> ·

--- a/projects/GlobalSaaSHub/public/best/landing-page-builders.html
+++ b/projects/GlobalSaaSHub/public/best/landing-page-builders.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Best Landing Page Builders in 2026: Unbounce, Systeme.io & HighLevel | COSHUMA</title>
+  <meta name="description" content="Compare landing page and funnel builders for lead generation in 2026. See current public pricing, free trials, buyer fit, and verified COSHUMA partner paths for Unbounce, Systeme.io and HighLevel." />
+  <link rel="canonical" href="https://coshuma.com/best/landing-page-builders.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="COSHUMA" />
+  <meta property="og:title" content="Best Landing Page Builders in 2026 | COSHUMA" />
+  <meta property="og:description" content="A practical shortlist for landing pages, funnels and lead generation based on current pricing and workflow fit." />
+  <meta property="og:url" content="https://coshuma.com/best/landing-page-builders.html" />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"Best Landing Page Builders in 2026",
+    "dateModified":"2026-09-05",
+    "author":{"@type":"Organization","name":"COSHUMA"},
+    "publisher":{"@type":"Organization","name":"COSHUMA"},
+    "mainEntityOfPage":"https://coshuma.com/best/landing-page-builders.html"
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>body{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}</style>
+</head>
+<body class="bg-[#08090d] text-slate-100 antialiased">
+  <header class="border-b border-white/10 bg-[#0c0e14]">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-5 py-4">
+      <a href="/" class="text-xl font-black tracking-tight text-white">COSHUMA</a>
+      <div class="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Independent AI & SaaS buyer guides</div>
+    </div>
+  </header>
+
+  <main class="mx-auto max-w-6xl px-5 py-12 sm:py-16">
+    <nav class="mb-7 text-sm text-slate-500"><a class="hover:text-white" href="/">Home</a> <span class="px-2">/</span> Best Landing Page Builders</nav>
+
+    <section class="max-w-4xl">
+      <div class="mb-5 inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">Pricing checked against official vendor pages · Sep 5, 2026</div>
+      <h1 class="text-4xl font-black tracking-[-0.04em] text-white sm:text-6xl">Best Landing Page Builders in 2026</h1>
+      <p class="mt-5 max-w-3xl text-lg leading-8 text-slate-400">Pick the tool around what happens after the click. Unbounce is the strongest fit when landing-page testing is the main job. Systeme.io is a lower-cost all-in-one choice when you also need funnels, email and basic automation. HighLevel makes more sense for agencies that want landing pages inside a broader CRM and client-management stack.</p>
+    </section>
+
+    <section class="mt-10 grid gap-4 md:grid-cols-3">
+      <div class="rounded-2xl border border-violet-400/30 bg-violet-500/10 p-5">
+        <div class="text-xs font-black uppercase tracking-widest text-violet-300">Best dedicated landing page platform</div>
+        <h2 class="mt-2 text-2xl font-black">Unbounce</h2>
+        <p class="mt-2 text-sm leading-6 text-slate-300">Built for marketers and agencies that want landing pages, lead forms and testing without adopting a full CRM.</p>
+        <div class="mt-4 text-sm font-bold text-white">14-day trial · Starter $29/mo</div>
+      </div>
+      <div class="rounded-2xl border border-cyan-400/30 bg-cyan-500/10 p-5">
+        <div class="text-xs font-black uppercase tracking-widest text-cyan-300">Best low-cost all-in-one funnel stack</div>
+        <h2 class="mt-2 text-2xl font-black">Systeme.io</h2>
+        <p class="mt-2 text-sm leading-6 text-slate-300">Funnels, email, courses, affiliate management and automation in one product, with a free plan that does not expire.</p>
+        <div class="mt-4 text-sm font-bold text-white">Free $0 · Startup $17/mo</div>
+      </div>
+      <div class="rounded-2xl border border-white/10 bg-white/[0.04] p-5">
+        <div class="text-xs font-black uppercase tracking-widest text-slate-400">Best for agencies that need CRM too</div>
+        <h2 class="mt-2 text-2xl font-black">HighLevel</h2>
+        <p class="mt-2 text-sm leading-6 text-slate-300">Landing pages and funnels sit inside a wider lead-capture, CRM, booking and client sub-account workflow.</p>
+        <div class="mt-4 text-sm font-bold text-white">14-day trial · Starter $97/mo</div>
+      </div>
+    </section>
+
+    <section class="mt-14">
+      <div class="mb-5"><div class="text-xs font-bold uppercase tracking-[0.2em] text-violet-300">Shortlist</div><h2 class="mt-2 text-3xl font-black">Three different ways to capture and convert leads</h2></div>
+
+      <article class="rounded-3xl border border-violet-400/25 bg-[#11131a] p-6 sm:p-8">
+        <div class="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div class="max-w-3xl">
+            <div class="text-xs font-black uppercase tracking-widest text-violet-300">#1 · Best when landing pages are the core workflow</div>
+            <h3 class="mt-2 text-3xl font-black">Unbounce</h3>
+            <p class="mt-3 leading-7 text-slate-300">Unbounce currently lists Starter at $29/month, Build at $99/month, Experiment at $149/month and Optimize at $249/month. Its 14-day trial requires no credit card. The product is a focused fit for teams that care about quickly launching landing pages, lead forms, popups and optimization experiments without moving their full sales process into a new CRM.</p>
+            <div class="mt-5 grid gap-3 sm:grid-cols-2"><div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Best for</div><div class="mt-1 text-sm text-slate-400">Paid traffic landing pages, lead generation, campaign-specific pages and conversion testing</div></div><div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Watch for</div><div class="mt-1 text-sm text-slate-400">Higher tiers are needed as traffic, experimentation and account needs grow</div></div></div>
+          </div>
+          <div class="w-full shrink-0 space-y-3 lg:w-72">
+            <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="best_landing_page_builders_unbounce" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="block rounded-xl bg-violet-600 px-5 py-4 text-center font-black text-white hover:bg-violet-500">Start Unbounce Free Trial →</a>
+            <a href="/tool/unbounce.html" class="block rounded-xl border border-white/10 px-5 py-3 text-center text-sm font-bold text-slate-300 hover:bg-white/5">Read Unbounce buyer guide</a>
+          </div>
+        </div>
+      </article>
+
+      <article class="mt-5 rounded-3xl border border-cyan-400/25 bg-[#11131a] p-6 sm:p-8">
+        <div class="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div class="max-w-3xl">
+            <div class="text-xs font-black uppercase tracking-widest text-cyan-300">#2 · Best value for funnels plus email</div>
+            <h3 class="mt-2 text-3xl font-black">Systeme.io</h3>
+            <p class="mt-3 leading-7 text-slate-300">Systeme.io currently offers a free plan with up to 2,000 contacts and three sales funnels, with no credit card required. Paid monthly plans are Startup at $17, Webinar at $47 and Unlimited at $97. It is the practical budget choice when the same business also needs email campaigns, courses, automation and affiliate management.</p>
+            <div class="mt-5 grid gap-3 sm:grid-cols-2"><div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Best for</div><div class="mt-1 text-sm text-slate-400">Small businesses, creators and lean teams that want funnels and email in one account</div></div><div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Watch for</div><div class="mt-1 text-sm text-slate-400">The free plan limits contacts and funnel count, so growing lists may require an upgrade</div></div></div>
+          </div>
+          <div class="w-full shrink-0 space-y-3 lg:w-72">
+            <a data-cta="affiliate" data-tool-id="systeme-io" data-cta-source="best_landing_page_builders_systeme_io" href="https://systeme.io/?sa=sa0279779913657b281b5d2c1fed58680413f14dca" target="_blank" rel="sponsored noopener noreferrer" class="block rounded-xl bg-cyan-600 px-5 py-4 text-center font-black text-white hover:bg-cyan-500">Start Systeme.io Free →</a>
+            <a href="/tool/systeme-io.html" class="block rounded-xl border border-white/10 px-5 py-3 text-center text-sm font-bold text-slate-300 hover:bg-white/5">Read Systeme.io buyer guide</a>
+          </div>
+        </div>
+      </article>
+
+      <article class="mt-5 rounded-3xl border border-white/10 bg-[#11131a] p-6 sm:p-8">
+        <div class="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div class="max-w-3xl">
+            <div class="text-xs font-black uppercase tracking-widest text-slate-400">#3 · Best when landing pages need to feed an agency CRM</div>
+            <h3 class="mt-2 text-3xl font-black">HighLevel</h3>
+            <p class="mt-3 leading-7 text-slate-300">HighLevel's official pricing currently shows Starter at $97/month, Unlimited at $297/month and Agency Pro at $497/month, with a 14-day free trial. Starter includes three sub-accounts, while Unlimited adds unlimited sub-accounts. That makes it more relevant when landing pages are one part of a larger agency workflow involving CRM, booking, follow-up and multiple client accounts.</p>
+            <div class="mt-5 grid gap-3 sm:grid-cols-2"><div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Best for</div><div class="mt-1 text-sm text-slate-400">Agencies, multi-client lead funnels, CRM follow-up and appointment-driven businesses</div></div><div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Watch for</div><div class="mt-1 text-sm text-slate-400">It costs more than a focused page builder if you do not need the CRM and agency features</div></div></div>
+          </div>
+          <div class="w-full shrink-0 space-y-3 lg:w-72">
+            <a data-cta="affiliate" data-tool-id="gohighlevel" data-cta-source="best_landing_page_builders_highlevel" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="block rounded-xl bg-slate-700 px-5 py-4 text-center font-black text-white hover:bg-slate-600">Start HighLevel Trial →</a>
+            <a href="/tool/gohighlevel.html" class="block rounded-xl border border-white/10 px-5 py-3 text-center text-sm font-bold text-slate-300 hover:bg-white/5">Read HighLevel buyer guide</a>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <section class="mt-14 overflow-hidden rounded-3xl border border-white/10 bg-white/[0.035]">
+      <div class="border-b border-white/10 p-6"><h2 class="text-2xl font-black">Fast comparison</h2><p class="mt-2 text-sm text-slate-400">Public pricing and documented product positioning checked Sep 5, 2026.</p></div>
+      <div class="overflow-x-auto"><table class="w-full min-w-[760px] text-left text-sm"><thead class="bg-white/[0.03] text-slate-400"><tr><th class="p-4">Tool</th><th class="p-4">Free start</th><th class="p-4">Entry paid plan</th><th class="p-4">Strongest fit</th><th class="p-4">Next step</th></tr></thead><tbody class="divide-y divide-white/10"><tr><td class="p-4 font-black">Unbounce</td><td class="p-4">14-day trial</td><td class="p-4">Starter $29/mo</td><td class="p-4">Dedicated landing pages & testing</td><td class="p-4"><a class="font-bold text-violet-300" href="/tool/unbounce.html">Buyer guide →</a></td></tr><tr><td class="p-4 font-black">Systeme.io</td><td class="p-4">Free forever</td><td class="p-4">Startup $17/mo</td><td class="p-4">Low-cost funnels + email</td><td class="p-4"><a class="font-bold text-cyan-300" href="/tool/systeme-io.html">Buyer guide →</a></td></tr><tr><td class="p-4 font-black">HighLevel</td><td class="p-4">14-day trial</td><td class="p-4">Starter $97/mo</td><td class="p-4">Agency funnels + CRM</td><td class="p-4"><a class="font-bold text-slate-300" href="/best/crm-for-marketing-agencies.html">Agency CRM guide →</a></td></tr></tbody></table></div>
+    </section>
+
+    <section class="mt-14 grid gap-5 lg:grid-cols-2">
+      <div class="rounded-2xl border border-white/10 bg-[#11131a] p-6"><h2 class="text-2xl font-black">How COSHUMA verifies this guide</h2><ul class="mt-4 space-y-3 text-sm leading-6 text-slate-300"><li><strong>Pricing:</strong> checked against the official Unbounce, Systeme.io and HighLevel pricing pages.</li><li><strong>Partner destinations:</strong> all three outbound partner URLs were already stored as verified tracking links in the COSHUMA project before this page was created.</li><li><strong>Ranking:</strong> based on buyer fit and public product information, not paid placement or invented user ratings.</li><li><strong>Updates:</strong> pricing and plan limits can change, so checkout terms should be rechecked before purchase.</li></ul></div>
+      <div class="rounded-2xl border border-white/10 bg-[#11131a] p-6"><h2 class="text-2xl font-black">Continue your research</h2><div class="mt-4 space-y-3 text-sm font-bold"><a class="block rounded-xl bg-white/[0.04] p-4 hover:bg-white/[0.07]" href="/compare/unbounce-vs-jotform.html">Unbounce vs Jotform →</a><a class="block rounded-xl bg-white/[0.04] p-4 hover:bg-white/[0.07]" href="/compare/systeme-io-vs-privy.html">Systeme.io vs Privy →</a><a class="block rounded-xl bg-white/[0.04] p-4 hover:bg-white/[0.07]" href="/best/crm-for-marketing-agencies.html">Best CRM for Marketing Agencies →</a><a class="block rounded-xl bg-white/[0.04] p-4 hover:bg-white/[0.07]" href="/tool/unbounce.html">Unbounce pricing & buyer guide →</a></div></div>
+    </section>
+
+    <section class="mt-10 rounded-2xl border border-amber-400/20 bg-amber-400/[0.06] p-5 text-sm leading-6 text-amber-100/80"><strong>Affiliate disclosure:</strong> COSHUMA may earn a commission when you use certain partner links on this page, at no extra cost to you. Partner status does not guarantee a positive recommendation. Pricing and product terms can change after our check date.</section>
+    <section class="mt-8 text-xs leading-6 text-slate-500"><strong class="text-slate-400">Official sources checked:</strong> Unbounce pricing (unbounce.com/pricing), Systeme.io pricing (systeme.io/pricing) and HighLevel pricing (gohighlevel.com/pricing). Last checked Sep 5, 2026.</section>
+  </main>
+
+  <footer class="border-t border-white/10 px-5 py-8 text-center text-xs text-slate-600">COSHUMA · Independent AI & SaaS buyer guides</footer>
+  <script src="/affiliate-attribution.js" defer></script>
+</body>
+</html>

--- a/projects/GlobalSaaSHub/scripts/ensure_best_pages_in_sitemap.py
+++ b/projects/GlobalSaaSHub/scripts/ensure_best_pages_in_sitemap.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+BASE_URL = "https://coshuma.com"
+PROJECT = Path(__file__).resolve().parents[1]
+PUBLIC = PROJECT / "public"
+SITEMAP = PUBLIC / "sitemap.xml"
+BEST_DIR = PUBLIC / "best"
+NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
+
+ET.register_namespace("", NS)
+
+tree = ET.parse(SITEMAP)
+root = tree.getroot()
+existing = {
+    node.text.strip()
+    for node in root.findall(f"{{{NS}}}url/{{{NS}}}loc")
+    if node.text and node.text.strip()
+}
+
+added = []
+for page in sorted(BEST_DIR.glob("*.html")):
+    url = f"{BASE_URL}/best/{page.name}"
+    if url in existing:
+        continue
+    url_node = ET.SubElement(root, f"{{{NS}}}url")
+    ET.SubElement(url_node, f"{{{NS}}}loc").text = url
+    ET.SubElement(url_node, f"{{{NS}}}changefreq").text = "weekly"
+    ET.SubElement(url_node, f"{{{NS}}}priority").text = "0.9"
+    added.append(url)
+
+ET.indent(tree, space="  ")
+tree.write(SITEMAP, encoding="utf-8", xml_declaration=True)
+print(f"Sitemap buyer hubs: {len(list(BEST_DIR.glob('*.html')))} total, {len(added)} added")
+for url in added:
+    print(f"+ {url}")


### PR DESCRIPTION
Adds a new high-intent landing-page buyer hub using only already-verified COSHUMA partner destinations for Unbounce, Systeme.io and HighLevel. Also adds deployment-time sitemap indexing for all /best/ buyer hubs so existing and future money hubs are discoverable in production. Pricing copy is grounded in current official vendor pages checked Sep 5, 2026. No paid services or unverified tracking URLs are introduced.