### PR TITLE
Launch eSignature revenue hub and BoldSign Shorts campaign

### DIFF
--- a/.github/workflows/coshuma-youtube-shorts.yml
+++ b/.github/workflows/coshuma-youtube-shorts.yml
@@ -72,6 +72,10 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: python3 scripts/youtube_shorts/run_pipeline.py bookyourdata
 
+      - name: Render BoldSign revenue Short through quality gate on main
+        if: ${{ github.event_name == 'push' }}
+        run: python3 scripts/youtube_shorts/run_pipeline.py boldsign
+
       - name: Upload revenue smoke MP4 artifacts
         if: ${{ github.event_name == 'push' }}
         uses: actions/upload-artifact@v6

--- a/projects/GlobalSaaSHub/data/youtube_shorts_campaigns.json
+++ b/projects/GlobalSaaSHub/data/youtube_shorts_campaigns.json
@@ -38,5 +38,25 @@
       "verified_at": "2026-09-05",
       "note": "Partner onboarding email supplied the verified referral URL and recommended 'Best email list providers' as an in-market search topic. COSHUMA's existing Bookyourdata guide records the current 10-free-leads, no-card offer from official product pages. The partner-search recommendation is retained as internal evidence rather than surfaced in viewer-facing copy."
     }
+  },
+  "boldsign": {
+    "priority": 90,
+    "source_page": "/best/esignature-software.html",
+    "campaign_slug": "boldsign_esignature_value",
+    "hook": "Still printing, signing, and scanning contracts?",
+    "beats": [
+      "BoldSign is built for electronic signatures, reusable templates, reminders, audit trails, and team approval workflows.",
+      "Its current public pricing includes a free entry option, while the Business plan emphasizes unlimited envelopes for frequent senders.",
+      "Before paying, compare your expected document volume, team size, and integrations instead of choosing on headline price alone.",
+      "COSHUMA compares BoldSign with Dropbox Sign and PandaDoc so you can see which workflow fits before you commit."
+    ],
+    "cta": "Compare eSignature software and review the verified BoldSign partner option on COSHUMA.",
+    "hashtags": ["eSignature", "SmallBusiness", "SaaS"],
+    "evidence": {
+      "type": "affiliate_program_email_and_official_pricing",
+      "sender": "BoldSign Affiliates",
+      "verified_at": "2026-09-05",
+      "note": "BoldSign affiliate emails confirm active program participation, while COSHUMA's verified tracking URL is stored in the repository. Viewer-facing plan claims are limited to current official BoldSign pricing signals checked September 5, 2026."
+    }
   }
 }

