### PR TITLE
Prepare Bookyourdata Shorts campaign for new revenue hub

### DIFF
--- a/.github/workflows/coshuma-youtube-shorts.yml
+++ b/.github/workflows/coshuma-youtube-shorts.yml
@@ -68,11 +68,15 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: python3 scripts/youtube_shorts/run_pipeline.py pictory
 
-      - name: Upload Pictory smoke MP4 artifact
+      - name: Render Bookyourdata revenue Short through quality gate on main
+        if: ${{ github.event_name == 'push' }}
+        run: python3 scripts/youtube_shorts/run_pipeline.py bookyourdata
+
+      - name: Upload revenue smoke MP4 artifacts
         if: ${{ github.event_name == 'push' }}
         uses: actions/upload-artifact@v6
         with:
-          name: coshuma-short-pictory-smoke-${{ github.run_id }}
+          name: coshuma-shorts-revenue-smoke-${{ github.run_id }}
           path: projects/GlobalSaaSHub/data/youtube_shorts_output/*.mp4
           if-no-files-found: error
           retention-days: 3

--- a/projects/GlobalSaaSHub/data/youtube_shorts_campaigns.json
+++ b/projects/GlobalSaaSHub/data/youtube_shorts_campaigns.json
@@ -18,5 +18,25 @@
       "verified_at": "2026-09-04",
       "note": "Email confirmed promo code coshuma20, 20% discount, and the then-current site-wide 40% annual offer with combined savings over 52%."
     }
+  },
+  "bookyourdata": {
+    "priority": 95,
+    "source_page": "/best/b2b-email-list-providers.html",
+    "campaign_slug": "bookyourdata_free_leads",
+    "hook": "Need a B2B email list without paying for another subscription?",
+    "beats": [
+      "Bookyourdata uses a pay-as-you-go model for B2B contact data.",
+      "Its current COSHUMA buyer guide highlights 10 free leads with no credit card required.",
+      "Bookyourdata's partner team specifically recommends best email list provider searches as an in-market promotion topic.",
+      "Start small, check whether the data fits your campaign, and compare the alternatives before buying more."
+    ],
+    "cta": "See the B2B email list provider comparison and Bookyourdata free-lead option on COSHUMA.",
+    "hashtags": ["B2BLeads", "SalesTools", "LeadGeneration"],
+    "evidence": {
+      "type": "partner_email_and_verified_buyer_guide",
+      "sender": "Bookyourdata via PartnerStack",
+      "verified_at": "2026-09-05",
+      "note": "Partner onboarding email supplied the verified referral URL and recommended 'Best email list providers' as an in-market search topic. COSHUMA's existing Bookyourdata guide records the current 10-free-leads, no-card offer from official product pages."
+    }
   }
 }


### PR DESCRIPTION
Adds an evidence-bounded Bookyourdata Shorts campaign that drives viewers to the new `/best/b2b-email-list-providers.html` Money Hub. The creative uses only the verified pay-as-you-go positioning, current 10-free-leads/no-card offer already documented in the COSHUMA buyer guide, and the partner team's explicit recommendation of 'best email list providers' as an in-market search topic. The main Shorts CI now smoke-renders both Pictory and Bookyourdata through the existing quality gate and retains the MP4s as artifacts. No public or private YouTube upload is triggered by this PR; scheduling remains disabled.