### PR TITLE
Launch Brand24 AI Visibility revenue landing

### DIFF
--- a/projects/GlobalSaaSHub/index.html
+++ b/projects/GlobalSaaSHub/index.html
@@ -63,7 +63,8 @@
           <a href="/best/ai-video-generators.html">Best AI Video Generators in 2026</a> ·
           <a href="/best/crm-for-marketing-agencies.html">Best CRM for Marketing Agencies in 2026</a> ·
           <a href="/best/landing-page-builders.html">Best Landing Page Builders in 2026</a> ·
-          <a href="/best/b2b-email-list-providers.html">Best B2B Email List Providers in 2026</a><br />
+          <a href="/best/b2b-email-list-providers.html">Best B2B Email List Providers in 2026</a> ·
+          <a href="/best/brand24-ai-visibility.html">Brand24 AI Visibility & GEO Tracking</a><br />
           <strong>Popular pricing and review guides:</strong><br />
           <a href="/tool/descript.html">Descript pricing & review</a> ·
           <a href="/tool/elevenlabs.html">ElevenLabs pricing & review</a> ·
@@ -82,6 +83,7 @@
           <a href="/tool/bookyourdata.html">Bookyourdata pricing & free leads</a> ·
           <a href="/tool/unbounce.html">Unbounce pricing & partner discount</a><br />
           <a href="/tool/databox.html">Databox pricing & review</a> ·
+          <a href="/tool/brand24.html">Brand24 pricing & free trial</a> ·
           <a href="/tool/shopify.html">Shopify pricing & review</a><br />
           <strong>Side-by-side comparisons:</strong><br />
           <a href="/compare/vidiq-vs-tubebuddy.html">vidIQ vs TubeBuddy</a> ·

