### PR TITLE
Smoke-test real Pictory Shorts rendering on main

### DIFF
--- a/.github/workflows/coshuma-youtube-shorts.yml
+++ b/.github/workflows/coshuma-youtube-shorts.yml
@@ -59,6 +59,19 @@ jobs:
       - name: Compile all Shorts modules
         run: python3 -m py_compile scripts/youtube_shorts/*.py
 
+      - name: Render Pictory smoke Short through quality gate on main
+        if: ${{ github.event_name == 'push' }}
+        run: python3 scripts/youtube_shorts/run_pipeline.py pictory
+
+      - name: Upload Pictory smoke MP4 artifact
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: coshuma-short-pictory-smoke-${{ github.run_id }}
+          path: projects/GlobalSaaSHub/data/youtube_shorts_output/*.mp4
+          if-no-files-found: error
+          retention-days: 3
+
       - name: Render requested Short through quality gate
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.render_tool != '' }}
         run: python3 scripts/youtube_shorts/run_pipeline.py "${{ inputs.render_tool }}"

--- a/projects/GlobalSaaSHub/scripts/youtube_shorts/render_short.py
+++ b/projects/GlobalSaaSHub/scripts/youtube_shorts/render_short.py
@@ -82,6 +82,7 @@ def render(tool_id: str, output: str | None = None) -> dict:
 
         font = font_path()
         slot = duration / len(card_files)
+        escaped_comma = r"\,"
         filters = [
             "drawbox=x=70:y=120:w=940:h=1460:color=0x151827@0.96:t=fill",
             f"drawtext=fontfile='{font}':text='COSHUMA':fontcolor=0xC4B5FD:fontsize=58:x=(w-text_w)/2:y=175",
@@ -95,7 +96,7 @@ def render(tool_id: str, output: str | None = None) -> dict:
                 f"fontfile='{font}':textfile='{card_file}':"
                 "fontcolor=white:fontsize=56:line_spacing=18:"
                 "x=(w-text_w)/2:y=(h-text_h)/2:"
-                f"enable='between(t\,{start:.3f}\,{end:.3f})'"
+                f"enable='between(t{escaped_comma}{start:.3f}{escaped_comma}{end:.3f})'"
             )
         filters.extend([
             "drawbox=x=90:y=1660:w=900:h=150:color=0x7C3AED@0.92:t=fill",


### PR DESCRIPTION
Makes the Shorts CI exercise the real end-to-end Pictory render + quality gate after Shorts code lands on main, then stores the generated MP4 as a short-lived GitHub Actions artifact. Nothing is uploaded to YouTube. Also removes the Python invalid-escape warning in the ffmpeg timing expression.