### PR TITLE
Add disclosures to monetized comparison pages

### DIFF
--- a/.github/workflows/coshuma-site-deploy.yml
+++ b/.github/workflows/coshuma-site-deploy.yml
@@ -78,6 +78,13 @@ jobs:
             exit 1
           fi
           grep -R -q -F 'https://unbounce.partnerlinks.io/5ubjnt8lluqi' projects/GlobalSaaSHub/dist/compare
+          for page in projects/GlobalSaaSHub/dist/compare/*.html; do
+            [ -e "$page" ] || continue
+            if grep -q 'data-cta="affiliate"' "$page" && ! grep -q 'data-affiliate-disclosure="compare"' "$page"; then
+              echo "Monetized comparison missing affiliate disclosure: $page"
+              exit 1
+            fi
+          done
           for page in projects/GlobalSaaSHub/dist/best/*.html; do
             [ -e "$page" ] || continue
             slug=$(basename "$page")

--- a/projects/GlobalSaaSHub/scripts/polish_public_copy.py
+++ b/projects/GlobalSaaSHub/scripts/polish_public_copy.py
@@ -45,7 +45,8 @@ VERIFIED_COMPARE_LINK_REPLACEMENTS = {
 COMPARE_AFFILIATE_DISCLOSURE = (
     '      <p data-affiliate-disclosure="compare" class="text-[11px] leading-relaxed text-slate-500">'
     'Affiliate disclosure: Some buttons on this comparison use verified COSHUMA partner links. '
-    'COSHUMA may earn a commission if you become a paying customer after using them, at no extra cost to you.'</n    'p>'
+    'COSHUMA may earn a commission if you become a paying customer after using them, at no extra cost to you.'
+    '</p>'
 )
 
 # These lines are generic claims that can be misleading when applied to every product.

--- a/projects/GlobalSaaSHub/scripts/polish_public_copy.py
+++ b/projects/GlobalSaaSHub/scripts/polish_public_copy.py
@@ -42,6 +42,12 @@ VERIFIED_COMPARE_LINK_REPLACEMENTS = {
         '<a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="compare-generated" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer"',
 }
 
+COMPARE_AFFILIATE_DISCLOSURE = (
+    '      <p data-affiliate-disclosure="compare" class="text-[11px] leading-relaxed text-slate-500">'
+    'Affiliate disclosure: Some buttons on this comparison use verified COSHUMA partner links. '
+    'COSHUMA may earn a commission if you become a paying customer after using them, at no extra cost to you.'</n    'p>'
+)
+
 # These lines are generic claims that can be misleading when applied to every product.
 REMOVE_LINE_PATTERNS = [
     r"<li>Flexible pricing structure \([^<]*\)</li>",
@@ -135,6 +141,18 @@ def monetize_verified_compare_links(text: str) -> str:
     return text
 
 
+def ensure_compare_affiliate_disclosure(text: str) -> str:
+    """Ensure every monetized comparison has one accurate, generic disclosure."""
+    if 'data-cta="affiliate"' not in text:
+        return text
+
+    existing = re.compile(r'<p\b[^>]*>Affiliate disclosure:.*?</p>', re.DOTALL)
+    if existing.search(text):
+        return existing.sub(COMPARE_AFFILIATE_DISCLOSURE.strip(), text)
+
+    return text.replace("    </main>", f"{COMPARE_AFFILIATE_DISCLOSURE}\n    </main>", 1)
+
+
 def main() -> None:
     changed = 0
     scanned = 0
@@ -147,6 +165,7 @@ def main() -> None:
             updated = polish(original)
             if folder.name == "compare":
                 updated = monetize_verified_compare_links(updated)
+                updated = ensure_compare_affiliate_disclosure(updated)
             if updated != original:
                 path.write_text(updated, encoding="utf-8")
                 changed += 1


### PR DESCRIPTION
Safety follow-up to the Unbounce revenue routing change. Every comparison page that contains an affiliate CTA now receives one neutral affiliate disclosure during the production polish step. Existing product-specific disclosures are replaced with the generic accurate disclosure so a page does not incorrectly imply that only one button is monetized. The deploy workflow also blocks publication if a monetized comparison is missing the disclosure.