--- a/projects/GlobalSaaSHub/public/best/brand24-ai-visibility.html
+++ b/projects/GlobalSaaSHub/public/best/brand24-ai-visibility.html
@@ -1,0 +1,186 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Brand24 AI Visibility Review (2026): ChatGPT, Gemini & GEO Tracking | COSHUMA</title>
+    <meta name="description" content="Brand24 AI Visibility review for 2026: track brand presence in ChatGPT, Gemini, Perplexity and Google AI Overview, compare the $99/month add-on, free trial, prompt limits and Brand24 pricing." />
+    <link rel="canonical" href="https://coshuma.com/best/brand24-ai-visibility.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://coshuma.com/best/brand24-ai-visibility.html" />
+    <meta property="og:title" content="Brand24 AI Visibility Review (2026): ChatGPT, Gemini & GEO Tracking" />
+    <meta property="og:description" content="See what Brand24 AI Visibility tracks, its current $99/month add-on price, trial limits and whether it fits GEO / AI-search monitoring workflows." />
+
+    <script type="application/ld+json">
+    {
+      "@context":"https://schema.org",
+      "@type":"Article",
+      "headline":"Brand24 AI Visibility Review (2026): ChatGPT, Gemini & GEO Tracking",
+      "description":"Independent buyer guide to Brand24 AI Visibility and Brand24's social-listening platform.",
+      "mainEntityOfPage":"https://coshuma.com/best/brand24-ai-visibility.html",
+      "publisher":{"@type":"Organization","name":"COSHUMA"},
+      "dateModified":"2026-09-05"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context":"https://schema.org",
+      "@type":"FAQPage",
+      "mainEntity":[
+        {
+          "@type":"Question",
+          "name":"What does Brand24 AI Visibility track?",
+          "acceptedAnswer":{"@type":"Answer","text":"Brand24 says AI Visibility tracks brand presence in ChatGPT, Perplexity, Google AI Overview and Gemini while its core platform covers traditional online mentions and social listening."}
+        },
+        {
+          "@type":"Question",
+          "name":"How much does Brand24 AI Visibility cost?",
+          "acceptedAnswer":{"@type":"Answer","text":"Brand24 currently lists the AI Visibility add-on at $99 per month for an active Brand24 subscription. Brand24 also offers a free trial of the add-on."}
+        },
+        {
+          "@type":"Question",
+          "name":"Does Brand24 offer a free trial?",
+          "acceptedAnswer":{"@type":"Answer","text":"Yes. Brand24's official pricing page currently advertises a 14-day free trial with no credit card required for the main Brand24 platform."}
+        }
+      ]
+    }
+    </script>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700;800;900&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <style>
+      body { font-family: 'Inter', sans-serif; background:#0b0c10; color:#f1f5f9; }
+      h1,h2,h3 { font-family:'Outfit',sans-serif; }
+    </style>
+  </head>
+  <body class="min-h-screen bg-[#0b0c10] text-slate-100">
+    <header class="sticky top-0 z-50 border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md">
+      <div class="max-w-5xl mx-auto px-5 py-4 flex items-center justify-between gap-4">
+        <a href="/" class="flex items-center gap-3">
+          <div class="h-9 w-9 rounded-xl bg-purple-600 flex items-center justify-center font-black text-white">C</div>
+          <span class="font-extrabold tracking-tight text-white">COSHUMA</span>
+        </a>
+        <a href="/tool/brand24.html" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 text-purple-200 hover:bg-purple-500/10">Brand24 pricing guide →</a>
+      </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-5 py-10 md:py-14 space-y-8">
+      <section class="rounded-3xl border border-purple-500/30 bg-[#121520] p-6 md:p-10 shadow-2xl space-y-7">
+        <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold border border-emerald-500/25 bg-emerald-500/10 text-emerald-300">GEO / AI-search monitoring · Updated September 5, 2026</div>
+        <div class="space-y-4">
+          <h1 class="text-4xl md:text-6xl font-black tracking-tight text-white">Brand24 AI Visibility: track how your brand appears in AI answers</h1>
+          <p class="text-lg text-slate-300 leading-relaxed max-w-4xl">Brand24 now combines classic social listening with an AI Visibility add-on for checking whether and how a brand appears in ChatGPT, Gemini, Perplexity and Google AI Overview. That makes it relevant for teams treating GEO / AI-search visibility as part of reputation and brand monitoring.</p>
+        </div>
+
+        <div class="grid md:grid-cols-3 gap-3">
+          <div class="rounded-2xl border border-purple-500/20 bg-purple-500/5 p-5">
+            <div class="text-[11px] uppercase tracking-wider font-extrabold text-purple-300">AI Visibility add-on</div>
+            <div class="text-2xl font-black text-white mt-1">$99 / month</div>
+            <div class="text-xs text-slate-400 mt-1">Brand24 currently lists this as an extension to an active Brand24 subscription.</div>
+          </div>
+          <div class="rounded-2xl border border-emerald-500/20 bg-emerald-500/5 p-5">
+            <div class="text-[11px] uppercase tracking-wider font-extrabold text-emerald-300">Core Brand24 trial</div>
+            <div class="text-2xl font-black text-white mt-1">14 days free</div>
+            <div class="text-xs text-slate-400 mt-1">No credit card required according to Brand24's current pricing page.</div>
+          </div>
+          <div class="rounded-2xl border border-blue-500/20 bg-blue-500/5 p-5">
+            <div class="text-[11px] uppercase tracking-wider font-extrabold text-blue-300">AI models tracked</div>
+            <div class="text-2xl font-black text-white mt-1">4 models</div>
+            <div class="text-xs text-slate-400 mt-1">ChatGPT, Perplexity, Google AI Overview and Gemini on Brand24's current AI Visibility page.</div>
+          </div>
+        </div>
+
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a data-cta="affiliate" data-tool-id="brand24" data-cta-source="brand24_ai_visibility_hero" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="px-7 py-4 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center font-extrabold hover:brightness-110 shadow-lg shadow-purple-950/40">Start Brand24 14-day free trial →</a>
+          <a data-cta="official" data-tool-id="brand24" data-cta-source="brand24_ai_visibility_official" href="https://brand24.com/llm-visibility/" target="_blank" rel="noopener noreferrer" class="px-7 py-4 rounded-xl border border-slate-600 bg-slate-800 text-white text-center font-bold hover:bg-slate-700">Verify AI Visibility details →</a>
+        </div>
+        <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission when an eligible Brand24 purchase is attributed through the verified partner link, at no extra cost to you. The $99 AI Visibility price and product limits below come from Brand24's public pages; COSHUMA does not claim a separate discount for this add-on.</p>
+      </section>
+
+      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-5">
+        <div>
+          <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">What you actually get</div>
+          <h2 class="text-3xl font-black text-white mt-1">AI visibility plus traditional social listening</h2>
+        </div>
+        <div class="grid md:grid-cols-2 gap-4">
+          <div class="rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-5 space-y-2">
+            <h3 class="text-lg font-extrabold text-white">AI answer visibility</h3>
+            <p class="text-sm text-slate-300 leading-relaxed">Brand24 says the add-on shows whether a brand appears in answers from ChatGPT, Perplexity, Google AI Overview and Gemini. It is designed to complement—not replace—traditional online-monitoring data.</p>
+          </div>
+          <div class="rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-5 space-y-2">
+            <h3 class="text-lg font-extrabold text-white">Web and social mentions</h3>
+            <p class="text-sm text-slate-300 leading-relaxed">The core Brand24 product monitors social media, news, blogs, video, forums, podcasts, reviews and other online sources, with sentiment and alerting features depending on plan.</p>
+          </div>
+          <div class="rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-5 space-y-2">
+            <h3 class="text-lg font-extrabold text-white">Trial prompt allowance</h3>
+            <p class="text-sm text-slate-300 leading-relaxed">Brand24 currently says the AI Visibility trial supports the four listed AI models with up to 5 prompts.</p>
+          </div>
+          <div class="rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-5 space-y-2">
+            <h3 class="text-lg font-extrabold text-white">Paid prompt allowance</h3>
+            <p class="text-sm text-slate-300 leading-relaxed">The current $99/month AI Visibility add-on is listed with up to 30 prompts across the same four models. Confirm limits before purchase because SaaS plans can change.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-5">
+        <div>
+          <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Cost reality</div>
+          <h2 class="text-3xl font-black text-white mt-1">The $99 add-on sits on top of a Brand24 subscription</h2>
+          <p class="text-sm text-slate-400 mt-2">This matters because the AI Visibility add-on is not a standalone $99 product. Buyers should budget for the underlying Brand24 plan as well.</p>
+        </div>
+        <div class="overflow-x-auto rounded-2xl border border-[#2a2e42]">
+          <table class="w-full min-w-[680px] text-left text-sm">
+            <thead class="bg-[#0d1018] text-slate-300">
+              <tr><th class="p-4">Brand24 plan</th><th class="p-4">Monthly billing</th><th class="p-4">Annual billing equivalent</th><th class="p-4">Good fit</th></tr>
+            </thead>
+            <tbody class="divide-y divide-[#222538]">
+              <tr><td class="p-4 font-bold text-white">Individual</td><td class="p-4">$249/mo</td><td class="p-4">$199/mo</td><td class="p-4 text-slate-300">Small-brand monitoring</td></tr>
+              <tr><td class="p-4 font-bold text-white">Team</td><td class="p-4">$349/mo</td><td class="p-4">$299/mo</td><td class="p-4 text-slate-300">Startups and small teams</td></tr>
+              <tr><td class="p-4 font-bold text-white">Pro</td><td class="p-4">$499/mo</td><td class="p-4">$399/mo</td><td class="p-4 text-slate-300">Growing teams and agencies</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-xs text-slate-500">Brand24's current pricing page also lists higher Business and Enterprise tiers. Prices above were checked September 5, 2026 and can change.</p>
+        <a data-cta="affiliate" data-tool-id="brand24" data-cta-source="brand24_ai_visibility_pricing" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="inline-block px-6 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-extrabold text-sm">Try Brand24 before adding AI Visibility →</a>
+      </section>
+
+      <section class="grid md:grid-cols-2 gap-4">
+        <div class="rounded-3xl border border-emerald-500/20 bg-emerald-500/5 p-6 space-y-3">
+          <h2 class="text-xl font-black text-white">Choose Brand24 AI Visibility when...</h2>
+          <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+            <li>You already need Brand24 for reputation or social-listening work.</li>
+            <li>You want one workflow spanning traditional mentions and AI-answer visibility.</li>
+            <li>You specifically care about visibility in ChatGPT, Gemini, Perplexity and Google AI Overview.</li>
+            <li>You can validate value with a small prompt set before paying for the add-on.</li>
+          </ul>
+        </div>
+        <div class="rounded-3xl border border-amber-500/20 bg-amber-500/5 p-6 space-y-3">
+          <h2 class="text-xl font-black text-white">Look elsewhere when...</h2>
+          <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+            <li>You only need AI-search/GEO tracking and do not need social listening.</li>
+            <li>Your budget cannot justify a core Brand24 subscription plus the add-on.</li>
+            <li>You need far more than the currently listed 30 paid prompts.</li>
+            <li>You need a specific AI engine outside Brand24's current four-model set.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="rounded-3xl border border-purple-500/30 bg-purple-500/5 p-6 md:p-8 text-center space-y-4">
+        <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Decision path</div>
+        <h2 class="text-3xl font-black text-white">Test the core platform first</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto">Brand24's 14-day core trial currently requires no credit card. Use it to confirm the social-listening workflow first, then evaluate whether the AI Visibility add-on is worth the additional cost for your GEO / AI-search monitoring use case.</p>
+        <div class="flex flex-col sm:flex-row justify-center gap-3 pt-1">
+          <a data-cta="affiliate" data-tool-id="brand24" data-cta-source="brand24_ai_visibility_bottom" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="px-7 py-4 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-extrabold">Start Brand24 free trial →</a>
+          <a href="/tool/brand24.html" class="px-7 py-4 rounded-xl border border-slate-600 bg-slate-800 text-white font-bold hover:bg-slate-700">Compare full Brand24 pricing →</a>
+        </div>
+      </section>
+    </main>
+
+    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
+      <div class="max-w-5xl mx-auto px-5">&copy; 2026 COSHUMA. Independent AI & SaaS buyer guides.</div>
+    </footer>
+    <script src="/affiliate-attribution.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Adds a buyer-intent landing for Brand24's current AI Visibility / GEO offering, grounded in Brand24's public September 5, 2026 product and pricing pages. The page explains the $99/month add-on, four tracked AI surfaces, prompt limits, the core Brand24 14-day no-card trial, and underlying Brand24 plan pricing. Revenue CTAs use only the already-verified Brand24 partner URL `https://try.brand24.com/8xqrjxybmsbt`, with distinct attribution sources. Also adds homepage crawler links to the new landing and existing Brand24 buyer guide. No paid service, unverified discount, or fabricated affiliate claim is introduced.