### PR TITLE
Activate verified Chatbase affiliate tracking

### DIFF
--- a/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
+++ b/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
@@ -18,11 +18,13 @@ const verified = {
   bookyourdata: 'https://join.bookyourdata.com/swcyqmumr3s5',
   unbounce: 'https://unbounce.partnerlinks.io/5ubjnt8lluqi',
   moosend: 'https://trymoo.moosend.com/6eappdpw04pw',
+  chatbase: 'https://link.chatbase.co/sang-kwon-an',
 };
 
 const verifiedAt = {
   unbounce: '2026-09-04T03:52:58+09:00',
   moosend: '2026-09-01T04:48:36+09:00',
+  chatbase: '2026-09-06T01:50:28+09:00',
 };
 
 for (const file of ['data/tools.json', 'data/tools.next.json']) {


### PR DESCRIPTION
## Revenue impact
- adds the exact customer-facing Chatbase referral URL supplied by Chatbase support after reviewing the existing approved COSHUMA partner account
- promotes Chatbase into the existing verified affiliate sync so comparison pages and the primary `/tool/chatbase.html` CTA can use the revenue route automatically

## Evidence
Chatbase support explicitly supplied `https://link.chatbase.co/sang-kwon-an` as the direct referral link for the approved COSHUMA partner account.

## Safety
- no Dub dashboard or generic homepage URL is used as an affiliate link
- no new application or duplicate partner signup
- no paid service, checkout, or unsupported commission claim