--- a/projects/GlobalSaaSHub/public/best/esignature-software.html
+++ b/projects/GlobalSaaSHub/public/best/esignature-software.html
@@ -1,0 +1,145 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Best eSignature Software for Small Teams in 2026 | COSHUMA</title>
+    <meta name="description" content="Compare BoldSign, Dropbox Sign, and PandaDoc for contracts, approvals, templates, pricing, and team workflows. See which eSignature tool fits your buying needs in 2026." />
+    <link rel="canonical" href="https://coshuma.com/best/esignature-software.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://coshuma.com/best/esignature-software.html" />
+    <meta property="og:title" content="Best eSignature Software for Small Teams in 2026 | COSHUMA" />
+    <meta property="og:description" content="A buyer-focused shortlist for electronic signatures, contracts, approvals, and team workflows." />
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      "name": "Best eSignature Software for Small Teams in 2026",
+      "url": "https://coshuma.com/best/esignature-software.html",
+      "itemListElement": [
+        {"@type":"ListItem","position":1,"name":"BoldSign","url":"https://coshuma.com/tool/boldsign.html"},
+        {"@type":"ListItem","position":2,"name":"Dropbox Sign","url":"https://sign.dropbox.com/products/dropbox-sign/pricing"},
+        {"@type":"ListItem","position":3,"name":"PandaDoc","url":"https://www.pandadoc.com/pricing/"}
+      ]
+    }
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <style>
+      body { font-family: 'Inter', sans-serif; background:#0b0c10; color:#f1f5f9; }
+      h1,h2,h3 { font-family:'Outfit', sans-serif; }
+    </style>
+  </head>
+  <body class="min-h-screen bg-[#0b0c10]">
+    <header class="sticky top-0 z-50 border-b border-[#222538] bg-[#07080c]/90 px-6 py-4 backdrop-blur-md">
+      <div class="mx-auto flex max-w-6xl items-center justify-between">
+        <a href="/" class="flex items-center gap-3">
+          <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-purple-600 text-lg font-extrabold text-white">C</div>
+          <span class="text-lg font-extrabold tracking-tight text-white">COSHUMA</span>
+        </a>
+        <a href="/" class="rounded-full border border-purple-500/30 bg-purple-500/10 px-4 py-2 text-xs font-bold text-purple-300 hover:bg-purple-500/20">← Browse all tools</a>
+      </div>
+    </header>
+
+    <main class="mx-auto w-full max-w-5xl space-y-8 px-4 py-12">
+      <section class="space-y-5 text-center">
+        <div class="inline-flex rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 text-xs font-bold text-emerald-300">Buyer guide · Updated September 5, 2026</div>
+        <h1 class="text-4xl font-black tracking-tight text-white md:text-6xl">Best eSignature Software for Small Teams</h1>
+        <p class="mx-auto max-w-3xl text-base leading-relaxed text-slate-300">For most buyers, the real decision is not whether electronic signatures work. It is whether the plan fits your document volume, team size, templates, integrations, and budget. This shortlist keeps those tradeoffs visible.</p>
+      </section>
+
+      <section class="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <article class="rounded-3xl border border-purple-500/40 bg-[#131520] p-6 shadow-xl md:col-span-3">
+          <div class="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div class="max-w-2xl space-y-3">
+              <div class="text-xs font-black uppercase tracking-wider text-purple-300">Best value for frequent sending</div>
+              <h2 class="text-3xl font-black text-white">1. BoldSign</h2>
+              <p class="text-sm leading-relaxed text-slate-300">BoldSign is the strongest fit here for teams that care about predictable eSignature costs and higher document volume. Its current public pricing emphasizes an unlimited-envelope Business option, while the free tier gives smaller teams a low-risk way to test the workflow.</p>
+              <div class="grid grid-cols-1 gap-2 text-xs text-slate-300 sm:grid-cols-2">
+                <div class="rounded-xl border border-white/10 bg-[#181a29] p-3">✓ Free entry option</div>
+                <div class="rounded-xl border border-white/10 bg-[#181a29] p-3">✓ Business plan highlights unlimited envelopes</div>
+                <div class="rounded-xl border border-white/10 bg-[#181a29] p-3">✓ Templates, reminders, audit trails</div>
+                <div class="rounded-xl border border-white/10 bg-[#181a29] p-3">✓ API and embedded-signing workflows</div>
+              </div>
+            </div>
+            <div class="w-full shrink-0 space-y-3 lg:w-72">
+              <a data-cta="affiliate" data-tool-id="boldsign" data-cta-source="best_esignature_software_boldsign" href="https://boldsign.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="block rounded-xl bg-purple-600 px-5 py-4 text-center font-black text-white hover:bg-purple-500">Try BoldSign via verified partner link →</a>
+              <a href="/tool/boldsign.html" class="block rounded-xl border border-white/10 px-5 py-3 text-center text-sm font-bold text-slate-300 hover:bg-white/5">Read BoldSign pricing guide</a>
+            </div>
+          </div>
+        </article>
+
+        <article class="rounded-3xl border border-blue-500/25 bg-[#131520] p-6 space-y-4">
+          <div class="text-xs font-black uppercase tracking-wider text-blue-300">Best for Dropbox-centered workflows</div>
+          <h2 class="text-2xl font-black text-white">2. Dropbox Sign</h2>
+          <p class="text-sm leading-relaxed text-slate-300">Dropbox Sign is a practical choice when your team already works heavily in Dropbox or wants a straightforward signature workflow with reusable templates, reminders, and admin controls.</p>
+          <div class="rounded-2xl border border-white/10 bg-[#181a29] p-4 text-sm text-slate-300">
+            <div class="font-bold text-white">Current public pricing signal</div>
+            <p class="mt-2 text-xs leading-relaxed text-slate-400">Essentials lists $15/month on the official pricing page, with lower annual promotional pricing shown. Standard is positioned for small teams, while Premium is quote-based.</p>
+          </div>
+          <a data-cta="official" href="https://sign.dropbox.com/products/dropbox-sign/pricing" target="_blank" rel="noopener noreferrer" class="block rounded-xl border border-blue-500/30 bg-blue-500/10 px-5 py-3 text-center text-sm font-bold text-blue-200 hover:bg-blue-500/20">Check Dropbox Sign pricing →</a>
+        </article>
+
+        <article class="rounded-3xl border border-emerald-500/25 bg-[#131520] p-6 space-y-4">
+          <div class="text-xs font-black uppercase tracking-wider text-emerald-300">Best for proposals + signatures</div>
+          <h2 class="text-2xl font-black text-white">3. PandaDoc</h2>
+          <p class="text-sm leading-relaxed text-slate-300">PandaDoc is more than a signature tool. It is a stronger fit when sales teams also need proposal creation, document editing, tracking, and agreement workflows around the signature step.</p>
+          <div class="rounded-2xl border border-white/10 bg-[#181a29] p-4 text-sm text-slate-300">
+            <div class="font-bold text-white">Current public pricing signal</div>
+            <p class="mt-2 text-xs leading-relaxed text-slate-400">The official page currently lists a free plan, Starter at $19/seat/month billed annually, and Business at $49/seat/month billed annually.</p>
+          </div>
+          <a data-cta="official" href="https://www.pandadoc.com/pricing/" target="_blank" rel="noopener noreferrer" class="block rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-5 py-3 text-center text-sm font-bold text-emerald-200 hover:bg-emerald-500/20">Check PandaDoc pricing →</a>
+        </article>
+
+        <article class="rounded-3xl border border-amber-500/25 bg-[#131520] p-6 space-y-4">
+          <div class="text-xs font-black uppercase tracking-wider text-amber-300">Quick decision</div>
+          <h2 class="text-2xl font-black text-white">Which one should you pick?</h2>
+          <ul class="space-y-3 text-sm leading-relaxed text-slate-300">
+            <li><strong class="text-white">Choose BoldSign</strong> if sending volume and predictable eSignature pricing matter most.</li>
+            <li><strong class="text-white">Choose Dropbox Sign</strong> if Dropbox is already central to your document workflow.</li>
+            <li><strong class="text-white">Choose PandaDoc</strong> if proposals, sales docs, and signatures need to live in the same workflow.</li>
+          </ul>
+        </article>
+      </section>
+
+      <section class="rounded-3xl border border-[#222538] bg-[#131520] p-6 space-y-5">
+        <h2 class="text-2xl font-black text-white">What to compare before paying</h2>
+        <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div class="rounded-2xl border border-white/10 bg-[#181a29] p-5">
+            <h3 class="font-bold text-white">Document volume</h3>
+            <p class="mt-2 text-sm leading-relaxed text-slate-400">Check whether the plan limits envelopes, documents, users, templates, or API requests. A low headline price can be less attractive if your real usage triggers limits quickly.</p>
+          </div>
+          <div class="rounded-2xl border border-white/10 bg-[#181a29] p-5">
+            <h3 class="font-bold text-white">Team and admin controls</h3>
+            <p class="mt-2 text-sm leading-relaxed text-slate-400">Look at role management, reporting, reusable templates, branding, signer authentication, and whether adding users changes the economics.</p>
+          </div>
+          <div class="rounded-2xl border border-white/10 bg-[#181a29] p-5">
+            <h3 class="font-bold text-white">Integrations</h3>
+            <p class="mt-2 text-sm leading-relaxed text-slate-400">The right eSignature tool should fit where documents already live. Switching between apps can erase the time savings you expected from electronic signatures.</p>
+          </div>
+          <div class="rounded-2xl border border-white/10 bg-[#181a29] p-5">
+            <h3 class="font-bold text-white">Compliance and procurement</h3>
+            <p class="mt-2 text-sm leading-relaxed text-slate-400">If your organization has specific legal, identity, retention, or procurement requirements, verify those directly with the vendor before switching platforms.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-3xl border border-purple-500/30 bg-gradient-to-br from-purple-950/40 to-[#131520] p-7 text-center space-y-4">
+        <h2 class="text-2xl font-black text-white">Want the fastest low-risk starting point?</h2>
+        <p class="mx-auto max-w-2xl text-sm leading-relaxed text-slate-300">Start with the option that matches your expected sending volume, then verify the live checkout price and limits before paying. BoldSign currently offers the clearest COSHUMA partner path in this shortlist.</p>
+        <div class="mx-auto grid max-w-2xl grid-cols-1 gap-3 sm:grid-cols-2">
+          <a href="/tool/boldsign.html" class="rounded-xl border border-white/10 px-5 py-3 text-sm font-bold text-slate-300 hover:bg-white/5">Review BoldSign details</a>
+          <a data-cta="affiliate" data-tool-id="boldsign" data-cta-source="best_esignature_software_boldsign_final" href="https://boldsign.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-purple-600 px-5 py-3 text-sm font-black text-white hover:bg-purple-500">Open BoldSign partner offer →</a>
+        </div>
+        <p class="text-[10px] leading-relaxed text-slate-500">Affiliate disclosure: BoldSign links marked as partner links may earn COSHUMA a commission at no extra cost to you. Dropbox Sign and PandaDoc buttons on this page are official non-affiliate links. Prices and promotions can change; pricing references above were checked on September 5, 2026.</p>
+      </section>
+    </main>
+
+    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
+      <div class="mx-auto max-w-6xl px-4">&copy; 2026 COSHUMA. AI & SaaS buyer guides.</div>
+    </footer>
+    <script src="/affiliate-attribution.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
Adds a buyer-intent eSignature software hub centered on the verified BoldSign partner path, with official non-affiliate Dropbox Sign and PandaDoc alternatives. Also adds an evidence-bounded BoldSign Shorts campaign and renders it through the existing quality-gated Shorts smoke workflow on main. No paid services, OAuth changes, or public YouTube uploads are introduced.