### PR TITLE
Auto-monetize verified comparison CTAs from affiliate data

### DIFF
--- a/projects/GlobalSaaSHub/package.json
+++ b/projects/GlobalSaaSHub/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "node scripts/monetize_verified_compare_links.mjs && vite build",
     "test:links": "python scripts/tests/test_link_integrity.py",
     "lint": "oxlint",
     "preview": "vite preview"

--- a/projects/GlobalSaaSHub/scripts/monetize_verified_compare_links.mjs
+++ b/projects/GlobalSaaSHub/scripts/monetize_verified_compare_links.mjs
@@ -1,0 +1,95 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_DIR = path.resolve(SCRIPT_DIR, '..');
+const TOOLS_PATH = path.join(PROJECT_DIR, 'data', 'tools.json');
+const COMPARE_DIR = path.join(PROJECT_DIR, 'public', 'compare');
+
+const DISCLOSURE =
+  '      <p data-affiliate-disclosure="compare" class="text-[11px] leading-relaxed text-slate-500">' +
+  'Affiliate disclosure: Some buttons on this comparison use verified COSHUMA partner links. ' +
+  'COSHUMA may earn a commission if you become a paying customer after using them, at no extra cost to you.' +
+  '</p>';
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function isSafeHttpUrl(value) {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
+const tools = JSON.parse(fs.readFileSync(TOOLS_PATH, 'utf8'));
+const verifiedRoutes = tools.filter((tool) =>
+  tool?.id &&
+  tool?.affiliate_verified === true &&
+  tool?.affiliate_status === 'approved_tracking' &&
+  isSafeHttpUrl(tool?.affiliate_url) &&
+  isSafeHttpUrl(tool?.official_url) &&
+  tool.affiliate_url !== tool.official_url
+);
+
+let filesChanged = 0;
+let linksMonetized = 0;
+const changedByTool = new Map();
+
+for (const filename of fs.readdirSync(COMPARE_DIR)) {
+  if (!filename.endsWith('.html')) continue;
+
+  const filePath = path.join(COMPARE_DIR, filename);
+  const original = fs.readFileSync(filePath, 'utf8');
+  let updated = original;
+  let changedThisFile = 0;
+
+  for (const tool of verifiedRoutes) {
+    const exactGeneratedAnchor = new RegExp(
+      `<a href="${escapeRegExp(tool.official_url)}" target="_blank" rel="noopener noreferrer"`,
+      'g'
+    );
+    const matches = updated.match(exactGeneratedAnchor)?.length || 0;
+    if (!matches) continue;
+
+    const replacement =
+      `<a data-cta="affiliate" data-tool-id="${tool.id}" data-cta-source="compare-generated-auto" ` +
+      `href="${tool.affiliate_url}" target="_blank" rel="sponsored noopener noreferrer"`;
+
+    updated = updated.replace(exactGeneratedAnchor, () => replacement);
+    changedThisFile += matches;
+    linksMonetized += matches;
+    changedByTool.set(tool.id, (changedByTool.get(tool.id) || 0) + matches);
+  }
+
+  if (!changedThisFile) continue;
+
+  if (!updated.includes('/affiliate-attribution.js')) {
+    updated = updated.replace(
+      /\s*<\/head>/,
+      '\n    <script defer src="/affiliate-attribution.js"></script>\n  </head>'
+    );
+  }
+
+  if (!updated.includes('data-affiliate-disclosure="compare"')) {
+    updated = updated.replace(/(?=\s*<\/main>)/, `${DISCLOSURE}\n`);
+  }
+
+  fs.writeFileSync(filePath, updated, 'utf8');
+  filesChanged += 1;
+}
+
+const breakdown = [...changedByTool.entries()]
+  .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+  .map(([toolId, count]) => `${toolId}:${count}`)
+  .join(', ');
+
+console.log(
+  `monetize_verified_compare_links: verified_routes=${verifiedRoutes.length} ` +
+  `files_changed=${filesChanged} links_monetized=${linksMonetized}` +
+  (breakdown ? ` [${breakdown}]` : '')
+);


### PR DESCRIPTION
## Revenue impact
COSHUMA already stores verified affiliate URLs and `approved_tracking` state in `data/tools.json`, but generated comparison pages can still ship exact vendor-homepage CTAs that bypass revenue attribution unless each vendor is hardcoded into `polish_public_copy.py`.

## Changes
- add a build-time, data-driven monetization pass for comparison pages
- only replace exact generated anchors whose tool has `affiliate_verified=true`, `affiliate_status=approved_tracking`, valid HTTP(S) official/affiliate URLs, and distinct URLs
- add affiliate click metadata, `rel="sponsored"`, attribution script when missing, and a neutral disclosure when missing
- run the pass automatically before every Vite production build

This removes the need to add one hardcoded vendor at a time while preserving the rule that generic dashboard/onboarding links are never treated as revenue URLs. No paid services or subscriptions are introduced.