### PR TITLE
Launch Unbounce buyer-intent discount landing

### DIFF
--- a/projects/GlobalSaaSHub/public/best/unbounce-discount.html
+++ b/projects/GlobalSaaSHub/public/best/unbounce-discount.html
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Unbounce Discount (2026): 20% Off 3 Months or 35% Off Annual | COSHUMA</title>
+    <meta name="description" content="Use COSHUMA's verified Unbounce partner link for the current customer offer: 20% off the first 3 months or 35% off the first annual subscription, plus a 14-day free trial." />
+    <link rel="canonical" href="https://coshuma.com/best/unbounce-discount.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://coshuma.com/best/unbounce-discount.html" />
+    <meta property="og:title" content="Unbounce Discount (2026): 20% Off 3 Months or 35% Off Annual" />
+    <meta property="og:description" content="Current Unbounce partner offer, pricing and billing choice explained before you start the free trial." />
+
+    <script type="application/ld+json">
+    {
+      "@context":"https://schema.org",
+      "@type":"Article",
+      "headline":"Unbounce Discount (2026): 20% Off 3 Months or 35% Off Annual",
+      "description":"Buyer guide to the current Unbounce partner discount, free trial and public pricing.",
+      "mainEntityOfPage":"https://coshuma.com/best/unbounce-discount.html",
+      "publisher":{"@type":"Organization","name":"COSHUMA"},
+      "dateModified":"2026-09-05"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context":"https://schema.org",
+      "@type":"FAQPage",
+      "mainEntity":[
+        {
+          "@type":"Question",
+          "name":"What Unbounce discount do referrals get?",
+          "acceptedAnswer":{"@type":"Answer","text":"Unbounce's official Partner Program page currently says referrals get 20% off their first three months or 35% off their first year when they purchase an annual plan."}
+        },
+        {
+          "@type":"Question",
+          "name":"Does Unbounce have a free trial?",
+          "acceptedAnswer":{"@type":"Answer","text":"Yes. Unbounce's official pricing page currently advertises a 14-day free trial with no credit card required."}
+        },
+        {
+          "@type":"Question",
+          "name":"How long does Unbounce referral tracking last?",
+          "acceptedAnswer":{"@type":"Answer","text":"Unbounce's official Partner Program FAQ says referral cookies last for 90 days after a click and the 90-day window restarts if the person clicks the referral link again."}
+        }
+      ]
+    }
+    </script>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700;800;900&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <style>
+      body { font-family:'Inter',sans-serif; background:#0b0c10; color:#f1f5f9; }
+      h1,h2,h3 { font-family:'Outfit',sans-serif; }
+    </style>
+  </head>
+  <body class="min-h-screen bg-[#0b0c10] text-slate-100">
+    <header class="sticky top-0 z-50 border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md">
+      <div class="max-w-5xl mx-auto px-5 py-4 flex items-center justify-between gap-4">
+        <a href="/" class="flex items-center gap-3">
+          <div class="h-9 w-9 rounded-xl bg-purple-600 flex items-center justify-center font-black text-white">C</div>
+          <span class="font-extrabold tracking-tight text-white">COSHUMA</span>
+        </a>
+        <a href="/tool/unbounce.html" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 text-purple-200 hover:bg-purple-500/10">Full Unbounce pricing guide →</a>
+      </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-5 py-10 md:py-14 space-y-8">
+      <section class="rounded-3xl border border-purple-500/30 bg-[#121520] p-6 md:p-10 shadow-2xl space-y-7">
+        <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold border border-emerald-500/25 bg-emerald-500/10 text-emerald-300">Verified partner offer · Checked September 5, 2026</div>
+        <div class="space-y-4">
+          <h1 class="text-4xl md:text-6xl font-black tracking-tight text-white">Unbounce discount: 20% off 3 months or 35% off the first year</h1>
+          <p class="text-lg text-slate-300 leading-relaxed max-w-4xl">COSHUMA's verified Unbounce referral route unlocks the customer offer published by Unbounce's official Partner Program: 20% off the first three months, or 35% off the first year when you choose an annual plan. New customers also start with Unbounce's current 14-day free trial.</p>
+        </div>
+
+        <div class="grid md:grid-cols-3 gap-3">
+          <div class="rounded-2xl border border-purple-500/20 bg-purple-500/5 p-5">
+            <div class="text-[11px] uppercase tracking-wider font-extrabold text-purple-300">Monthly route</div>
+            <div class="text-2xl font-black text-white mt-1">20% off</div>
+            <div class="text-xs text-slate-400 mt-1">First 3 months through the verified partner route.</div>
+          </div>
+          <div class="rounded-2xl border border-blue-500/20 bg-blue-500/5 p-5">
+            <div class="text-[11px] uppercase tracking-wider font-extrabold text-blue-300">Annual route</div>
+            <div class="text-2xl font-black text-white mt-1">35% off</div>
+            <div class="text-xs text-slate-400 mt-1">First year when purchasing an annual plan, per Unbounce's Partner Program.</div>
+          </div>
+          <div class="rounded-2xl border border-emerald-500/20 bg-emerald-500/5 p-5">
+            <div class="text-[11px] uppercase tracking-wider font-extrabold text-emerald-300">Try before paying</div>
+            <div class="text-2xl font-black text-white mt-1">14 days free</div>
+            <div class="text-xs text-slate-400 mt-1">No credit card required on Unbounce's current pricing page.</div>
+          </div>
+        </div>
+
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="unbounce_discount_hero" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="px-7 py-4 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center font-extrabold hover:brightness-110 shadow-lg shadow-purple-950/40">Start 14-day trial + partner discount →</a>
+          <a data-cta="official" data-tool-id="unbounce" data-cta-source="unbounce_discount_official" href="https://unbounce.com/partner-program/" target="_blank" rel="noopener noreferrer" class="px-7 py-4 rounded-xl border border-slate-600 bg-slate-800 text-white text-center font-bold hover:bg-slate-700">Verify offer on Unbounce →</a>
+        </div>
+        <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission if an eligible Unbounce purchase is attributed through the verified partner link, at no extra cost to you. Discount eligibility and final checkout pricing are controlled by Unbounce.</p>
+      </section>
+
+      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-5">
+        <div>
+          <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Current public pricing</div>
+          <h2 class="text-3xl font-black text-white mt-1">Monthly vs yearly billing before the partner offer</h2>
+          <p class="text-sm text-slate-400 mt-2">Unbounce's official plan comparison currently lists these base rates. The yearly column is the published monthly equivalent for annual billing. The separate partner offer is applied by Unbounce; do not assume discounts stack beyond what checkout confirms.</p>
+        </div>
+        <div class="overflow-x-auto rounded-2xl border border-[#2a2e42]">
+          <table class="w-full min-w-[720px] text-left text-sm">
+            <thead class="bg-[#0d1018] text-slate-300">
+              <tr><th class="p-4">Plan</th><th class="p-4">Monthly billing</th><th class="p-4">Yearly billing equivalent</th><th class="p-4">Best fit</th></tr>
+            </thead>
+            <tbody class="divide-y divide-[#222538]">
+              <tr><td class="p-4 font-bold text-white">Starter</td><td class="p-4">$29/mo</td><td class="p-4">$22/mo</td><td class="p-4 text-slate-300">First landing pages; up to 5 pages</td></tr>
+              <tr><td class="p-4 font-bold text-white">Build</td><td class="p-4">$99/mo</td><td class="p-4">$74/mo</td><td class="p-4 text-slate-300">Unlimited landing pages and broader campaign production</td></tr>
+              <tr><td class="p-4 font-bold text-white">Experiment</td><td class="p-4">$149/mo</td><td class="p-4">$112/mo</td><td class="p-4 text-slate-300">Unlimited A/B testing and variants</td></tr>
+              <tr><td class="p-4 font-bold text-white">Optimize</td><td class="p-4">$249/mo</td><td class="p-4">$187/mo</td><td class="p-4 text-slate-300">AI traffic optimization and deeper insights</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-xs text-slate-500">Prices checked against Unbounce's official plan comparison on September 5, 2026. Concierge and Agency plans use custom pricing. SaaS prices can change, so verify checkout before purchase.</p>
+        <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="unbounce_discount_pricing" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="inline-block px-6 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-extrabold text-sm">Check your Unbounce partner offer →</a>
+      </section>
+
+      <section class="grid md:grid-cols-2 gap-4">
+        <div class="rounded-3xl border border-emerald-500/20 bg-emerald-500/5 p-6 space-y-3">
+          <h2 class="text-xl font-black text-white">Choose monthly when...</h2>
+          <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+            <li>You are still validating whether Unbounce improves your campaign workflow.</li>
+            <li>You want lower commitment after the free trial.</li>
+            <li>The 20% first-three-month partner offer is more useful than locking into a full year.</li>
+          </ul>
+        </div>
+        <div class="rounded-3xl border border-blue-500/20 bg-blue-500/5 p-6 space-y-3">
+          <h2 class="text-xl font-black text-white">Choose annual when...</h2>
+          <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
+            <li>You already know you need landing pages throughout the year.</li>
+            <li>You value Unbounce's published annual billing rates.</li>
+            <li>The 35% first-year partner offer is confirmed at checkout for your purchase.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-5">
+        <div>
+          <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Tracking facts</div>
+          <h2 class="text-3xl font-black text-white mt-1">Use the verified partner link before signing up</h2>
+        </div>
+        <p class="text-sm text-slate-300 leading-relaxed">Unbounce's official Partner Program FAQ says referral tracking uses a 90-day cookie. If the referral link is clicked again, Unbounce says the 90-day window restarts. COSHUMA therefore uses the verified PartnerStack URL rather than a generic Unbounce homepage link for revenue CTAs.</p>
+        <div class="rounded-2xl border border-amber-500/20 bg-amber-500/5 p-5 text-sm text-slate-300">Tip: complete the trial signup from the same browser session after using the partner link when practical. Attribution is ultimately controlled by Unbounce and PartnerStack, so COSHUMA does not claim a referral until the partner dashboard confirms it.</div>
+      </section>
+
+      <section class="rounded-3xl border border-purple-500/30 bg-purple-500/5 p-6 md:p-8 text-center space-y-4">
+        <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Decision path</div>
+        <h2 class="text-3xl font-black text-white">Start with the free trial, then choose the billing route that fits</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto">The partner offer reduces the barrier to becoming a paid customer, but the best plan still depends on how many landing pages, visitors, users and optimization features you actually need.</p>
+        <div class="flex flex-col sm:flex-row justify-center gap-3 pt-1">
+          <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="unbounce_discount_bottom" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="px-7 py-4 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-extrabold">Start Unbounce trial + partner offer →</a>
+          <a href="/tool/unbounce.html" class="px-7 py-4 rounded-xl border border-slate-600 bg-slate-800 hover:bg-slate-700 text-white font-bold">Read full Unbounce guide →</a>
+        </div>
+      </section>
+    </main>
+
+    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
+      <div class="max-w-5xl mx-auto px-5">© 2026 COSHUMA · Independent SaaS buyer guides</div>
+    </footer>
+    <script src="/affiliate-attribution.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Adds a focused Unbounce discount / billing-choice landing built around the verified PartnerStack revenue URL. Claims are limited to current official Unbounce pricing and Partner Program terms checked 2026-09-05. Includes affiliate disclosure, FAQ structured data, and source-specific CTA attribution. No paid services or new subscriptions.