### PR TITLE
Publish live affiliate coverage audit

### DIFF
--- a/.github/workflows/coshuma-site-deploy.yml
+++ b/.github/workflows/coshuma-site-deploy.yml
@@ -13,6 +13,7 @@ on:
       - 'projects/GlobalSaaSHub/scripts/polish_public_copy.py'
       - 'projects/GlobalSaaSHub/scripts/ensure_best_pages_in_sitemap.py'
       - 'projects/GlobalSaaSHub/scripts/inject_pictory_partner_offer.py'
+      - 'projects/GlobalSaaSHub/scripts/publish_affiliate_audit.mjs'
       - 'projects/GlobalSaaSHub/index.html'
       - 'projects/GlobalSaaSHub/package.json'
       - 'projects/GlobalSaaSHub/package-lock.json'
@@ -73,6 +74,10 @@ jobs:
       - name: Index buyer-intent hubs in sitemap
         run: python projects/GlobalSaaSHub/scripts/ensure_best_pages_in_sitemap.py
 
+      - name: Publish live affiliate coverage audit
+        working-directory: projects/GlobalSaaSHub
+        run: node scripts/publish_affiliate_audit.mjs
+
       - name: Build production bundle
         working-directory: projects/GlobalSaaSHub
         run: npm run build
@@ -81,6 +86,7 @@ jobs:
         run: |
           set -e
           test -f projects/GlobalSaaSHub/dist/index.html
+          test -f projects/GlobalSaaSHub/dist/admin-affiliate-audit.json
           grep -q 'COSHUMA' projects/GlobalSaaSHub/dist/index.html
           if grep -R -q 'GlobalSaaSHub' projects/GlobalSaaSHub/dist/tool projects/GlobalSaaSHub/dist/compare 2>/dev/null; then
             echo 'Legacy GlobalSaaSHub branding detected in generated production pages.'

--- a/projects/GlobalSaaSHub/scripts/publish_affiliate_audit.mjs
+++ b/projects/GlobalSaaSHub/scripts/publish_affiliate_audit.mjs
@@ -1,0 +1,82 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tools = JSON.parse(fs.readFileSync(path.join(root, 'data/tools.json'), 'utf8'));
+
+const terminalStatuses = new Set([
+  'program_closed_to_new_applicants',
+  'program_unavailable',
+  'no_affiliate_program',
+  'rejected',
+  'cooldown',
+  'closed',
+  'program_inactive',
+  'application_blocked_region',
+  'application_blocked_vendor_site_paused',
+  'blocked_partnerstack_marketplace_limited',
+]);
+
+const records = tools.map((tool) => {
+  const status = tool.affiliate_status || 'unclassified';
+  const hasAffiliateUrl = typeof tool.affiliate_url === 'string' && /^https?:\/\//i.test(tool.affiliate_url);
+  const revenueReady = tool.affiliate_verified === true && status === 'approved_tracking' && hasAffiliateUrl;
+  const terminal = terminalStatuses.has(status);
+  let blocker = null;
+  if (!revenueReady && !terminal) {
+    if (status === 'unclassified') blocker = 'affiliate_status_unclassified';
+    else if (!hasAffiliateUrl) blocker = 'exact_customer_affiliate_url_missing';
+    else if (tool.affiliate_verified !== true) blocker = 'affiliate_evidence_not_verified';
+    else blocker = `affiliate_status_${status}`;
+  }
+  return {
+    id: tool.id,
+    name: tool.name,
+    affiliateStatus: status,
+    affiliateVerified: tool.affiliate_verified === true,
+    hasAffiliateUrl,
+    revenueReady,
+    terminal,
+    blocker,
+    officialVerified: tool.official_verification_status === 'verified',
+    pricingVerified: tool.pricing_verified === true,
+    payoutSetupStatus: tool.payout_setup_status || null,
+  };
+});
+
+const counts = records.reduce((acc, item) => {
+  acc.totalTools += 1;
+  acc.revenueReady += Number(item.revenueReady);
+  acc.terminal += Number(item.terminal);
+  acc.openMonetizationGaps += Number(!item.revenueReady && !item.terminal);
+  acc.exactAffiliateUrlMissing += Number(!item.revenueReady && !item.terminal && !item.hasAffiliateUrl);
+  acc.unclassifiedAffiliateStatus += Number(item.affiliateStatus === 'unclassified');
+  acc.officialUnverified += Number(!item.officialVerified);
+  acc.pricingUnverified += Number(!item.pricingVerified);
+  acc.payoutNeedsReview += Number(item.revenueReady && item.payoutSetupStatus && item.payoutSetupStatus !== 'complete');
+  return acc;
+}, {
+  totalTools: 0,
+  revenueReady: 0,
+  terminal: 0,
+  openMonetizationGaps: 0,
+  exactAffiliateUrlMissing: 0,
+  unclassifiedAffiliateStatus: 0,
+  officialUnverified: 0,
+  pricingUnverified: 0,
+  payoutNeedsReview: 0,
+});
+
+const output = {
+  generatedAt: new Date().toISOString(),
+  policy: 'finish_existing_tool_affiliate_coverage_before_expansion',
+  allowNewTools: counts.openMonetizationGaps === 0,
+  counts,
+  openGaps: records.filter((item) => !item.revenueReady && !item.terminal),
+  revenueReady: records.filter((item) => item.revenueReady),
+  terminal: records.filter((item) => item.terminal),
+};
+
+fs.writeFileSync(path.join(root, 'public/admin-affiliate-audit.json'), `${JSON.stringify(output, null, 2)}\n`);
+console.log(JSON.stringify(counts));


### PR DESCRIPTION
Generate a machine-readable affiliate coverage audit from the current tools.json on every COSHUMA site deploy, publish it in the production bundle, and verify the file exists before gh-pages publication. No new tools, affiliate URLs, pricing claims, or paid services are added.