### PR TITLE
Surface verified Pictory discount across revenue pages

### DIFF
--- a/.github/workflows/coshuma-site-deploy.yml
+++ b/.github/workflows/coshuma-site-deploy.yml
@@ -8,6 +8,7 @@ on:
       - 'projects/GlobalSaaSHub/public/**'
       - 'projects/GlobalSaaSHub/scripts/polish_public_copy.py'
       - 'projects/GlobalSaaSHub/scripts/ensure_best_pages_in_sitemap.py'
+      - 'projects/GlobalSaaSHub/scripts/inject_pictory_partner_offer.py'
       - 'projects/GlobalSaaSHub/index.html'
       - 'projects/GlobalSaaSHub/package.json'
       - 'projects/GlobalSaaSHub/package-lock.json'
@@ -43,6 +44,9 @@ jobs:
       - name: Polish generated public copy
         run: python projects/GlobalSaaSHub/scripts/polish_public_copy.py
 
+      - name: Inject current Pictory partner offer
+        run: python projects/GlobalSaaSHub/scripts/inject_pictory_partner_offer.py
+
       - name: Index buyer-intent hubs in sitemap
         run: python projects/GlobalSaaSHub/scripts/ensure_best_pages_in_sitemap.py
 
@@ -63,6 +67,12 @@ jobs:
             echo 'Legacy comparison boilerplate detected in production pages.'
             exit 1
           fi
+          while IFS= read -r page; do
+            if ! grep -q 'COSHUMA20' "$page"; then
+              echo "Pictory monetized page missing current partner offer: $page"
+              exit 1
+            fi
+          done < <(grep -R -l -F 'https://pictory.ai?fpr=sangkwon-an23' projects/GlobalSaaSHub/dist --include='*.html' || true)
           for page in projects/GlobalSaaSHub/dist/best/*.html; do
             [ -e "$page" ] || continue
             slug=$(basename "$page")

--- a/projects/GlobalSaaSHub/scripts/inject_pictory_partner_offer.py
+++ b/projects/GlobalSaaSHub/scripts/inject_pictory_partner_offer.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import re
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+PUBLIC_DIR = PROJECT_DIR / "public"
+PICTORY_AFFILIATE_URL = "https://pictory.ai?fpr=sangkwon-an23"
+MARKER = 'data-pictory-promo="coshuma20"'
+
+PROMO = r'''
+<section data-pictory-promo="coshuma20" class="mx-auto mb-6 max-w-4xl rounded-2xl border border-amber-400/25 bg-amber-400/[0.07] p-4 sm:p-5">
+  <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+    <div>
+      <div class="text-xs font-black uppercase tracking-[0.16em] text-amber-300">Current Pictory partner offer</div>
+      <p class="mt-1 text-sm leading-6 text-amber-50/90"><strong>Use code COSHUMA20 for 20% off.</strong> Pictory currently advertises annual plans at up to 40% off, and Pictory's affiliate manager confirmed that combining the annual promotion with this code can produce savings of more than 52%.</p>
+    </div>
+    <div class="shrink-0 rounded-xl border border-amber-300/20 bg-black/20 px-4 py-2 text-center">
+      <div class="text-[10px] uppercase tracking-widest text-amber-200/70">Promo code</div>
+      <div class="text-lg font-black tracking-wider text-white">COSHUMA20</div>
+    </div>
+  </div>
+  <p class="mt-2 text-[11px] leading-5 text-amber-100/60">Offer details verified September 5, 2026. Promotions can change, so confirm the final price and eligibility at checkout.</p>
+</section>
+'''.strip()
+
+updated = []
+for path in sorted(PUBLIC_DIR.rglob("*.html")):
+    text = path.read_text(encoding="utf-8")
+    if PICTORY_AFFILIATE_URL not in text or MARKER in text:
+        continue
+
+    new_text, count = re.subn(r"(<main\b[^>]*>)", r"\1\n" + PROMO, text, count=1, flags=re.IGNORECASE)
+    if count != 1:
+        raise RuntimeError(f"Could not find a single <main> insertion point in {path}")
+
+    path.write_text(new_text, encoding="utf-8")
+    updated.append(path.relative_to(PROJECT_DIR).as_posix())
+
+if not updated:
+    raise RuntimeError("No Pictory affiliate pages were updated; expected at least one monetized page.")
+
+print(f"Injected Pictory partner offer into {len(updated)} pages")
+for item in updated:
+    print(f" - {item}")


### PR DESCRIPTION
Adds a build-time Pictory partner-offer layer based on the affiliate manager's September 5, 2026 guidance. Any public HTML page using the verified COSHUMA Pictory affiliate URL now gets a visible COSHUMA20 promo banner, including the affiliate manager-confirmed 20% code and the current annual-plan savings context. The deploy workflow verifies that every Pictory monetized page contains the offer before publishing. No paid service, new subscription, or unverified referral URL is introduced.