### PR TITLE
Polish BoldSign Shorts viewer-facing CTA

### DIFF
--- a/projects/GlobalSaaSHub/data/youtube_shorts_campaigns.json
+++ b/projects/GlobalSaaSHub/data/youtube_shorts_campaigns.json
@@ -50,13 +50,13 @@
       "Before paying, compare your expected document volume, team size, and integrations instead of choosing on headline price alone.",
       "COSHUMA compares BoldSign with Dropbox Sign and PandaDoc so you can see which workflow fits before you commit."
     ],
-    "cta": "Compare eSignature software and review the verified BoldSign partner option on COSHUMA.",
+    "cta": "See the full eSignature comparison and BoldSign buyer guide on COSHUMA.",
     "hashtags": ["eSignature", "SmallBusiness", "SaaS"],
     "evidence": {
       "type": "affiliate_program_email_and_official_pricing",
       "sender": "BoldSign Affiliates",
       "verified_at": "2026-09-05",
-      "note": "BoldSign affiliate emails confirm active program participation, while COSHUMA's verified tracking URL is stored in the repository. Viewer-facing plan claims are limited to current official BoldSign pricing signals checked September 5, 2026."
+      "note": "BoldSign affiliate emails confirm active program participation, while COSHUMA's verified tracking URL is stored in the repository. Viewer-facing plan claims are limited to current official BoldSign pricing signals checked September 5, 2026; affiliate-program details remain internal evidence rather than viewer-facing copy."
     }
   }
 }


### PR DESCRIPTION
Removes affiliate-operations wording from the viewer-facing BoldSign Short. Keeps partner evidence internal while changing the final CTA to a natural buyer-guide prompt. No pricing, affiliate URL, upload behavior, or paid service changes.