### PR TITLE
[COSHUMA] Launch targeted B2B email list buyer landing

### DIFF
--- a/projects/GlobalSaaSHub/public/best/where-to-buy-targeted-b2b-email-lists.html
+++ b/projects/GlobalSaaSHub/public/best/where-to-buy-targeted-b2b-email-lists.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Where to Buy Targeted B2B Email Lists in 2026 | COSHUMA</title>
+  <meta name="description" content="Where to buy targeted B2B email lists in 2026: compare buying models, verification, free samples and the safest way to test a list before paying for more data." />
+  <link rel="canonical" href="https://coshuma.com/best/where-to-buy-targeted-b2b-email-lists.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="COSHUMA" />
+  <meta property="og:title" content="Where to Buy Targeted B2B Email Lists in 2026" />
+  <meta property="og:description" content="A buyer-focused checklist for purchasing targeted B2B contact data without overcommitting to a subscription." />
+  <meta property="og:url" content="https://coshuma.com/best/where-to-buy-targeted-b2b-email-lists.html" />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"Where to Buy Targeted B2B Email Lists in 2026",
+    "dateModified":"2026-09-05",
+    "author":{"@type":"Organization","name":"COSHUMA"},
+    "publisher":{"@type":"Organization","name":"COSHUMA"},
+    "mainEntityOfPage":"https://coshuma.com/best/where-to-buy-targeted-b2b-email-lists.html"
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {
+        "@type":"Question",
+        "name":"Can I test Bookyourdata before buying credits?",
+        "acceptedAnswer":{"@type":"Answer","text":"Bookyourdata currently offers 10 free credits with no credit card and no subscription requirement."}
+      },
+      {
+        "@type":"Question",
+        "name":"Do Bookyourdata credits expire?",
+        "acceptedAnswer":{"@type":"Answer","text":"Bookyourdata states that purchased credits do not expire."}
+      },
+      {
+        "@type":"Question",
+        "name":"What deliverability guarantee does Bookyourdata advertise?",
+        "acceptedAnswer":{"@type":"Answer","text":"Bookyourdata advertises a 97% deliverability guarantee and says replacement credits are provided when a qualifying purchased list falls below that standard."}
+      }
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>body{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}</style>
+</head>
+<body class="bg-[#08090d] text-slate-100 antialiased">
+  <header class="border-b border-white/10 bg-[#0c0e14]">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-5 py-4">
+      <a href="/" class="text-xl font-black tracking-tight text-white">COSHUMA</a>
+      <div class="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Independent AI & SaaS buyer guides</div>
+    </div>
+  </header>
+
+  <main class="mx-auto max-w-6xl px-5 py-12 sm:py-16">
+    <nav class="mb-7 text-sm text-slate-500"><a class="hover:text-white" href="/">Home</a> <span class="px-2">/</span> Where to Buy Targeted B2B Email Lists</nav>
+
+    <section class="max-w-4xl">
+      <div class="mb-5 inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">Product facts checked Sep 5, 2026</div>
+      <h1 class="text-4xl font-black tracking-[-0.04em] text-white sm:text-6xl">Where to Buy Targeted B2B Email Lists in 2026</h1>
+      <p class="mt-5 max-w-3xl text-lg leading-8 text-slate-400">If your goal is to buy a targeted list rather than commit to a recurring sales-data subscription, start with a provider that lets you test the data first. Bookyourdata is the clearest current fit we found for that buying model because it offers 10 free credits, no card requirement, pay-as-you-go purchases and non-expiring credits.</p>
+      <div class="mt-7 flex flex-col gap-3 sm:flex-row">
+        <a data-cta="affiliate" data-tool-id="bookyourdata" data-cta-source="targeted_b2b_email_lists_hero" href="https://join.bookyourdata.com/swcyqmumr3s5" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-violet-600 px-6 py-4 text-center font-black text-white hover:bg-violet-500">Get 10 free Bookyourdata leads →</a>
+        <a href="/best/b2b-email-list-providers.html" class="rounded-xl border border-white/10 px-6 py-4 text-center font-bold text-slate-300 hover:bg-white/5">Compare B2B data providers</a>
+      </div>
+      <p class="mt-3 text-xs leading-5 text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if you use the Bookyourdata partner link, at no extra cost to you.</p>
+    </section>
+
+    <section class="mt-12 grid gap-4 md:grid-cols-4">
+      <div class="rounded-2xl border border-white/10 bg-white/[0.04] p-5"><div class="text-xs font-black uppercase tracking-wider text-violet-300">Free test</div><div class="mt-2 text-2xl font-black">10 credits</div><p class="mt-2 text-sm leading-6 text-slate-400">Bookyourdata says its free pack requires no credit card or subscription.</p></div>
+      <div class="rounded-2xl border border-white/10 bg-white/[0.04] p-5"><div class="text-xs font-black uppercase tracking-wider text-violet-300">Buying model</div><div class="mt-2 text-2xl font-black">Pay as you go</div><p class="mt-2 text-sm leading-6 text-slate-400">Buy only the credits you need rather than taking a recurring plan.</p></div>
+      <div class="rounded-2xl border border-white/10 bg-white/[0.04] p-5"><div class="text-xs font-black uppercase tracking-wider text-violet-300">Credit policy</div><div class="mt-2 text-2xl font-black">No expiry</div><p class="mt-2 text-sm leading-6 text-slate-400">Bookyourdata states that purchased credits do not expire.</p></div>
+      <div class="rounded-2xl border border-white/10 bg-white/[0.04] p-5"><div class="text-xs font-black uppercase tracking-wider text-violet-300">Data guarantee</div><div class="mt-2 text-2xl font-black">97%</div><p class="mt-2 text-sm leading-6 text-slate-400">Its public guarantee page advertises 97% deliverability with replacement credits for qualifying shortfalls.</p></div>
+    </section>
+
+    <section class="mt-14 grid gap-6 lg:grid-cols-[1.25fr_0.75fr]">
+      <article class="rounded-3xl border border-violet-400/25 bg-[#11131a] p-6 sm:p-8">
+        <div class="text-xs font-black uppercase tracking-[0.2em] text-violet-300">Best fit for a direct list purchase</div>
+        <h2 class="mt-2 text-3xl font-black">Why Bookyourdata is a low-commitment place to start</h2>
+        <p class="mt-4 leading-7 text-slate-300">For a first purchase, the key advantage is not database size by itself. It is the ability to test your targeting and export quality before spending more. Bookyourdata currently says each credit reveals one contact, its free pack includes 10 credits, and paid credits never expire.</p>
+        <p class="mt-4 leading-7 text-slate-300">The platform also advertises real-time verification and a 97% deliverability guarantee. If a purchased list falls below the stated threshold under the guarantee terms, Bookyourdata says it adds replacement data credits.</p>
+        <div class="mt-6 rounded-2xl border border-emerald-400/20 bg-emerald-400/[0.06] p-5">
+          <div class="font-black text-emerald-200">Practical buying sequence</div>
+          <ol class="mt-3 space-y-2 text-sm leading-6 text-slate-300">
+            <li>1. Build a narrow target profile by industry, role and geography.</li>
+            <li>2. Use the 10 free credits to inspect fit and export quality.</li>
+            <li>3. Test a small outreach batch before purchasing a larger pack.</li>
+            <li>4. Scale only if the list produces useful conversations for your workflow.</li>
+          </ol>
+        </div>
+      </article>
+
+      <aside class="rounded-3xl border border-white/10 bg-white/[0.035] p-6">
+        <h2 class="text-2xl font-black">What to verify before buying any B2B list</h2>
+        <ul class="mt-5 space-y-4 text-sm leading-6 text-slate-300">
+          <li><strong class="text-white">Verification timing:</strong> Is the email checked when you export it?</li>
+          <li><strong class="text-white">Refund or replacement policy:</strong> What happens when contacts bounce?</li>
+          <li><strong class="text-white">Contract pressure:</strong> Do credits expire or require a monthly commitment?</li>
+          <li><strong class="text-white">Targeting depth:</strong> Can you filter tightly enough for the exact buyer you need?</li>
+          <li><strong class="text-white">Compliance:</strong> Confirm your intended outreach is lawful for the jurisdictions and channels you use.</li>
+        </ul>
+      </aside>
+    </section>
+
+    <section class="mt-14 rounded-3xl border border-white/10 bg-[#11131a] p-6 sm:p-8">
+      <h2 class="text-3xl font-black">Who this buying model suits</h2>
+      <div class="mt-6 grid gap-4 md:grid-cols-3">
+        <div class="rounded-2xl bg-white/[0.04] p-5"><h3 class="font-black">One-off campaigns</h3><p class="mt-2 text-sm leading-6 text-slate-400">Useful when you need a defined list for a specific campaign instead of a recurring prospecting platform.</p></div>
+        <div class="rounded-2xl bg-white/[0.04] p-5"><h3 class="font-black">Niche targeting</h3><p class="mt-2 text-sm leading-6 text-slate-400">A better fit when you already know the industry, geography or job titles you need.</p></div>
+        <div class="rounded-2xl bg-white/[0.04] p-5"><h3 class="font-black">Budget-controlled tests</h3><p class="mt-2 text-sm leading-6 text-slate-400">Pay-as-you-go can reduce commitment when you want to validate data quality before scaling.</p></div>
+      </div>
+      <div class="mt-7 flex flex-col gap-3 sm:flex-row">
+        <a data-cta="affiliate" data-tool-id="bookyourdata" data-cta-source="targeted_b2b_email_lists_mid" href="https://join.bookyourdata.com/swcyqmumr3s5" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-violet-600 px-6 py-4 text-center font-black text-white hover:bg-violet-500">Start with 10 free leads →</a>
+        <a href="/tool/bookyourdata.html" class="rounded-xl border border-white/10 px-6 py-4 text-center font-bold text-slate-300 hover:bg-white/5">Read the Bookyourdata buyer guide</a>
+      </div>
+    </section>
+
+    <section class="mt-14 rounded-3xl border border-amber-400/20 bg-amber-400/[0.06] p-6 sm:p-8">
+      <h2 class="text-2xl font-black text-amber-100">Do not buy a large list first</h2>
+      <p class="mt-3 max-w-4xl text-sm leading-7 text-amber-100/80">Even when a provider advertises strong verification, the real question is whether the contacts match your exact buyer profile and outreach process. Use the free sample or the smallest practical purchase, measure bounce quality and relevance, and expand only after the list proves useful for your campaign.</p>
+    </section>
+
+    <section class="mt-14 rounded-3xl border border-violet-400/30 bg-violet-500/[0.08] p-7 text-center sm:p-9">
+      <h2 class="text-3xl font-black">Ready to test a targeted B2B list?</h2>
+      <p class="mx-auto mt-3 max-w-2xl text-sm leading-6 text-slate-300">Bookyourdata currently offers 10 free credits with no credit card, no subscription requirement and access to its pay-as-you-go prospecting platform.</p>
+      <a data-cta="affiliate" data-tool-id="bookyourdata" data-cta-source="targeted_b2b_email_lists_bottom" href="https://join.bookyourdata.com/swcyqmumr3s5" target="_blank" rel="sponsored noopener noreferrer" class="mt-6 inline-block rounded-xl bg-violet-600 px-7 py-4 font-black text-white hover:bg-violet-500">Get the 10 free leads →</a>
+      <div class="mt-4 text-xs text-slate-500">COSHUMA may earn a commission from qualifying purchases through this partner link.</div>
+    </section>
+
+    <section class="mt-10 text-xs leading-6 text-slate-500"><strong class="text-slate-400">Official sources checked:</strong> Bookyourdata pricing, Prospector and guarantee pages on Sep 5, 2026. Product terms can change, so confirm the final offer before purchasing.</section>
+  </main>
+
+  <footer class="border-t border-white/10 px-5 py-8 text-center text-xs text-slate-600">COSHUMA · Independent AI & SaaS buyer guides</footer>
+  <script src="/affiliate-attribution.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
Adds a new buyer-intent SEO landing for the exact partner-recommended search topic “where to buy targeted B2B email lists.” Uses only the already verified Bookyourdata PartnerStack URL, adds three attributed revenue CTAs, affiliate disclosure, official-source fact notes, and internal links to existing COSHUMA buyer guides. No paid services or new subscriptions.