### PR TITLE
Strengthen Unbounce buyer-intent card after verified click

### DIFF
--- a/projects/GlobalSaaSHub/public/best/index.html
+++ b/projects/GlobalSaaSHub/public/best/index.html
@@ -69,9 +69,9 @@
         </div>
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           <a href="/best/unbounce-discount.html" class="p-5 rounded-2xl bg-[#131520] border border-purple-500/25 hover:border-purple-400/60 transition-all">
-            <div class="text-xs uppercase tracking-wider font-bold text-purple-300">Landing pages</div>
+            <div class="text-xs uppercase tracking-wider font-bold text-purple-300">Landing pages · verified partner offer</div>
             <h3 class="text-lg font-extrabold text-white mt-2">Unbounce Discount & Pricing</h3>
-            <p class="text-sm text-slate-400 mt-2 leading-relaxed">Buyer guide for current partner savings, plan choices and free-trial considerations.</p>
+            <p class="text-sm text-slate-300 mt-2 leading-relaxed">14-day free trial, then 20% off the first 3 months or 35% off the first annual subscription through COSHUMA's verified Unbounce route.</p>
           </a>
           <a href="/best/pictory-discount-code.html" class="p-5 rounded-2xl bg-[#131520] border border-purple-500/25 hover:border-purple-400/60 transition-all">
             <div class="text-xs uppercase tracking-wider font-bold text-purple-300">AI video</div>


### PR DESCRIPTION
## Revenue impact
- the Unbounce partner program reported a real click on COSHUMA's unique link
- upgrades the first card in the high-intent buyer-guide hub from generic copy to the verified customer offer: 14-day trial, 20% off first 3 months or 35% off first annual subscription
- preserves the existing route to `/best/unbounce-discount.html` and does not introduce a new or unverified affiliate URL

## Evidence
- Unbounce welcome email confirms `https://unbounce.partnerlinks.io/5ubjnt8lluqi`, the 20%/35% customer offer, 90-day tracking and 25%+ first-year reward terms
- Unbounce official partner page currently publishes the same 20%/35% customer offer
- Unbounce official pricing page currently publishes a 14-day free trial with no credit card required

## Safety
- no new paid service or subscription
- no new tracking URL
- no revenue claim beyond the verified click notification