### PR TITLE
Add Chatbase pricing and free-trial buyer landing

### DIFF
--- a/projects/GlobalSaaSHub/public/best/chatbase-pricing-free-trial.html
+++ b/projects/GlobalSaaSHub/public/best/chatbase-pricing-free-trial.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chatbase Pricing & Free Trial (2026): Hobby, Standard, Pro | COSHUMA</title>
+    <meta name="description" content="Compare current Chatbase pricing, free plan, 7-day paid trials and annual savings, then start through COSHUMA's verified Chatbase referral link." />
+    <link rel="canonical" href="https://coshuma.com/best/chatbase-pricing-free-trial.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://coshuma.com/best/chatbase-pricing-free-trial.html" />
+    <meta property="og:title" content="Chatbase Pricing & Free Trial (2026)" />
+    <meta property="og:description" content="Current Chatbase Free, Hobby, Standard and Pro pricing with trial and annual-billing guidance." />
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "Chatbase Pricing & Free Trial (2026)",
+      "dateModified": "2026-09-06",
+      "mainEntityOfPage": "https://coshuma.com/best/chatbase-pricing-free-trial.html",
+      "publisher": {"@type": "Organization", "name": "COSHUMA", "url": "https://coshuma.com/"}
+    }
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <style>
+      body { font-family: 'Inter', sans-serif; background:#0b0c10; color:#f1f5f9; }
+      h1,h2,h3 { font-family:'Outfit',sans-serif; }
+    </style>
+  </head>
+  <body class="min-h-screen bg-[#0b0c10] text-slate-100">
+    <header class="border-b border-[#222538] bg-[#07080c]/90 py-4 px-6 sticky top-0 z-50 backdrop-blur-md">
+      <div class="max-w-5xl mx-auto flex items-center justify-between">
+        <a href="/" class="font-black text-lg text-white">COSHUMA</a>
+        <a href="/best/index.html" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">Buyer guides</a>
+      </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-4 py-12 space-y-8">
+      <section class="p-7 md:p-9 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
+        <div class="inline-flex px-3 py-1 rounded-full text-xs font-extrabold bg-emerald-500/10 border border-emerald-500/20 text-emerald-300">Verified partner route</div>
+        <div class="space-y-3">
+          <h1 class="text-3xl md:text-5xl font-black tracking-tight text-white">Chatbase Pricing & Free Trial (2026)</h1>
+          <p class="text-slate-300 leading-relaxed">Chatbase offers a permanent Free plan plus 7-day trials on its paid Hobby, Standard and Pro tiers. Annual billing currently shows a 20% discount versus monthly billing.</p>
+        </div>
+        <a data-cta="affiliate" data-tool-id="chatbase" data-cta-source="best-chatbase-pricing-hero" href="https://link.chatbase.co/sang-kwon-an" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex items-center justify-center px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white">Start Chatbase via Verified COSHUMA Link →</a>
+        <p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if you become a paying Chatbase customer after using this verified referral link, at no extra cost to you.</p>
+      </section>
+
+      <section class="space-y-4">
+        <div>
+          <h2 class="text-2xl font-black text-white">Current Chatbase pricing</h2>
+          <p class="text-sm text-slate-400 mt-1">Checked against Chatbase's official pricing page on September 6, 2026. Pricing can change; confirm the checkout total before purchasing.</p>
+        </div>
+        <div class="grid md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-emerald-400">Free — $0/month</div><p class="text-sm text-slate-300 mt-2">50 message credits/month, 1 member and limited model access. Free-plan agents are deleted after 14 days of inactivity.</p></div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-emerald-400">Hobby — $40 monthly / $32 annual-rate</div><p class="text-sm text-slate-300 mt-2">700 message credits/month, 2 members, advanced models, integrations, basic analytics and attachments. A 7-day trial is offered.</p></div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-emerald-400">Standard — $150 monthly / $120 annual-rate</div><p class="text-sm text-slate-300 mt-2">4,000 message credits/month, 3 members, Helpdesk, voice, telephony, outbound campaigns, API access, personalization and advanced integrations. A 7-day trial is offered.</p></div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-extrabold text-emerald-400">Pro — $500 monthly / $400 annual-rate</div><p class="text-sm text-slate-300 mt-2">15,000 message credits/month, 5 members, advanced analytics, source suggestions and tickets as a source. A 7-day trial is offered.</p></div>
+        </div>
+      </section>
+
+      <section class="grid md:grid-cols-2 gap-4">
+        <div class="p-6 rounded-2xl bg-purple-500/5 border border-purple-500/20 space-y-3">
+          <h2 class="text-xl font-bold text-white">Which plan makes sense?</h2>
+          <p class="text-sm text-slate-300 leading-relaxed"><strong>Free</strong> is the safest place to validate an agent. <strong>Hobby</strong> adds integrations and more usage. <strong>Standard</strong> is where API, voice, telephony and advanced support integrations appear. <strong>Pro</strong> is aimed at heavier usage and advanced analytics.</p>
+        </div>
+        <div class="p-6 rounded-2xl bg-amber-500/5 border border-amber-500/20 space-y-3">
+          <h2 class="text-xl font-bold text-white">Check before upgrading</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">Chatbase is credit-based, so the right tier depends on message volume and model usage. Annual pricing is lower, but committing yearly only makes sense after your workload is proven.</p>
+        </div>
+      </section>
+
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-4">
+        <h2 class="text-2xl font-black text-white">Start with the verified referral route</h2>
+        <p class="text-sm text-slate-300 leading-relaxed">Chatbase support directly confirmed COSHUMA's customer-facing referral URL. Use it if you decide Chatbase is a fit, then verify the plan and billing term shown by Chatbase before subscribing.</p>
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a data-cta="affiliate" data-tool-id="chatbase" data-cta-source="best-chatbase-pricing-bottom" href="https://link.chatbase.co/sang-kwon-an" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white text-center font-extrabold text-sm">Try Chatbase via COSHUMA →</a>
+          <a data-cta="official" href="https://www.chatbase.co/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-slate-800 border border-slate-600 text-white text-center font-bold text-sm">Check official pricing</a>
+        </div>
+      </section>
+
+      <section class="p-5 rounded-2xl bg-[#0b0c10] border border-[#222538] text-xs text-slate-500 leading-relaxed">
+        <strong class="text-slate-300">Source transparency:</strong> Pricing, plan limits, annual discount and trial availability were checked against Chatbase's official pricing page on September 6, 2026. The COSHUMA referral URL was confirmed directly by Chatbase support on September 6, 2026.
+      </section>
+    </main>
+    <footer class="border-t border-[#222538] py-8 text-center text-xs text-slate-500">© 2026 COSHUMA. Independent AI & SaaS buyer guides.</footer>
+    <script defer src="/affiliate-attribution.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Add a purchase-intent Chatbase landing built from current official pricing and the customer-facing referral URL directly confirmed by Chatbase support.

- verified referral CTA: https://link.chatbase.co/sang-kwon-an
- current Free/Hobby/Standard/Pro pricing and 7-day paid trials
- monthly vs annual-rate guidance and annual 20% discount
- affiliate disclosure and official-pricing fallback
- existing affiliate attribution hooks included
- no paid services or speculative approval claims