### PR TITLE
Fix Murf revenue leak in Synthflow comparison

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/synthflow-ai-vs-murf-ai.html
+++ b/projects/GlobalSaaSHub/public/compare/synthflow-ai-vs-murf-ai.html
@@ -3,34 +3,27 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Synthflow AI vs Murf AI Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Synthflow AI vs Murf AI. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
-
+    <title>Synthflow AI vs Murf AI (2026): Voice Agents vs AI Voiceovers | COSHUMA</title>
+    <meta name="description" content="Compare Synthflow AI vs Murf AI in 2026. See which fits AI phone agents versus studio-quality voiceovers, current public pricing paths, and a verified COSHUMA Murf partner link." />
     <link rel="canonical" href="https://coshuma.com/compare/synthflow-ai-vs-murf-ai.html" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/compare/synthflow-ai-vs-murf-ai.html" />
-    <meta property="og:title" content="Synthflow AI vs Murf AI Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Synthflow AI and Murf AI by pricing, features, and verified public information." />
-
+    <meta property="og:title" content="Synthflow AI vs Murf AI (2026): Voice Agents vs AI Voiceovers" />
+    <meta property="og:description" content="A buyer-focused comparison of Synthflow AI for phone agents and Murf AI for voiceover production." />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebPage",
-      "name": "Synthflow AI vs Murf AI Comparison",
+      "name": "Synthflow AI vs Murf AI (2026)",
       "url": "https://coshuma.com/compare/synthflow-ai-vs-murf-ai.html",
-      "description": "Compare Synthflow AI and Murf AI by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
+      "description": "Compare Synthflow AI and Murf AI by primary use case, pricing path and buyer fit.",
+      "isPartOf": {"@type": "WebSite", "name": "COSHUMA", "url": "https://coshuma.com/"},
       "about": [
         {"@type": "SoftwareApplication", "name": "Synthflow AI", "url": "https://coshuma.com/tool/synthflow-ai.html"},
         {"@type": "SoftwareApplication", "name": "Murf AI", "url": "https://coshuma.com/tool/murf-ai.html"}
       ]
     }
     </script>
-    
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -44,129 +37,80 @@
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div>
+          <span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← All AI tools</a>
       </div>
     </header>
 
     <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
+      <section class="text-center space-y-4">
+        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Buyer guide · Updated September 5, 2026</div>
         <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Synthflow AI vs Murf AI</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Voice & Speech AI tool.
-        </p>
-      </div>
+        <p class="text-slate-300 text-base max-w-3xl mx-auto leading-7">These tools overlap around AI voice, but they solve different buying problems. Synthflow is built around autonomous phone agents and call workflows. Murf is built around producing natural AI voiceovers, narration and studio content.</p>
+      </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Synthflow AI if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-emerald-500/30 space-y-4">
+        <h2 class="text-xl font-bold text-white">Fast decision</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20">
+            <div class="font-extrabold text-purple-300 mb-2">Choose Synthflow AI when...</div>
+            <p class="text-slate-300 leading-6">You need AI agents to answer or place phone calls, qualify leads, route conversations, book appointments, transfer callers, and connect into business workflows.</p>
           </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Murf AI if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20">
+            <div class="font-extrabold text-blue-300 mb-2">Choose Murf AI when...</div>
+            <p class="text-slate-300 leading-6">You need polished text-to-speech for videos, presentations, training, ads or other produced content, with commercial-use features on paid plans.</p>
           </div>
         </div>
-      </div>
+      </section>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/synthflow-ai.html" class="hover:text-purple-300">Synthflow AI</a>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
+        <h2 class="text-xl font-bold text-white">What you are actually buying</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-3">
+            <h3 class="font-extrabold text-white">Synthflow AI</h3>
+            <ul class="space-y-2 text-sm text-slate-300">
+              <li>✓ AI phone-agent workflows</li>
+              <li>✓ Real-time booking and human transfer actions</li>
+              <li>✓ API and integrations</li>
+              <li>✓ Designed for operational call automation</li>
+            </ul>
+            <p class="text-xs text-slate-400 leading-5">Synthflow publishes multiple pricing paths for different customer segments. Its public materials include self-serve examples as well as enterprise contracts, so check the live pricing page before buying.</p>
+            <a data-cta="official" data-tool-id="synthflow-ai" data-cta-source="compare_synthflow_murf_synthflow" href="https://synthflow.ai/pricing" target="_blank" rel="noopener noreferrer" class="block py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Check Synthflow live pricing →</a>
           </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/murf-ai.html" class="hover:text-blue-300">Murf AI</a>
