### PR TITLE
Activate verified Moosend affiliate tracking from spam recovery

### DIFF
--- a/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
+++ b/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
@@ -17,10 +17,12 @@ const verified = {
   'vista-social': 'https://vistasocial.com?fpr=sangkwon14',
   bookyourdata: 'https://join.bookyourdata.com/swcyqmumr3s5',
   unbounce: 'https://unbounce.partnerlinks.io/5ubjnt8lluqi',
+  moosend: 'https://trymoo.moosend.com/6eappdpw04pw',
 };
 
 const verifiedAt = {
   unbounce: '2026-09-04T03:52:58+09:00',
+  moosend: '2026-09-01T04:48:36+09:00',
 };
 
 for (const file of ['data/tools.json', 'data/tools.next.json']) {


### PR DESCRIPTION
## Revenue impact
- promotes Moosend from `email_verification_pending` to the exact customer-facing PartnerStack referral URL recovered from the Moosend affiliate welcome email that Gmail had classified as spam
- makes the verified route available to the existing production affiliate sync and data-driven comparison CTA monetization pass

## Evidence
Moosend affiliate welcome email to support@coshuma.com explicitly labels `https://trymoo.moosend.com/6eappdpw04pw` as the Referral link. The dashboard URL in the same email is not used.

## Safety
- no generic homepage/dashboard/onboarding URL is treated as affiliate
- no new paid service or subscription
- no commission rate or pricing claim is introduced