### PR TITLE
Add Taskade 20% affiliate coupon conversion callout

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/taskade.html
+++ b/projects/GlobalSaaSHub/public/tool/taskade.html
@@ -65,6 +65,9 @@
             <a data-cta="affiliate" data-tool-id="taskade" href="https://www.taskade.com/?via=7zzjo7" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start Taskade via verified affiliate link →</a>
             <a data-cta="official" href="https://www.taskade.com/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">View official pricing →</a>
           </div>
+          <div data-conversion-offer="taskade-ai-code" class="rounded-xl border border-emerald-500/25 bg-emerald-500/5 p-4 text-sm text-slate-200">
+            <strong class="text-emerald-300">Taskade affiliate offer:</strong> Taskade's affiliate team states that code <code class="font-bold text-white">AI</code> gives 20% off. If a coupon field is offered at checkout, enter <code class="font-bold text-white">AI</code> and confirm the discount before paying. Offer terms can change.
+          </div>
           <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission if you become a paying Taskade customer through the verified affiliate link above, at no additional cost to you. Taskade's Partnership Program page, updated August 26, 2026, states a 50% recurring commission for life and a 90-day cookie window. Program terms can change, so the live partner documentation remains the source of truth.</p>
         </section>
 


### PR DESCRIPTION
## Revenue impact
- surfaces Taskade's official affiliate coupon code `AI` (20% off) directly beside the existing verified COSHUMA Taskade affiliate CTA
- gives price-sensitive buyers an immediate conversion incentive without changing the existing referral route

## Evidence
Taskade's affiliate email to the connected account states: "Share and apply a 20% off discount using this code: AI." The custom COSHUMA code request is still pending, so this PR does **not** claim a custom code exists.

## Safety
- existing verified Taskade referral URL remains unchanged
- visitors are told to confirm the discount at checkout because offer terms can change
- no stacking, lifetime-discount, or custom-code claim is made
- no paid service or subscription