-          </div>
-        </div>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">Varies by paid referral plan</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-3">
+            <h3 class="font-extrabold text-white">Murf AI</h3>
+            <ul class="space-y-2 text-sm text-slate-300">
+              <li>✓ Free plan at $0, no credit card required</li>
+              <li>✓ Creator from $19/month when billed annually</li>
+              <li>✓ Business from $66/month when billed annually</li>
+              <li>✓ 200+ voices plus commercial rights on paid plans</li>
+            </ul>
+            <p class="text-xs text-slate-400 leading-5">Murf's official affiliate FAQ says it does not offer a special new-user coupon through affiliates. The value of the link below is attribution to COSHUMA, not an extra customer discount.</p>
+            <a data-cta="affiliate" data-tool-id="murf-ai" data-cta-source="compare_synthflow_murf_murf" href="https://get.murf.ai/fqac0vixj0qs" target="_blank" rel="sponsored noopener noreferrer" class="block py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Try Murf via verified partner link →</a>
           </div>
         </div>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Synthflow AI Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ No-code voice AI agent builder</div>
-<div>✓ Automated customer interactions</div>
-<div>✓ Appointment scheduling automation</div>
-<div>✓ Lead qualification & support</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Murf AI Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Studio-quality AI voices</div>
-<div>✓ Custom voice cloning</div>
-<div>✓ Speech-to-text editor</div>
-<div>✓ Background music and sound</div>
-            </div>
-          </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-4">
+        <h2 class="text-xl font-bold text-white">Bottom line</h2>
+        <p class="text-sm text-slate-300 leading-7">For most buyers, this is not a close feature-for-feature contest. Pick <strong class="text-white">Synthflow</strong> when the voice needs to participate in live calls and execute business actions. Pick <strong class="text-white">Murf</strong> when the voice itself is the content you are producing. If your goal is YouTube narration, course audio, presentation voiceover or marketing video audio, Murf is the more direct fit.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 pt-2">
+          <a data-cta="official" data-tool-id="synthflow-ai" data-cta-source="compare_synthflow_murf_bottom_synthflow" href="https://synthflow.ai/pricing" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl border border-purple-500/40 bg-purple-500/10 hover:bg-purple-500/20 font-extrabold text-xs text-purple-200 text-center transition-all">Explore Synthflow →</a>
+          <a data-cta="affiliate" data-tool-id="murf-ai" data-cta-source="compare_synthflow_murf_bottom_murf" href="https://get.murf.ai/fqac0vixj0qs" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Start with Murf →</a>
         </div>
+        <p data-affiliate-disclosure="compare" class="text-[11px] text-slate-500 leading-5">Affiliate disclosure: COSHUMA may earn a commission if you sign up for or purchase Murf through our verified partner link, at no extra cost to you. Synthflow links on this page are ordinary official links.</p>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://synthflow.ai/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Synthflow AI →</a>
-          <a href="https://murf.ai/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Murf AI →</a>
-        </div>
-      </div>
+      <section class="text-xs text-slate-500 leading-6 border-t border-[#222538] pt-5">
+        <strong class="text-slate-400">Sources checked:</strong> Murf official pricing and affiliate-program pages; Synthflow official pricing and product materials. Pricing can change, so the vendor checkout page controls the final amount.
+      </section>
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI software comparison.</div>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
## Why
The live Synthflow AI vs Murf AI comparison still sent Murf clicks to the generic `murf.ai` homepage even though COSHUMA has a verified Murf PartnerStack referral link.

## Changes
- replaces the generic Murf CTA with the verified referral URL from the Murf welcome email
- adds affiliate click attribution via `data-cta`, `data-tool-id`, and distinct `data-cta-source` values
- adds an explicit affiliate disclosure
- rewrites low-quality autogenerated decision copy into buyer-focused guidance
- refreshes Murf pricing language against the current official pricing page
- keeps Synthflow links non-affiliate and points pricing CTAs to the official pricing page

No paid services or subscriptions used.