### PR TITLE
Launch B2B email list providers revenue hub

### DIFF
--- a/projects/GlobalSaaSHub/index.html
+++ b/projects/GlobalSaaSHub/index.html
@@ -62,7 +62,8 @@
           <a href="/best/ai-voice-generators.html">Best AI Voice Generators in 2026</a> ·
           <a href="/best/ai-video-generators.html">Best AI Video Generators in 2026</a> ·
           <a href="/best/crm-for-marketing-agencies.html">Best CRM for Marketing Agencies in 2026</a> ·
-          <a href="/best/landing-page-builders.html">Best Landing Page Builders in 2026</a><br />
+          <a href="/best/landing-page-builders.html">Best Landing Page Builders in 2026</a> ·
+          <a href="/best/b2b-email-list-providers.html">Best B2B Email List Providers in 2026</a><br />
           <strong>Popular pricing and review guides:</strong><br />
           <a href="/tool/descript.html">Descript pricing & review</a> ·
           <a href="/tool/elevenlabs.html">ElevenLabs pricing & review</a> ·

--- a/projects/GlobalSaaSHub/public/best/b2b-email-list-providers.html
+++ b/projects/GlobalSaaSHub/public/best/b2b-email-list-providers.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Best B2B Email List Providers in 2026 | COSHUMA</title>
+  <meta name="description" content="Compare B2B email list providers for prospecting in 2026. See free starting options, pricing models, data guarantees, and the best fit for pay-as-you-go lists versus ongoing sales prospecting." />
+  <link rel="canonical" href="https://coshuma.com/best/b2b-email-list-providers.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="COSHUMA" />
+  <meta property="og:title" content="Best B2B Email List Providers in 2026 | COSHUMA" />
+  <meta property="og:description" content="A practical shortlist for buying verified B2B contact data or running ongoing prospecting workflows." />
+  <meta property="og:url" content="https://coshuma.com/best/b2b-email-list-providers.html" />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"Best B2B Email List Providers in 2026",
+    "dateModified":"2026-09-05",
+    "author":{"@type":"Organization","name":"COSHUMA"},
+    "publisher":{"@type":"Organization","name":"COSHUMA"},
+    "mainEntityOfPage":"https://coshuma.com/best/b2b-email-list-providers.html"
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>body{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}</style>
+</head>
+<body class="bg-[#08090d] text-slate-100 antialiased">
+  <header class="border-b border-white/10 bg-[#0c0e14]">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-5 py-4">
+      <a href="/" class="text-xl font-black tracking-tight text-white">COSHUMA</a>
+      <div class="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Independent AI & SaaS buyer guides</div>
+    </div>
+  </header>
+
+  <main class="mx-auto max-w-6xl px-5 py-12 sm:py-16">
+    <nav class="mb-7 text-sm text-slate-500"><a class="hover:text-white" href="/">Home</a> <span class="px-2">/</span> Best B2B Email List Providers</nav>
+
+    <section class="max-w-4xl">
+      <div class="mb-5 inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">Pricing and product details checked Sep 5, 2026</div>
+      <h1 class="text-4xl font-black tracking-[-0.04em] text-white sm:text-6xl">Best B2B Email List Providers in 2026</h1>
+      <p class="mt-5 max-w-3xl text-lg leading-8 text-slate-400">If you need contact data, start with the buying model rather than the biggest database claim. Bookyourdata is the clearest fit for pay-as-you-go list purchases, Apollo is stronger when data and outbound sales workflow need to live in one platform, and UpLead is a straightforward subscription option for teams that want verified contacts and direct dials.</p>
+    </section>
+
+    <section class="mt-10 grid gap-4 md:grid-cols-3">
+      <div class="rounded-2xl border border-violet-400/30 bg-violet-500/10 p-5">
+        <div class="text-xs font-black uppercase tracking-widest text-violet-300">Best pay-as-you-go option</div>
+        <h2 class="mt-2 text-2xl font-black">Bookyourdata</h2>
+        <p class="mt-2 text-sm leading-6 text-slate-300">Buy credits without an ongoing subscription, start with 10 free leads, and only scale once the data quality fits your campaign.</p>
+        <div class="mt-4 text-sm font-bold text-white">10 free credits · no card · credits do not expire</div>
+      </div>
+      <div class="rounded-2xl border border-cyan-400/30 bg-cyan-500/10 p-5">
+        <div class="text-xs font-black uppercase tracking-widest text-cyan-300">Best all-in-one prospecting workflow</div>
+        <h2 class="mt-2 text-2xl font-black">Apollo</h2>
+        <p class="mt-2 text-sm leading-6 text-slate-300">Combines B2B contact data with outreach, enrichment and sales engagement, so it makes more sense when prospecting is an ongoing team workflow.</p>
+        <div class="mt-4 text-sm font-bold text-white">Free plan · paid tiers scale by user and credits</div>
+      </div>
+      <div class="rounded-2xl border border-white/10 bg-white/[0.04] p-5">
+        <div class="text-xs font-black uppercase tracking-widest text-slate-400">Best conventional data subscription</div>
+        <h2 class="mt-2 text-2xl font-black">UpLead</h2>
+        <p class="mt-2 text-sm leading-6 text-slate-300">A focused B2B data service with verified emails, mobile direct dials and a credit model for contact exports.</p>
+        <div class="mt-4 text-sm font-bold text-white">7-day trial · 5 credits · Essentials from $99/mo monthly</div>
+      </div>
+    </section>
+
+    <section class="mt-14">
+      <div class="mb-5"><div class="text-xs font-bold uppercase tracking-[0.2em] text-violet-300">Shortlist</div><h2 class="mt-2 text-3xl font-black">Three different ways to buy prospect data</h2></div>
+
+      <article class="rounded-3xl border border-violet-400/25 bg-[#11131a] p-6 sm:p-8">
+        <div class="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div class="max-w-3xl">
+            <div class="text-xs font-black uppercase tracking-widest text-violet-300">#1 · Best for buying a list without a subscription</div>
+            <h3 class="mt-2 text-3xl font-black">Bookyourdata</h3>
+            <p class="mt-3 leading-7 text-slate-300">Bookyourdata uses a pay-as-you-go credit model instead of forcing an ongoing subscription. Its public pricing page currently offers 10 free credits with no credit card, says credits never expire, and advertises a 97% deliverability guarantee. That makes it the easiest option here to test with a small list before spending more.</p>
+            <div class="mt-5 grid gap-3 sm:grid-cols-2">
+              <div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Best for</div><div class="mt-1 text-sm text-slate-400">One-off campaigns, targeted list purchases, teams avoiding recurring data subscriptions</div></div>
+              <div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Watch for</div><div class="mt-1 text-sm text-slate-400">A pay-as-you-go database is different from a full outbound sales-engagement platform</div></div>
+            </div>
+          </div>
+          <div class="w-full shrink-0 space-y-3 lg:w-72">
+            <a data-cta="affiliate" data-tool-id="bookyourdata" data-cta-source="best_b2b_email_list_providers_bookyourdata" href="https://join.bookyourdata.com/swcyqmumr3s5" target="_blank" rel="sponsored noopener noreferrer" class="block rounded-xl bg-violet-600 px-5 py-4 text-center font-black text-white hover:bg-violet-500">Get 10 free leads →</a>
+            <a href="/tool/bookyourdata.html" class="block rounded-xl border border-white/10 px-5 py-3 text-center text-sm font-bold text-slate-300 hover:bg-white/5">Read Bookyourdata buyer guide</a>
+          </div>
+        </div>
+      </article>
+
+      <article class="mt-5 rounded-3xl border border-cyan-400/25 bg-[#11131a] p-6 sm:p-8">
+        <div class="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div class="max-w-3xl">
+            <div class="text-xs font-black uppercase tracking-widest text-cyan-300">#2 · Best when prospecting and outreach belong together</div>
+            <h3 class="mt-2 text-3xl font-black">Apollo</h3>
+            <p class="mt-3 leading-7 text-slate-300">Apollo is broader than a list vendor. It combines contact data with enrichment and sales-engagement features. Apollo's current official pricing guidance lists a free tier and annual paid plans starting at $49 per user per month for Basic, so it is a better fit for teams that expect prospecting to be an ongoing workflow rather than a single export.</p>
+            <div class="mt-5 grid gap-3 sm:grid-cols-2">
+              <div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Best for</div><div class="mt-1 text-sm text-slate-400">SDRs, RevOps teams, ongoing outbound sequences and integrated prospecting</div></div>
+              <div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Watch for</div><div class="mt-1 text-sm text-slate-400">Seat pricing and credit limits matter more as the team grows</div></div>
+            </div>
+          </div>
+          <div class="w-full shrink-0 space-y-3 lg:w-72">
+            <a href="https://www.apollo.io/pricing" target="_blank" rel="noopener noreferrer" class="block rounded-xl bg-cyan-700 px-5 py-4 text-center font-black text-white hover:bg-cyan-600">Check Apollo pricing →</a>
+            <a href="/tool/apollo.html" class="block rounded-xl border border-white/10 px-5 py-3 text-center text-sm font-bold text-slate-300 hover:bg-white/5">Read Apollo buyer guide</a>
+          </div>
+        </div>
+      </article>
+
+      <article class="mt-5 rounded-3xl border border-white/10 bg-[#11131a] p-6 sm:p-8">
+        <div class="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div class="max-w-3xl">
+            <div class="text-xs font-black uppercase tracking-widest text-slate-400">#3 · Best for a focused contact-data subscription</div>
+            <h3 class="mt-2 text-3xl font-black">UpLead</h3>
+            <p class="mt-3 leading-7 text-slate-300">UpLead's current pricing page offers a 7-day trial with 5 credits. Its Essentials plan is listed at $99 per month on monthly billing, with a lower effective monthly price on annual billing. It is a conventional choice when you mainly want verified B2B contacts, direct dials and a predictable monthly credit allowance.</p>
+            <div class="mt-5 grid gap-3 sm:grid-cols-2">
+              <div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Best for</div><div class="mt-1 text-sm text-slate-400">Recurring prospect research, verified emails and direct-dial access</div></div>
+              <div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold">Watch for</div><div class="mt-1 text-sm text-slate-400">The trial is time-limited and the paid model is subscription-based</div></div>
+            </div>
+          </div>
+          <div class="w-full shrink-0 space-y-3 lg:w-72">
+            <a href="https://www.uplead.com/pricing/" target="_blank" rel="noopener noreferrer" class="block rounded-xl bg-slate-700 px-5 py-4 text-center font-black text-white hover:bg-slate-600">Check UpLead pricing →</a>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <section class="mt-14 overflow-hidden rounded-3xl border border-white/10 bg-white/[0.035]">
+      <div class="border-b border-white/10 p-6"><h2 class="text-2xl font-black">Fast comparison</h2><p class="mt-2 text-sm text-slate-400">Public pricing and product details checked Sep 5, 2026.</p></div>
+      <div class="overflow-x-auto"><table class="w-full min-w-[780px] text-left text-sm"><thead class="bg-white/[0.03] text-slate-400"><tr><th class="p-4">Provider</th><th class="p-4">Free start</th><th class="p-4">Buying model</th><th class="p-4">Strongest fit</th><th class="p-4">Next step</th></tr></thead><tbody class="divide-y divide-white/10"><tr><td class="p-4 font-black">Bookyourdata</td><td class="p-4">10 free credits · no card</td><td class="p-4">Pay as you go</td><td class="p-4">Targeted list purchases</td><td class="p-4"><a class="font-bold text-violet-300" href="/tool/bookyourdata.html">Buyer guide →</a></td></tr><tr><td class="p-4 font-black">Apollo</td><td class="p-4">Free plan</td><td class="p-4">Per-user plans + credits</td><td class="p-4">Data + outbound workflow</td><td class="p-4"><a class="font-bold text-cyan-300" href="/tool/apollo.html">Buyer guide →</a></td></tr><tr><td class="p-4 font-black">UpLead</td><td class="p-4">7-day trial · 5 credits</td><td class="p-4">Monthly/annual subscription</td><td class="p-4">Focused B2B contact data</td><td class="p-4"><a class="font-bold text-slate-300" href="https://www.uplead.com/pricing/" target="_blank" rel="noopener noreferrer">Official pricing →</a></td></tr></tbody></table></div>
+    </section>
+
+    <section class="mt-14 grid gap-5 lg:grid-cols-2">
+      <div class="rounded-2xl border border-white/10 bg-[#11131a] p-6"><h2 class="text-2xl font-black">How to choose</h2><div class="mt-4 space-y-3 text-sm leading-6 text-slate-300"><p><strong>Need one list without a subscription?</strong> Start with Bookyourdata's free credits and only buy more if the export quality fits.</p><p><strong>Running outbound every week?</strong> Apollo's combined data and engagement stack can remove the need to stitch together separate tools.</p><p><strong>Want a traditional data subscription?</strong> UpLead is the more conventional monthly-credit model of the three.</p></div></div>
+      <div class="rounded-2xl border border-white/10 bg-[#11131a] p-6"><h2 class="text-2xl font-black">Verification notes</h2><ul class="mt-4 space-y-3 text-sm leading-6 text-slate-300"><li>Bookyourdata facts were checked against its official pricing, Prospector and guarantee pages.</li><li>Apollo plan figures were checked against Apollo's official 2026 prospecting-pricing guidance.</li><li>UpLead trial and plan figures were checked against its official pricing page.</li><li>No user ratings or invented performance scores are used in this ranking.</li></ul></div>
+    </section>
+
+    <section class="mt-10 rounded-2xl border border-amber-400/20 bg-amber-400/[0.06] p-5 text-sm leading-6 text-amber-100/80"><strong>Affiliate disclosure:</strong> COSHUMA may earn a commission if you use the Bookyourdata partner link on this page, at no extra cost to you. That relationship does not guarantee a positive recommendation or affect the other providers' placement.</section>
+    <section class="mt-8 text-xs leading-6 text-slate-500"><strong class="text-slate-400">Official sources checked:</strong> Bookyourdata pricing and guarantee pages, Apollo official pricing guidance, and UpLead pricing. Product terms can change after the check date, so confirm the final price before purchase.</section>
+  </main>
+  <footer class="border-t border-white/10 px-5 py-8 text-center text-xs text-slate-600">COSHUMA · Independent AI & SaaS buyer guides</footer>
+  <script src="/affiliate-attribution.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
Adds a new buyer-intent Money Hub for the exact search topic Bookyourdata's partner team recommended in its latest onboarding email: best email list providers. The page compares Bookyourdata, Apollo, and UpLead by buying model and current official pricing. Only Bookyourdata uses a revenue CTA, and it preserves the already-verified partner URL `https://join.bookyourdata.com/swcyqmumr3s5` with a distinct attribution source. Apollo and UpLead use official pricing links only. Also links the new hub from the homepage crawler fallback; the existing build step will add `/best/*.html` pages to the sitemap. No paid services, fabricated ratings, or unverified affiliate URLs are introduced.