### PR TITLE
Monetize verified Brand24 comparison CTAs

### DIFF
--- a/projects/GlobalSaaSHub/scripts/polish_public_copy.py
+++ b/projects/GlobalSaaSHub/scripts/polish_public_copy.py
@@ -40,6 +40,8 @@ TEXT_REPLACEMENTS = {
 VERIFIED_COMPARE_LINK_REPLACEMENTS = {
     '<a href="https://unbounce.com/" target="_blank" rel="noopener noreferrer"':
         '<a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="compare-generated" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer"',
+    '<a href="https://brand24.com/" target="_blank" rel="noopener noreferrer"':
+        '<a data-cta="affiliate" data-tool-id="brand24" data-cta-source="compare-generated" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer"',
 }
 
 COMPARE_AFFILIATE_DISCLOSURE = (


### PR DESCRIPTION
## What changed
- Generated comparison CTAs that pointed to the generic Brand24 homepage now route through the repository-verified Brand24 partner URL.
- Adds `rel="sponsored"` plus affiliate attribution metadata (`data-cta`, `data-tool-id`, `data-cta-source`).
- Reuses the existing comparison affiliate-disclosure safeguard.

## Why
Generic Brand24 homepage CTAs bypass affiliate attribution even though COSHUMA already has a verified Brand24 revenue route. This closes that no-cost revenue leak during every production build without touching unrelated vendor links.

No paid services or subscriptions are introduced.