### PR TITLE
Add Sudowrite fiction buyer-intent free-trial landing

### DIFF
--- a/projects/GlobalSaaSHub/public/best/sudowrite-free-trial-pricing.html
+++ b/projects/GlobalSaaSHub/public/best/sudowrite-free-trial-pricing.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sudowrite Free Trial & Pricing 2026 for Fiction Writers | COSHUMA</title>
+  <meta name="description" content="See Sudowrite's current free-trial terms, 2026 pricing, credit tiers and fiction-writing features before you subscribe. Includes a verified COSHUMA partner route." />
+  <link rel="canonical" href="https://coshuma.com/best/sudowrite-free-trial-pricing.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="COSHUMA" />
+  <meta property="og:title" content="Sudowrite Free Trial & Pricing 2026 | COSHUMA" />
+  <meta property="og:description" content="A buyer-focused Sudowrite guide for novelists and fiction writers: free trial, current plans, credits and practical fit." />
+  <meta property="og:url" content="https://coshuma.com/best/sudowrite-free-trial-pricing.html" />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"Sudowrite Free Trial & Pricing 2026 for Fiction Writers",
+    "dateModified":"2026-09-06",
+    "author":{"@type":"Organization","name":"COSHUMA"},
+    "publisher":{"@type":"Organization","name":"COSHUMA"},
+    "mainEntityOfPage":"https://coshuma.com/best/sudowrite-free-trial-pricing.html"
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>body{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}</style>
+</head>
+<body class="bg-[#08090d] text-slate-100 antialiased">
+  <header class="border-b border-white/10 bg-[#0c0e14]">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-5 py-4">
+      <a href="/" class="text-xl font-black tracking-tight text-white">COSHUMA</a>
+      <div class="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Independent AI & SaaS buyer guides</div>
+    </div>
+  </header>
+
+  <main class="mx-auto max-w-5xl px-5 py-12 sm:py-16">
+    <nav class="mb-7 text-sm text-slate-500"><a class="hover:text-white" href="/">Home</a> <span class="px-2">/</span> <a class="hover:text-white" href="/best/">Buyer guides</a> <span class="px-2">/</span> Sudowrite</nav>
+
+    <section class="max-w-4xl">
+      <div class="mb-5 inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">Official pricing checked Sep 6, 2026</div>
+      <h1 class="text-4xl font-black tracking-[-0.04em] text-white sm:text-6xl">Sudowrite free trial & pricing for fiction writers</h1>
+      <p class="mt-5 max-w-3xl text-lg leading-8 text-slate-400">Sudowrite is built around fiction workflows rather than general-purpose prompting. If you are deciding whether to pay for it, the practical questions are simple: can you test it without a card, how many credits do the plans include, and are the fiction-specific tools worth using in your drafting workflow?</p>
+      <div class="mt-7 flex flex-col gap-3 sm:flex-row">
+        <a data-cta="affiliate" data-tool-id="sudowrite" data-cta-source="sudowrite_free_trial_hero" href="https://www.sudowrite.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-violet-600 px-6 py-4 text-center font-black text-white hover:bg-violet-500">Try Sudowrite free →</a>
+        <a href="/tool/sudowrite.html" class="rounded-xl border border-white/10 px-6 py-4 text-center font-bold text-slate-300 hover:bg-white/5">Read the full Sudowrite buyer guide</a>
+      </div>
+      <p class="mt-3 text-xs leading-5 text-slate-500">Affiliate disclosure: the purple button uses a verified COSHUMA partner link. COSHUMA may earn a commission if you later become a paying customer, at no extra cost to you.</p>
+    </section>
+
+    <section class="mt-12 grid gap-4 md:grid-cols-3">
+      <div class="rounded-2xl border border-white/10 bg-white/[0.04] p-5">
+        <div class="text-xs font-black uppercase tracking-widest text-slate-400">Hobby & Student</div>
+        <div class="mt-2 text-3xl font-black text-white">$10/mo</div>
+        <p class="mt-2 text-sm leading-6 text-slate-400">225,000 credits per month on the current yearly-billing view.</p>
+      </div>
+      <div class="rounded-2xl border border-violet-400/30 bg-violet-500/10 p-5">
+        <div class="text-xs font-black uppercase tracking-widest text-violet-300">Professional</div>
+        <div class="mt-2 text-3xl font-black text-white">$22/mo</div>
+        <p class="mt-2 text-sm leading-6 text-slate-300">1,000,000 credits per month on the current yearly-billing view; positioned for longer works such as novels and screenplays.</p>
+      </div>
+      <div class="rounded-2xl border border-cyan-400/30 bg-cyan-500/10 p-5">
+        <div class="text-xs font-black uppercase tracking-widest text-cyan-300">Max</div>
+        <div class="mt-2 text-3xl font-black text-white">$44/mo</div>
+        <p class="mt-2 text-sm leading-6 text-slate-300">2,000,000 credits per month on yearly billing, with unused credits rolling over for 12 months.</p>
+      </div>
+    </section>
+
+    <section class="mt-12 rounded-3xl border border-emerald-400/20 bg-emerald-500/[0.06] p-6 sm:p-8">
+      <div class="text-xs font-black uppercase tracking-widest text-emerald-300">Free-trial check</div>
+      <h2 class="mt-2 text-3xl font-black">No credit card is required for the current free trial</h2>
+      <p class="mt-3 max-w-3xl leading-7 text-slate-300">Sudowrite's current official pricing page says the free trial does not require a credit card and can be cancelled at any time. Plan prices can change, and the site offers monthly and yearly billing views, so confirm the live checkout before subscribing.</p>
+      <a data-cta="affiliate" data-tool-id="sudowrite" data-cta-source="sudowrite_free_trial_mid" href="https://www.sudowrite.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="mt-5 inline-flex rounded-xl bg-emerald-500 px-5 py-3 font-black text-slate-950 hover:bg-emerald-400">Open the verified Sudowrite route →</a>
+    </section>
+
+    <section class="mt-14">
+      <div class="text-xs font-bold uppercase tracking-[0.2em] text-violet-300">What you are paying for</div>
+      <h2 class="mt-2 text-3xl font-black">Fiction-specific tools, not just a blank chatbot</h2>
+      <div class="mt-6 grid gap-4 md:grid-cols-2">
+        <div class="rounded-2xl border border-white/10 bg-[#11131a] p-5"><h3 class="text-xl font-black">Write</h3><p class="mt-2 text-sm leading-6 text-slate-400">Continues a story in Auto or Guided mode when you are stuck or know the direction but want drafting help.</p></div>
+        <div class="rounded-2xl border border-white/10 bg-[#11131a] p-5"><h3 class="text-xl font-black">Rewrite</h3><p class="mt-2 text-sm leading-6 text-slate-400">Rephrases existing passages, shortens text, makes it more descriptive, or applies other revision styles while preserving the underlying idea.</p></div>
+        <div class="rounded-2xl border border-white/10 bg-[#11131a] p-5"><h3 class="text-xl font-black">Brainstorm & Describe</h3><p class="mt-2 text-sm leading-6 text-slate-400">Generates plot, character and worldbuilding ideas, while Describe focuses on sensory detail for scenes and objects.</p></div>
+        <div class="rounded-2xl border border-white/10 bg-[#11131a] p-5"><h3 class="text-xl font-black">Draft & Scenes</h3><p class="mt-2 text-sm leading-6 text-slate-400">Structures scenes and can generate longer chapter drafts from outlines and scene instructions, aimed at long-form fiction workflows.</p></div>
+      </div>
+    </section>
+
+    <section class="mt-14 overflow-hidden rounded-3xl border border-white/10 bg-white/[0.035]">
+      <div class="border-b border-white/10 p-6"><h2 class="text-2xl font-black">Which plan makes the most sense?</h2><p class="mt-2 text-sm text-slate-400">All current plans include the feature set; the main difference is monthly credit volume and rollover behavior.</p></div>
+      <div class="overflow-x-auto"><table class="w-full min-w-[720px] text-left text-sm"><thead class="bg-white/[0.03] text-slate-400"><tr><th class="p-4">Plan</th><th class="p-4">Yearly-view price</th><th class="p-4">Credits</th><th class="p-4">Practical fit</th></tr></thead><tbody class="divide-y divide-white/10"><tr><td class="p-4 font-black">Hobby & Student</td><td class="p-4">$10/mo</td><td class="p-4">225,000/mo</td><td class="p-4">Occasional fiction, school or experimentation</td></tr><tr><td class="p-4 font-black">Professional</td><td class="p-4">$22/mo</td><td class="p-4">1,000,000/mo</td><td class="p-4">Novel and screenplay drafting</td></tr><tr><td class="p-4 font-black">Max</td><td class="p-4">$44/mo</td><td class="p-4">2,000,000/mo + rollover</td><td class="p-4">Frequent or multi-project publishing</td></tr></tbody></table></div>
+    </section>
+
+    <section class="mt-14 grid gap-5 lg:grid-cols-2">
+      <div class="rounded-2xl border border-white/10 bg-[#11131a] p-6"><h2 class="text-2xl font-black">Good fit when</h2><ul class="mt-4 space-y-3 text-sm leading-6 text-slate-300"><li>• You write fiction, novels or screenplays and want tools shaped around scenes, prose and story continuity.</li><li>• You want a no-card trial before deciding whether the workflow helps.</li><li>• You want brainstorming, rewriting and long-form drafting in the same writing environment.</li></ul></div>
+      <div class="rounded-2xl border border-white/10 bg-[#11131a] p-6"><h2 class="text-2xl font-black">Compare alternatives first when</h2><ul class="mt-4 space-y-3 text-sm leading-6 text-slate-300"><li>• Your main work is marketing copy, SEO content or business writing rather than fiction.</li><li>• You only need occasional general AI assistance and already have another writing subscription.</li><li>• Your expected usage is low enough that a free general-purpose tool already covers it.</li></ul></div>
+    </section>
+
+    <section class="mt-14 rounded-3xl border border-violet-400/30 bg-gradient-to-br from-violet-950/50 to-[#11131a] p-7 text-center sm:p-9">
+      <h2 class="text-3xl font-black">Test the workflow before paying</h2>
+      <p class="mx-auto mt-3 max-w-2xl leading-7 text-slate-300">The current trial does not require a credit card. Use it on a real scene or chapter, then decide whether the fiction-specific workflow is worth a paid plan for you.</p>
+      <a data-cta="affiliate" data-tool-id="sudowrite" data-cta-source="sudowrite_free_trial_final" href="https://www.sudowrite.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="mt-6 inline-flex rounded-xl bg-violet-600 px-6 py-4 font-black text-white hover:bg-violet-500">Start the Sudowrite free trial →</a>
+      <p class="mt-3 text-xs text-slate-500">Verify the current trial and checkout terms on Sudowrite before subscribing.</p>
+    </section>
+
+    <section class="mt-12 rounded-2xl border border-white/10 bg-white/[0.03] p-5 text-xs leading-6 text-slate-500">
+      <strong class="text-slate-300">Source note:</strong> plan prices, credit allowances and free-trial terms were checked against Sudowrite's official pricing page and documentation on Sep 6, 2026. Product features were checked against Sudowrite's official documentation. The outbound partner URL was separately verified from Sudowrite's affiliate welcome email to COSHUMA.
+    </section>
+  </main>
+
+  <footer class="border-t border-white/10 bg-[#0c0e14] py-8 text-center text-xs text-slate-500">© 2026 COSHUMA. Independent AI & SaaS buyer guides.</footer>
+  <script defer src="/affiliate-attribution.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Revenue impact
- adds a dedicated high-intent Sudowrite landing targeting free-trial/pricing buyers
- uses the exact customer-facing affiliate URL from Sudowrite's partner welcome email: `https://www.sudowrite.com?via=sangkwon`
- places verified affiliate CTAs at hero, trial, and final-decision stages with attribution metadata and disclosure
- relies on the existing buyer-hub sitemap pass, which automatically indexes every `/public/best/*.html` page

## Evidence
- Sudowrite partner welcome email explicitly provides the affiliate link and confirms the account is active
- Sudowrite official pricing/docs checked Sep 6, 2026: no-card free trial; yearly-view prices $10 / $22 / $44; 225k / 1M / 2M credits; Max credits roll over for 12 months
- feature copy is limited to official Sudowrite documentation (Write, Rewrite, Brainstorm, Describe, Draft/Scenes)

## Safety
- no dashboard/onboarding URL is treated as revenue
- no fabricated ratings or conversion claims
- no paid service or new subscription
- page tells buyers to re-check live checkout terms before purchase