### PR TITLE
Link Sudowrite buyer guide from revenue hub

### DIFF
--- a/projects/GlobalSaaSHub/public/best/index.html
+++ b/projects/GlobalSaaSHub/public/best/index.html
@@ -22,15 +22,16 @@
         "itemListElement": [
           {"@type":"ListItem","position":1,"url":"https://coshuma.com/best/unbounce-discount.html","name":"Unbounce Discount & Pricing Guide"},
           {"@type":"ListItem","position":2,"url":"https://coshuma.com/best/pictory-discount-code.html","name":"Pictory Discount Code Guide"},
-          {"@type":"ListItem","position":3,"url":"https://coshuma.com/best/databox-genie-ai-analyst.html","name":"Databox Genie AI Analyst Review"},
-          {"@type":"ListItem","position":4,"url":"https://coshuma.com/best/brand24-ai-visibility.html","name":"Brand24 AI Visibility Review"},
-          {"@type":"ListItem","position":5,"url":"https://coshuma.com/best/where-to-buy-targeted-b2b-email-lists.html","name":"Where to Buy Targeted B2B Email Lists"},
-          {"@type":"ListItem","position":6,"url":"https://coshuma.com/best/b2b-email-list-providers.html","name":"Best B2B Email List Providers"},
-          {"@type":"ListItem","position":7,"url":"https://coshuma.com/best/landing-page-builders.html","name":"Best Landing Page Builders"},
-          {"@type":"ListItem","position":8,"url":"https://coshuma.com/best/crm-for-marketing-agencies.html","name":"Best CRM for Marketing Agencies"},
-          {"@type":"ListItem","position":9,"url":"https://coshuma.com/best/ai-video-generators.html","name":"Best AI Video Generators"},
-          {"@type":"ListItem","position":10,"url":"https://coshuma.com/best/ai-voice-generators.html","name":"Best AI Voice Generators"},
-          {"@type":"ListItem","position":11,"url":"https://coshuma.com/best/esignature-software.html","name":"Best E-Signature Software"}
+          {"@type":"ListItem","position":3,"url":"https://coshuma.com/best/sudowrite-free-trial-pricing.html","name":"Sudowrite Free Trial & Pricing Guide"},
+          {"@type":"ListItem","position":4,"url":"https://coshuma.com/best/databox-genie-ai-analyst.html","name":"Databox Genie AI Analyst Review"},
+          {"@type":"ListItem","position":5,"url":"https://coshuma.com/best/brand24-ai-visibility.html","name":"Brand24 AI Visibility Review"},
+          {"@type":"ListItem","position":6,"url":"https://coshuma.com/best/where-to-buy-targeted-b2b-email-lists.html","name":"Where to Buy Targeted B2B Email Lists"},
+          {"@type":"ListItem","position":7,"url":"https://coshuma.com/best/b2b-email-list-providers.html","name":"Best B2B Email List Providers"},
+          {"@type":"ListItem","position":8,"url":"https://coshuma.com/best/landing-page-builders.html","name":"Best Landing Page Builders"},
+          {"@type":"ListItem","position":9,"url":"https://coshuma.com/best/crm-for-marketing-agencies.html","name":"Best CRM for Marketing Agencies"},
+          {"@type":"ListItem","position":10,"url":"https://coshuma.com/best/ai-video-generators.html","name":"Best AI Video Generators"},
+          {"@type":"ListItem","position":11,"url":"https://coshuma.com/best/ai-voice-generators.html","name":"Best AI Voice Generators"},
+          {"@type":"ListItem","position":12,"url":"https://coshuma.com/best/esignature-software.html","name":"Best E-Signature Software"}
         ]
       }
     }
@@ -77,6 +78,11 @@
             <div class="text-xs uppercase tracking-wider font-bold text-purple-300">AI video</div>
             <h3 class="text-lg font-extrabold text-white mt-2">Pictory Discount Code</h3>
             <p class="text-sm text-slate-400 mt-2 leading-relaxed">Checkout-focused guide for the verified COSHUMA partner offer and current Pictory plans.</p>
+          </a>
+          <a href="/best/sudowrite-free-trial-pricing.html" class="p-5 rounded-2xl bg-[#131520] border border-purple-500/25 hover:border-purple-400/60 transition-all">
+            <div class="text-xs uppercase tracking-wider font-bold text-purple-300">Fiction writing AI · verified partner route</div>
+            <h3 class="text-lg font-extrabold text-white mt-2">Sudowrite Free Trial & Pricing</h3>
+            <p class="text-sm text-slate-400 mt-2 leading-relaxed">Free-trial terms, current plan pricing, credit tiers and a buyer-focused path for novelists evaluating Sudowrite.</p>
           </a>
           <a href="/best/databox-genie-ai-analyst.html" class="p-5 rounded-2xl bg-[#131520] border border-purple-500/25 hover:border-purple-400/60 transition-all">
             <div class="text-xs uppercase tracking-wider font-bold text-purple-300">Analytics</div>


### PR DESCRIPTION
## Revenue impact
- adds the newly deployed Sudowrite free-trial/pricing buyer guide to the central `/best/` revenue hub
- removes an internal-linking gap: the page existed and was in the sitemap, but the buyer hub did not link to it
- adds the guide to the hub's CollectionPage/ItemList structured data so crawlers and high-intent visitors can discover it from an already-linked page

## Safety
- no new affiliate URL is introduced
- no pricing or partner claim is changed
- no paid service or subscription