### PR TITLE
Add Shopify pricing and free-trial buyer landing

### DIFF
--- a/projects/GlobalSaaSHub/public/best/shopify-pricing-free-trial.html
+++ b/projects/GlobalSaaSHub/public/best/shopify-pricing-free-trial.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Shopify Pricing & Free Trial (2026) | COSHUMA</title>
+    <meta name="description" content="Compare Shopify Basic, Grow, Advanced and Plus pricing, understand the current trial offer, and start through COSHUMA's verified Shopify affiliate link." />
+    <link rel="canonical" href="https://coshuma.com/best/shopify-pricing-free-trial.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://coshuma.com/best/shopify-pricing-free-trial.html" />
+    <meta property="og:title" content="Shopify Pricing & Free Trial (2026) | COSHUMA" />
+    <meta property="og:description" content="A buyer-focused Shopify pricing guide with current trial terms and a verified COSHUMA partner route." />
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "Shopify Pricing & Free Trial (2026)",
+      "description": "Buyer-focused Shopify pricing and trial guide with a verified COSHUMA affiliate route.",
+      "mainEntityOfPage": "https://coshuma.com/best/shopify-pricing-free-trial.html",
+      "author": {"@type":"Organization","name":"COSHUMA"},
+      "publisher": {"@type":"Organization","name":"COSHUMA"}
+    }
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <style>
+      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
+      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
+    </style>
+  </head>
+  <body class="min-h-screen bg-[#0b0c10] text-slate-100">
+    <header class="border-b border-[#222538] bg-[#07080c]/90 sticky top-0 z-50 py-4 px-6 backdrop-blur-md">
+      <div class="max-w-5xl mx-auto flex items-center justify-between gap-4">
+        <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white">C</div><span class="font-extrabold text-lg text-white">COSHUMA</span></a>
+        <a href="/best/index.html" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">Buyer guides</a>
+      </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-4 py-12 space-y-8">
+      <section class="p-8 md:p-10 rounded-3xl bg-[#131520] border border-purple-500/30 shadow-2xl space-y-6">
+        <div class="inline-flex items-center px-3 py-1 rounded-full text-xs font-bold bg-emerald-500/10 border border-emerald-500/20 text-emerald-300">Verified Shopify affiliate route</div>
+        <h1 class="text-4xl md:text-6xl font-black tracking-tight text-white">Shopify pricing & free trial: what to choose in 2026</h1>
+        <p class="text-base md:text-lg text-slate-300 leading-relaxed">Shopify currently advertises a 3-day free trial followed by $1/month for 3 months on its US pricing page. If you are testing a new store, start the trial first and choose a paid tier only after you know which staff, reporting and international features you actually need.</p>
+        <div class="p-5 rounded-2xl bg-emerald-500/10 border border-emerald-500/25 space-y-3">
+          <div class="text-sm font-extrabold text-emerald-300">Current entry offer</div>
+          <p class="text-sm text-slate-200">Try Shopify free for 3 days, then $1/month for 3 months. Offers and local pricing can vary by country, so confirm the exact checkout terms shown after you open Shopify.</p>
+          <a data-cta="affiliate" data-tool-id="shopify" data-cta-source="shopify-pricing-hero" href="https://shopify.pxf.io/7670642-link?sharedid=7670642" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex w-full sm:w-auto justify-center px-7 py-4 rounded-xl bg-emerald-500 hover:bg-emerald-400 text-slate-950 font-black">Start Shopify through the verified partner link →</a>
+          <p class="text-[11px] text-slate-400">Affiliate disclosure: COSHUMA is a Shopify Affiliate and may receive compensation for a qualifying referral. There is no extra charge for using this link.</p>
+        </div>
+      </section>
+
+      <section class="space-y-4">
+        <div>
+          <h2 class="text-2xl md:text-3xl font-black text-white">Shopify plan prices at a glance</h2>
+          <p class="text-sm text-slate-400 mt-2">The values below reflect Shopify's current US pricing page. Yearly pricing is shown as the monthly equivalent when billed annually.</p>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="p-6 rounded-2xl bg-[#131520] border border-[#222538] space-y-2"><div class="text-lg font-extrabold text-white">Basic</div><div class="text-emerald-300 font-black">$29/mo yearly · $39/mo monthly</div><p class="text-sm text-slate-300">Best starting point for a solo entrepreneur who needs the full online store, unlimited products, AI commerce tools and core reports without extra staff accounts.</p></div>
+          <div class="p-6 rounded-2xl bg-[#131520] border border-[#222538] space-y-2"><div class="text-lg font-extrabold text-white">Grow</div><div class="text-emerald-300 font-black">$79/mo yearly · $105/mo monthly</div><p class="text-sm text-slate-300">Useful when a small team needs additional staff access and lower card rates while keeping the standard Shopify commerce stack.</p></div>
+          <div class="p-6 rounded-2xl bg-[#131520] border border-[#222538] space-y-2"><div class="text-lg font-extrabold text-white">Advanced</div><div class="text-emerald-300 font-black">$299/mo yearly · $399/mo monthly</div><p class="text-sm text-slate-300">Designed for larger or international operations that need more staff accounts, live third-party shipping rates and regional selling controls.</p></div>
+          <div class="p-6 rounded-2xl bg-[#131520] border border-[#222538] space-y-2"><div class="text-lg font-extrabold text-white">Plus</div><div class="text-emerald-300 font-black">From $2,300/mo</div><p class="text-sm text-slate-300">Enterprise-oriented. Consider it only when checkout customization, B2B scale, higher limits or complex multi-location operations justify the jump.</p></div>
+        </div>
+      </section>
+
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">Which Shopify plan should you start with?</h2>
+        <div class="space-y-4 text-sm text-slate-300 leading-relaxed">
+          <p><strong class="text-white">Start with Basic</strong> if this is your first store or you are validating demand. The lower entry price usually matters more than team features while you are still proving that traffic converts.</p>
+          <p><strong class="text-white">Move to Grow</strong> when staff access and transaction economics start to matter. Do not upgrade only because a higher tier exists.</p>
+          <p><strong class="text-white">Use Advanced</strong> when international selling, shipping-rate control or a larger operating team creates a concrete need. For most new stores, it is unnecessary at launch.</p>
+        </div>
+      </section>
+
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="p-6 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-3"><h3 class="text-lg font-extrabold text-emerald-300">Good reasons to test Shopify</h3><ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>Hosted online store with checkout, inventory and payments in one platform.</li><li>Unlimited products on the core plans.</li><li>Built-in tools for social, marketplace and AI-channel selling.</li><li>Trial path lets you validate the setup before standard pricing begins.</li></ul></div>
+        <div class="p-6 rounded-2xl bg-amber-500/5 border border-amber-500/20 space-y-3"><h3 class="text-lg font-extrabold text-amber-300">Check before paying</h3><ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>Local pricing, payment fees and promotions can differ from US pricing.</li><li>Apps and premium themes can increase the total monthly cost.</li><li>Choose a higher plan only when its operational savings exceed the price difference.</li></ul></div>
+      </section>
+
+      <section class="p-8 rounded-3xl bg-purple-500/10 border border-purple-500/30 text-center space-y-4">
+        <div class="text-xs uppercase tracking-wider font-bold text-purple-300">Decision point</div>
+        <h2 class="text-3xl font-black text-white">Start the trial before you over-design the store</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto">The useful test is whether you can publish a real product, configure checkout and get a real visitor through the buying flow. Start with the current trial offer, then pay only if the store is worth continuing.</p>
+        <a data-cta="affiliate" data-tool-id="shopify" data-cta-source="shopify-pricing-final" href="https://shopify.pxf.io/7670642-link?sharedid=7670642" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex justify-center px-7 py-4 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-black">Start Shopify free via COSHUMA →</a>
+        <p class="text-[11px] text-slate-500">COSHUMA's Shopify welcome email explicitly identifies this exact URL as its personalized affiliate link. Always confirm the final offer and price shown by Shopify before purchase.</p>
+      </section>
+
+      <section class="p-5 rounded-2xl bg-[#0b0c10] border border-[#222538] text-xs text-slate-400 leading-relaxed">
+        <strong class="text-slate-300">Source note:</strong> Pricing and trial terms were checked against Shopify's official pricing page on September 6, 2026. The affiliate route was checked against the account-specific Shopify Affiliate welcome email sent to COSHUMA. Shopify can change pricing, promotions and regional terms.
+      </section>
+    </main>
+
+    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-5xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS buyer guides.</div></footer>
+    <script defer src="/affiliate-attribution.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Adds a high-intent Shopify pricing/free-trial landing using COSHUMA's exact personalized Shopify affiliate URL from the account-specific welcome email. Buyer claims are limited to Shopify's current official pricing page (3-day free trial, $1/month for 3 months, current US plan pricing) with regional-change caveats. No new paid services or unverified tracking parameters are introduced. The existing deployment workflow automatically validates /best/*.html sitemap inclusion.