### PR TITLE
Add a central buyer-guides revenue hub

### DIFF
--- a/projects/GlobalSaaSHub/index.html
+++ b/projects/GlobalSaaSHub/index.html
@@ -59,6 +59,7 @@
         </p>
         <nav aria-label="Featured software buyer guides" style="margin-top: 20px; font-size: 13px; line-height: 2;">
           <strong>Best software shortlists:</strong><br />
+          <a href="/best/index.html"><strong>All AI & SaaS buyer guides</strong></a> ·
           <a href="/best/ai-voice-generators.html">Best AI Voice Generators in 2026</a> ·
           <a href="/best/ai-video-generators.html">Best AI Video Generators in 2026</a> ·
           <a href="/best/crm-for-marketing-agencies.html">Best CRM for Marketing Agencies in 2026</a> ·

--- a/projects/GlobalSaaSHub/public/best/index.html
+++ b/projects/GlobalSaaSHub/public/best/index.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Best AI & SaaS Buyer Guides (2026) | COSHUMA</title>
+    <meta name="description" content="Browse COSHUMA's independent 2026 AI and SaaS buyer guides, including pricing, discounts, trials, comparisons and verified partner offers." />
+    <link rel="canonical" href="https://coshuma.com/best/index.html" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://coshuma.com/best/index.html" />
+    <meta property="og:title" content="Best AI & SaaS Buyer Guides (2026) | COSHUMA" />
+    <meta property="og:description" content="Independent buyer guides for AI software and business SaaS, organized around pricing, free trials, discounts and high-intent use cases." />
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "CollectionPage",
+      "name": "COSHUMA AI & SaaS Buyer Guides",
+      "url": "https://coshuma.com/best/index.html",
+      "description": "Independent AI and SaaS buyer guides covering pricing, trials, discounts, alternatives and use-case shortlists.",
+      "mainEntity": {
+        "@type": "ItemList",
+        "itemListElement": [
+          {"@type":"ListItem","position":1,"url":"https://coshuma.com/best/unbounce-discount.html","name":"Unbounce Discount & Pricing Guide"},
+          {"@type":"ListItem","position":2,"url":"https://coshuma.com/best/pictory-discount-code.html","name":"Pictory Discount Code Guide"},
+          {"@type":"ListItem","position":3,"url":"https://coshuma.com/best/databox-genie-ai-analyst.html","name":"Databox Genie AI Analyst Review"},
+          {"@type":"ListItem","position":4,"url":"https://coshuma.com/best/brand24-ai-visibility.html","name":"Brand24 AI Visibility Review"},
+          {"@type":"ListItem","position":5,"url":"https://coshuma.com/best/where-to-buy-targeted-b2b-email-lists.html","name":"Where to Buy Targeted B2B Email Lists"},
+          {"@type":"ListItem","position":6,"url":"https://coshuma.com/best/b2b-email-list-providers.html","name":"Best B2B Email List Providers"},
+          {"@type":"ListItem","position":7,"url":"https://coshuma.com/best/landing-page-builders.html","name":"Best Landing Page Builders"},
+          {"@type":"ListItem","position":8,"url":"https://coshuma.com/best/crm-for-marketing-agencies.html","name":"Best CRM for Marketing Agencies"},
+          {"@type":"ListItem","position":9,"url":"https://coshuma.com/best/ai-video-generators.html","name":"Best AI Video Generators"},
+          {"@type":"ListItem","position":10,"url":"https://coshuma.com/best/ai-voice-generators.html","name":"Best AI Voice Generators"},
+          {"@type":"ListItem","position":11,"url":"https://coshuma.com/best/esignature-software.html","name":"Best E-Signature Software"}
+        ]
+      }
+    }
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <style>
+      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
+      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
+    </style>
+  </head>
+  <body class="min-h-screen bg-[#0b0c10] text-slate-100">
+    <header class="border-b border-[#222538] bg-[#07080c]/90 sticky top-0 z-50 py-4 px-6 backdrop-blur-md">
+      <div class="max-w-6xl mx-auto flex items-center justify-between gap-4">
+        <a href="/" class="flex items-center gap-3">
+          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div>
+          <span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span>
+        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">Browse all tools</a>
+      </div>
+    </header>
+
+    <main class="max-w-6xl mx-auto px-4 py-12 space-y-10">
+      <section class="max-w-4xl space-y-5">
+        <div class="inline-flex items-center px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Independent software buying guides · 2026</div>
+        <h1 class="text-4xl md:text-6xl font-black text-white tracking-tight">AI & SaaS buyer guides built around real purchase decisions</h1>
+        <p class="text-base md:text-lg text-slate-300 leading-relaxed max-w-3xl">Use this hub to move from a broad category to a focused pricing, trial, discount or use-case guide. COSHUMA separates editorial comparisons from partner links and labels monetized CTAs inside each guide.</p>
+      </section>
+
+      <section class="space-y-5">
+        <div>
+          <h2 class="text-2xl md:text-3xl font-black text-white">High-intent pricing, trial & discount guides</h2>
+          <p class="text-sm text-slate-400 mt-2">Start here when you are close to testing or buying a specific product.</p>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <a href="/best/unbounce-discount.html" class="p-5 rounded-2xl bg-[#131520] border border-purple-500/25 hover:border-purple-400/60 transition-all">
+            <div class="text-xs uppercase tracking-wider font-bold text-purple-300">Landing pages</div>
+            <h3 class="text-lg font-extrabold text-white mt-2">Unbounce Discount & Pricing</h3>
+            <p class="text-sm text-slate-400 mt-2 leading-relaxed">Buyer guide for current partner savings, plan choices and free-trial considerations.</p>
+          </a>
+          <a href="/best/pictory-discount-code.html" class="p-5 rounded-2xl bg-[#131520] border border-purple-500/25 hover:border-purple-400/60 transition-all">
+            <div class="text-xs uppercase tracking-wider font-bold text-purple-300">AI video</div>
+            <h3 class="text-lg font-extrabold text-white mt-2">Pictory Discount Code</h3>
+            <p class="text-sm text-slate-400 mt-2 leading-relaxed">Checkout-focused guide for the verified COSHUMA partner offer and current Pictory plans.</p>
+          </a>
+          <a href="/best/databox-genie-ai-analyst.html" class="p-5 rounded-2xl bg-[#131520] border border-purple-500/25 hover:border-purple-400/60 transition-all">
+            <div class="text-xs uppercase tracking-wider font-bold text-purple-300">Analytics</div>
+            <h3 class="text-lg font-extrabold text-white mt-2">Databox Genie AI Analyst</h3>
+            <p class="text-sm text-slate-400 mt-2 leading-relaxed">Pricing, AI credits, integrations and a practical trial workflow for data-heavy teams.</p>
+          </a>
+          <a href="/best/brand24-ai-visibility.html" class="p-5 rounded-2xl bg-[#131520] border border-purple-500/25 hover:border-purple-400/60 transition-all">
+            <div class="text-xs uppercase tracking-wider font-bold text-purple-300">AI visibility</div>
+            <h3 class="text-lg font-extrabold text-white mt-2">Brand24 AI Visibility</h3>
+            <p class="text-sm text-slate-400 mt-2 leading-relaxed">A buyer-focused look at AI visibility and GEO tracking before adding it to a monitoring stack.</p>
+          </a>
+          <a href="/best/where-to-buy-targeted-b2b-email-lists.html" class="p-5 rounded-2xl bg-[#131520] border border-purple-500/25 hover:border-purple-400/60 transition-all md:col-span-2">
+            <div class="text-xs uppercase tracking-wider font-bold text-purple-300">B2B data</div>
+            <h3 class="text-lg font-extrabold text-white mt-2">Where to Buy Targeted B2B Email Lists</h3>
+            <p class="text-sm text-slate-400 mt-2 leading-relaxed">A purchase-intent guide for teams evaluating targeted B2B contact data and small-scale validation before scaling outreach.</p>
+          </a>
+        </div>
+      </section>
+
+      <section class="space-y-5">
+        <div>
+          <h2 class="text-2xl md:text-3xl font-black text-white">Best-software shortlists</h2>
+          <p class="text-sm text-slate-400 mt-2">Use these when you are still comparing categories rather than one vendor.</p>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <a href="/best/b2b-email-list-providers.html" class="p-5 rounded-2xl bg-[#131520] border border-[#222538] hover:border-purple-400/50 transition-all"><h3 class="font-extrabold text-white">Best B2B Email List Providers</h3><p class="text-sm text-slate-400 mt-2">Compare providers for prospecting data and outreach workflows.</p></a>
+          <a href="/best/landing-page-builders.html" class="p-5 rounded-2xl bg-[#131520] border border-[#222538] hover:border-purple-400/50 transition-all"><h3 class="font-extrabold text-white">Best Landing Page Builders</h3><p class="text-sm text-slate-400 mt-2">Compare tools for paid traffic, lead capture and campaign landing pages.</p></a>
+          <a href="/best/crm-for-marketing-agencies.html" class="p-5 rounded-2xl bg-[#131520] border border-[#222538] hover:border-purple-400/50 transition-all"><h3 class="font-extrabold text-white">Best CRM for Marketing Agencies</h3><p class="text-sm text-slate-400 mt-2">Shortlist agency-oriented CRM and client acquisition platforms.</p></a>
+          <a href="/best/ai-video-generators.html" class="p-5 rounded-2xl bg-[#131520] border border-[#222538] hover:border-purple-400/50 transition-all"><h3 class="font-extrabold text-white">Best AI Video Generators</h3><p class="text-sm text-slate-400 mt-2">Compare AI video creation tools for marketing and content workflows.</p></a>
+          <a href="/best/ai-voice-generators.html" class="p-5 rounded-2xl bg-[#131520] border border-[#222538] hover:border-purple-400/50 transition-all"><h3 class="font-extrabold text-white">Best AI Voice Generators</h3><p class="text-sm text-slate-400 mt-2">Compare voice generation platforms for narration, localization and production.</p></a>
+          <a href="/best/esignature-software.html" class="p-5 rounded-2xl bg-[#131520] border border-[#222538] hover:border-purple-400/50 transition-all"><h3 class="font-extrabold text-white">Best E-Signature Software</h3><p class="text-sm text-slate-400 mt-2">Compare electronic-signature products for business document workflows.</p></a>
+        </div>
+      </section>
+
+      <section class="p-7 rounded-3xl bg-purple-500/5 border border-purple-500/20 text-center space-y-3">
+        <h2 class="text-2xl font-black text-white">Prefer product-by-product research?</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto">COSHUMA also maintains individual tool pricing/review pages and side-by-side comparisons. Use the main directory when you already know the product name.</p>
+        <a href="/" class="inline-flex px-6 py-3 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-extrabold text-sm">Open the full AI & SaaS directory →</a>
+      </section>
+    </main>
+
+    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS buyer guides.</div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Revenue impact
- adds a dedicated `/best/index.html` hub that links every current buyer-intent COSHUMA guide from one crawlable page
- groups high-intent pricing/discount/trial guides separately from broader category shortlists
- adds CollectionPage + ItemList structured data so search crawlers can understand the guide cluster
- adds a homepage static-crawl link to the hub so new buyer pages are less likely to remain weakly linked/orphaned

## Safety
- no new affiliate URL is introduced
- no partner status, pricing, discount or conversion claim is invented
- no paid service or subscription is used
- monetized CTAs remain on the underlying verified guides with their existing disclosures and attribution