### PR TITLE
Launch Databox Genie buyer-intent revenue landing

### DIFF
--- a/projects/GlobalSaaSHub/index.html
+++ b/projects/GlobalSaaSHub/index.html
@@ -64,7 +64,8 @@
           <a href="/best/crm-for-marketing-agencies.html">Best CRM for Marketing Agencies in 2026</a> ·
           <a href="/best/landing-page-builders.html">Best Landing Page Builders in 2026</a> ·
           <a href="/best/b2b-email-list-providers.html">Best B2B Email List Providers in 2026</a> ·
-          <a href="/best/brand24-ai-visibility.html">Brand24 AI Visibility & GEO Tracking</a><br />
+          <a href="/best/brand24-ai-visibility.html">Brand24 AI Visibility & GEO Tracking</a> ·
+          <a href="/best/databox-genie-ai-analyst.html">Databox Genie AI Analyst review</a><br />
           <strong>Popular pricing and review guides:</strong><br />
           <a href="/tool/descript.html">Descript pricing & review</a> ·
           <a href="/tool/elevenlabs.html">ElevenLabs pricing & review</a> ·

--- a/projects/GlobalSaaSHub/public/best/databox-genie-ai-analyst.html
+++ b/projects/GlobalSaaSHub/public/best/databox-genie-ai-analyst.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Databox Genie AI Analyst Review (2026): Pricing, Integrations & Free Trial | COSHUMA</title>
+    <meta name="description" content="Databox Genie AI Analyst review for 2026: see current pricing, AI credit limits, 130+ integrations, dashboard/report automation, free-plan limits and the 14-day no-card Growth trial." />
+    <link rel="canonical" href="https://coshuma.com/best/databox-genie-ai-analyst.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://coshuma.com/best/databox-genie-ai-analyst.html" />
+    <meta property="og:title" content="Databox Genie AI Analyst Review (2026): Pricing, Integrations & Free Trial" />
+    <meta property="og:description" content="A buyer-focused look at Databox Genie, including AI credits, 130+ integrations, reporting workflows and the 14-day Growth trial." />
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "Databox Genie AI Analyst Review (2026): Pricing, Integrations & Free Trial",
+      "dateModified": "2026-09-05",
+      "author": {"@type": "Organization", "name": "COSHUMA"},
+      "publisher": {"@type": "Organization", "name": "COSHUMA"},
+      "mainEntityOfPage": "https://coshuma.com/best/databox-genie-ai-analyst.html"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "What is Databox Genie?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Genie is Databox's AI Analyst. It can answer questions about connected business data, help create metrics and dashboards, analyze performance, and turn conversations into shareable reports or other artifacts."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How much does Databox cost?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "As checked on September 5, 2026, Databox's annual-billing prices are Free at $0 per month, Analyst at $64 per month, Pro at $159 per month, and Growth at $399 per month. Databox also advertises a 14-day Growth-plan trial with no credit card required."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How many AI credits are included?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Databox currently lists 50 AI credits per month on Free, 500 on Analyst, 1,500 on Pro, and 4,000 on Growth. Credits are shared across the account and reset monthly."
+          }
+        }
+      ]
+    }
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <style>
+      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
+      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
+    </style>
+    <script src="/affiliate-attribution.js" defer></script>
+  </head>
+  <body class="min-h-screen flex flex-col justify-between">
+    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+      <div class="max-w-6xl mx-auto flex items-center justify-between">
+        <a href="/" class="flex items-center gap-3">
+          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div>
+          <span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span>
+        </a>
+        <a href="/tool/databox.html" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">Databox pricing guide</a>
+      </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
+      <section class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-7">
+        <div class="inline-flex items-center px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">AI analytics buyer guide · updated Sep 5, 2026</div>
+        <div class="space-y-4">
+          <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Databox Genie AI Analyst Review (2026)</h1>
+          <p class="text-base text-slate-300 leading-relaxed">Genie sits on top of your Databox data and lets you ask performance questions in plain language. It can analyze trends, create metrics and dashboards, and turn conversations into shareable reports. For teams already juggling GA4, HubSpot, Salesforce or other business data, the main value is getting answers without jumping between separate dashboards.</p>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-[1fr_auto] gap-5 items-center p-5 rounded-2xl bg-purple-500/5 border border-purple-500/20">
+          <div>
+            <h2 class="text-xl font-bold text-white">Try Genie with your own business data</h2>
+            <p class="text-sm text-slate-300 mt-2 leading-relaxed">Databox currently offers a 14-day Growth-plan trial with no credit card required. That gives you a practical way to connect real data sources and test whether Genie's answers and reporting workflow save enough time to justify a paid plan.</p>
+            <p class="text-[11px] text-slate-500 mt-2">Affiliate disclosure: this button uses COSHUMA's verified Databox referral link. COSHUMA may earn a commission if a referred user becomes a customer, at no extra cost to the user.</p>
+          </div>
+          <a data-cta="affiliate" data-tool-id="databox" data-cta-source="databox_genie_hero" href="https://databox.com?aff_id=15298659&fp_ref=sangkwon-72c9ec" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-extrabold text-sm text-center whitespace-nowrap">Try Databox Free →</a>
+        </div>
+      </section>
+
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">What Genie can do</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="font-bold text-white">Ask performance questions</div>
+            <p class="text-sm text-slate-400 mt-2 leading-relaxed">Ask why conversions changed, which campaigns drive results, or how this week compares with last week, using the data already connected to Databox.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="font-bold text-white">Build metrics and dashboards</div>
+            <p class="text-sm text-slate-400 mt-2 leading-relaxed">Describe what you want to see and Genie can help create the metrics, charts and dashboards needed for the analysis.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="font-bold text-white">Create shareable reports</div>
+            <p class="text-sm text-slate-400 mt-2 leading-relaxed">Databox says Genie can turn a conversation into a report, deck or interactive artifact that can be shared by public link or downloaded.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="font-bold text-white">Work across 130+ integrations</div>
+            <p class="text-sm text-slate-400 mt-2 leading-relaxed">Genie works with data connected to Databox, including native integrations such as Google Analytics 4, HubSpot and Salesforce, plus databases and spreadsheets.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <div>
+          <h2 class="text-2xl font-black text-white">Databox pricing and AI credits</h2>
+          <p class="text-sm text-slate-400 mt-1">Official annual-billing prices checked September 5, 2026. Monthly billing is higher and live checkout pricing can change.</p>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs font-bold text-purple-300 uppercase tracking-wider">Free</div>
+            <div class="text-2xl font-black text-white mt-1">$0/mo</div>
+            <div class="text-xs text-slate-400 mt-2">3 data sources, 1 user, limited BI features and 50 AI credits per month.</div>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs font-bold text-purple-300 uppercase tracking-wider">Analyst</div>
+            <div class="text-2xl font-black text-white mt-1">$64/mo</div>
+            <div class="text-xs text-slate-400 mt-2">Annual billing. 5 data sources, 1 user, unlimited dashboards/reports and 500 AI credits per month.</div>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs font-bold text-purple-300 uppercase tracking-wider">Pro</div>
+            <div class="text-2xl font-black text-white mt-1">$159/mo</div>
+            <div class="text-xs text-slate-400 mt-2">Annual billing. Unlimited users, 1,500 AI credits per month, hourly sync and unlimited dashboards/reports.</div>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/30">
+            <div class="text-xs font-bold text-purple-300 uppercase tracking-wider">Growth</div>
+            <div class="text-2xl font-black text-white mt-1">$399/mo</div>
+            <div class="text-xs text-slate-400 mt-2">Annual billing. 4,000 AI credits per month, datasets, forecasting and faster sync.</div>
+          </div>
+        </div>
+        <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/20 flex flex-col md:flex-row gap-4 items-start md:items-center justify-between">
+          <div class="text-sm text-slate-300 leading-relaxed">AI credits are shared across the account and reset monthly. If Genie becomes central to your reporting workflow, compare the credit allowance—not just the dashboard features—before choosing a plan.</div>
+          <a data-cta="affiliate" data-tool-id="databox" data-cta-source="databox_genie_pricing" href="https://databox.com?aff_id=15298659&fp_ref=sangkwon-72c9ec" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-extrabold text-sm whitespace-nowrap">Start trial →</a>
+        </div>
+      </section>
+
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">Who gets the most value?</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20">
+            <div class="font-bold text-emerald-300">Strong fit</div>
+            <ul class="mt-3 space-y-2 text-slate-300 list-disc list-inside">
+              <li>Marketing or revenue teams with data spread across multiple tools</li>
+              <li>Agencies that repeatedly build client dashboards and reports</li>
+              <li>Operators who want natural-language analysis on trusted internal metrics</li>
+            </ul>
+          </div>
+          <div class="p-5 rounded-2xl bg-amber-500/5 border border-amber-500/20">
+            <div class="font-bold text-amber-300">Check before paying</div>
+            <ul class="mt-3 space-y-2 text-slate-300 list-disc list-inside">
+              <li>Genie's usefulness depends on the quality and completeness of connected data</li>
+              <li>AI usage is limited by monthly credits</li>
+              <li>Lower-priced plans cap users or data sources</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="p-7 rounded-3xl bg-[#131520] border border-purple-500/30 text-center space-y-4">
+        <h2 class="text-2xl font-black text-white">Best way to evaluate Databox Genie</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto">Connect a few real sources, ask Genie questions your team already spends time answering, and compare the result with your current manual reporting process. If it reliably saves time, then choose a plan based on user count, data-source needs and monthly AI credits.</p>
+        <a data-cta="affiliate" data-tool-id="databox" data-cta-source="databox_genie_bottom" href="https://databox.com?aff_id=15298659&fp_ref=sangkwon-72c9ec" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-4 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-extrabold text-sm">Try Databox via Verified Partner Link →</a>
+        <div class="text-[11px] text-slate-500">Official sources: <a class="underline hover:text-slate-300" href="https://databox.com/ai-analyst" target="_blank" rel="noopener noreferrer">Databox Genie AI Analyst</a> · <a class="underline hover:text-slate-300" href="https://databox.com/pricing" target="_blank" rel="noopener noreferrer">Databox pricing</a></div>
+      </section>
+    </main>
+
+    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS buyer guides.</div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
Adds a dedicated Databox Genie AI Analyst buyer guide using the verified Databox partner URL already confirmed in COSHUMA's affiliate email. The page separates hero/pricing/bottom affiliate attribution, uses current official Databox pricing and AI-credit information, and is linked from the homepage crawl path. No paid services or new subscriptions are introduced.