### PR TITLE
Convert Pipedrive pricing traffic into verified HighLevel revenue path

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/pipedrive.html
+++ b/projects/GlobalSaaSHub/public/tool/pipedrive.html
@@ -1,186 +1,140 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Pipedrive Pricing, Features & Alternatives (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Research Pipedrive pricing, CRM features, and alternatives for 2026. Review the official Pipedrive option and compare a verified GoHighLevel alternative for agency-focused sales and marketing workflows." />
-    <link rel="canonical" href="https://coshuma.com/tool/pipedrive.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://coshuma.com/tool/pipedrive.html" />
-    <meta property="og:title" content="Pipedrive Pricing, Features & Alternatives (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Research Pipedrive pricing and features, then compare a verified GoHighLevel alternative for agency-focused CRM, sales, and marketing workflows." />
-
-    <!-- JSON-LD Structured Data for Google Indexing -->
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "Pipedrive",
-      "operatingSystem": "Web",
-      "applicationCategory": "Sales & CRM",
-      "description": "Pipedrive is a sales-focused CRM platform designed to help small and medium businesses manage their sales pipeline, track deals, and automate workflows, ensuring no lead is missed."
-    }
-    </script>
-
-    <!-- Tailwind & Fonts -->
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pipedrive Pricing 2026: Lite, Growth, Premium & Ultimate | COSHUMA</title>
+  <meta name="description" content="Current Pipedrive pricing for 2026, plan differences, 14-day trial details, and a practical Pipedrive vs HighLevel decision for sales teams and agencies." />
+  <link rel="canonical" href="https://coshuma.com/tool/pipedrive.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://coshuma.com/tool/pipedrive.html" />
+  <meta property="og:title" content="Pipedrive Pricing 2026: Plans, Trial & HighLevel Alternative | COSHUMA" />
+  <meta property="og:description" content="Compare Pipedrive Lite, Growth, Premium and Ultimate pricing, then decide whether a sales CRM or an agency-focused all-in-one platform fits better." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"SoftwareApplication",
+    "name":"Pipedrive",
+    "applicationCategory":"BusinessApplication",
+    "operatingSystem":"Web",
+    "url":"https://www.pipedrive.com/",
+    "description":"Sales CRM with pipeline, email, automation, reporting and lead-management features."
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"Does Pipedrive have a free trial?","acceptedAnswer":{"@type":"Answer","text":"Pipedrive currently advertises a 14-day free trial with no credit card required on its pricing page."}},
+      {"@type":"Question","name":"What are the current Pipedrive plans?","acceptedAnswer":{"@type":"Answer","text":"Pipedrive currently lists Lite, Growth, Premium and Ultimate plans."}},
+      {"@type":"Question","name":"When should I compare HighLevel instead of Pipedrive?","acceptedAnswer":{"@type":"Answer","text":"Pipedrive is centered on sales pipeline management. HighLevel is worth comparing when an agency also needs funnels, marketing automation, websites, calendars, reputation management and client sub-accounts in one platform."}}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen bg-[#0b0c10]">
+<header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50">
+  <div class="max-w-6xl mx-auto px-5 py-4 flex items-center justify-between">
+    <a href="/" class="font-black text-white tracking-tight text-lg">COSHUMA</a>
+    <a href="/best/index.html" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">Buyer Guides</a>
+  </div>
+</header>
+<main class="max-w-5xl mx-auto px-5 py-12 space-y-8">
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-10 shadow-2xl">
+    <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-8">
+      <div class="max-w-2xl">
+        <div class="text-xs font-extrabold uppercase tracking-[0.18em] text-purple-300">Verified Sep 6, 2026</div>
+        <h1 class="text-4xl md:text-5xl font-black tracking-tight mt-3">Pipedrive pricing in 2026 — and when an agency should compare HighLevel</h1>
+        <p class="text-slate-300 mt-5 leading-relaxed">Pipedrive now uses four plans: Lite, Growth, Premium and Ultimate. Its official pricing page currently advertises a 14-day free trial with no credit card required. This guide keeps Pipedrive on official non-affiliate links and uses COSHUMA's separately verified HighLevel partner link only for visitors who need a broader agency stack.</p>
+        <div class="flex flex-col sm:flex-row gap-3 mt-7">
+          <a data-cta="official" href="https://www.pipedrive.com/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-slate-800 border border-slate-600 text-white font-extrabold text-center">Check Pipedrive pricing →</a>
+          <a data-cta="affiliate" data-tool-id="gohighlevel" data-cta-source="pipedrive_hero_agency_alternative" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-extrabold text-center">Compare HighLevel for agencies →</a>
+        </div>
+        <p class="text-[11px] text-slate-500 mt-3">Affiliate disclosure: COSHUMA may earn a commission if you sign up for HighLevel through the partner link. Pipedrive links on this page are standard official links because COSHUMA does not currently publish a verified Pipedrive customer tracking URL.</p>
       </div>
-    </header>
-
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
-          <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=pipedrive.com&sz=128" alt="Pipedrive logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
-            <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Sales & CRM</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Pipedrive</h1>
-            </div>
-          </div>
-
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
-        </div>
-
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">Pipedrive is a sales-focused CRM platform designed to help small and medium businesses manage their sales pipeline, track deals, and automate workflows, ensuring no lead is missed.</p>
-        </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Sales pipeline management</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Activity scheduling</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Lead management</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Sales reporting</div>
-          </div>
-        </div>
-
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Pipedrive</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
-            <a href="/tool/privy.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=privy.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Privy</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/reply-io.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=reply.io&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Reply.io</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/omnisend.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=omnisend.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Omnisend</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/gohighlevel.html" class="p-3.5 rounded-xl bg-[#181a29] border border-purple-500/30 hover:border-purple-400 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=gohighlevel.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">GoHighLevel</span></div><span class="text-[10px] font-extrabold text-purple-300">Agency CRM alternative</span></a>
-          </div>
-        </div>
-
-        <!-- Verified Revenue Alternative -->
-        <div class="p-6 rounded-2xl bg-purple-500/5 border border-purple-500/30 space-y-4">
-          <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-3">
-            <div>
-              <div class="text-[10px] uppercase font-extrabold tracking-[0.16em] text-purple-300">Alternative for agency workflows</div>
-              <h2 class="text-xl font-black text-white mt-1">Compare Pipedrive with GoHighLevel</h2>
-              <p class="text-sm text-slate-300 mt-2 leading-relaxed">If you are evaluating Pipedrive for an agency or an all-in-one sales and marketing workflow, GoHighLevel is another CRM option worth comparing. GlobalSaaSHub has a verified affiliate relationship with GoHighLevel; Pipedrive itself remains linked to its official website below.</p>
-            </div>
-            <span class="text-[10px] font-extrabold px-2.5 py-1 rounded-full border border-emerald-500/30 bg-emerald-500/10 text-emerald-300 whitespace-nowrap">Verified affiliate link</span>
-          </div>
-          <div class="flex flex-col sm:flex-row gap-3">
-            <a href="/tool/gohighlevel.html" class="px-5 py-3 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Review GoHighLevel on GlobalSaaSHub</a>
-            <a data-cta="affiliate" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Visit GoHighLevel via Verified Affiliate Link →</a>
-          </div>
-          <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: GlobalSaaSHub may earn a commission if you purchase through the verified GoHighLevel affiliate link, at no additional cost to you. This does not alter editorial rankings or ratings.</p>
-        </div>
-
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://pipedrive.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Pipedrive Site</span><span>→</span></a>
-        </div>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Pipedrive?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Pipedrive Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/pipedrive.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Pipedrive Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
+      <div class="min-w-[250px] p-5 rounded-2xl border border-emerald-500/20 bg-emerald-500/5">
+        <div class="text-xs uppercase tracking-wider font-bold text-emerald-300">Fast decision</div>
+        <p class="text-sm text-slate-300 mt-2"><strong class="text-white">Choose Pipedrive</strong> when the main job is managing deals, activities, follow-ups and a sales pipeline.</p>
+        <p class="text-sm text-slate-300 mt-3"><strong class="text-white">Compare HighLevel</strong> when an agency also wants client sub-accounts, funnels, sites, messaging, calendars, reputation and automation in one platform.</p>
       </div>
-    </main>
+    </div>
+  </section>
 
-    <!-- Footer -->
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-9">
+    <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-3">
+      <div>
+        <h2 class="text-2xl font-black">Current Pipedrive plan snapshot</h2>
+        <p class="text-sm text-slate-400 mt-2">Official annual-billing effective prices shown by Pipedrive on Sep 6, 2026. Taxes, currency and add-ons can change the final checkout total.</p>
       </div>
-    </footer>
-  </body>
+      <a href="https://www.pipedrive.com/pricing" target="_blank" rel="noopener noreferrer" class="text-sm font-bold text-purple-300">Verify live pricing ↗</a>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-6">
+      <div class="rounded-2xl bg-[#181a29] border border-[#2a2d42] p-5"><div class="text-xs font-bold text-slate-400">Lite</div><div class="text-3xl font-black mt-2">$14</div><div class="text-xs text-slate-500">per seat/month, annual billing</div><p class="text-sm text-slate-300 mt-4">Pipeline basics, leads, calendar, AI-assisted reporting and integrations.</p></div>
+      <div class="rounded-2xl bg-[#181a29] border border-[#2a2d42] p-5"><div class="text-xs font-bold text-slate-400">Growth</div><div class="text-3xl font-black mt-2">$39</div><div class="text-xs text-slate-500">per seat/month, annual billing</div><p class="text-sm text-slate-300 mt-4">Adds full email sync, tracking, automations, nurture sequences and forecasting.</p></div>
+      <div class="rounded-2xl bg-[#181a29] border border-purple-500/40 p-5"><div class="text-xs font-bold text-purple-300">Premium · Popular</div><div class="text-3xl font-black mt-2">$59</div><div class="text-xs text-slate-500">per seat/month, annual billing</div><p class="text-sm text-slate-300 mt-4">Adds lead generation/routing, scoring, enrichment, multi-email tools and e-signatures.</p></div>
+      <div class="rounded-2xl bg-[#181a29] border border-[#2a2d42] p-5"><div class="text-xs font-bold text-slate-400">Ultimate</div><div class="text-3xl font-black mt-2">$79</div><div class="text-xs text-slate-500">per seat/month, annual billing</div><p class="text-sm text-slate-300 mt-4">Adds stronger security controls, enrichment, sandbox testing and extended phone support.</p></div>
+    </div>
+    <div class="mt-5 p-4 rounded-xl bg-amber-500/5 border border-amber-500/20 text-sm text-slate-300">Pipedrive also lists paid add-ons such as LeadBooster, Projects, Campaigns, Web Visitors and Smart Docs. Compare the final configured checkout price, not only the base seat price.</div>
+  </section>
+
+  <section class="grid grid-cols-1 lg:grid-cols-2 gap-5">
+    <div class="rounded-3xl border border-[#222538] bg-[#131520] p-7">
+      <h2 class="text-2xl font-black">Pipedrive is the cleaner fit when…</h2>
+      <ul class="mt-5 space-y-3 text-sm text-slate-300">
+        <li>✓ Your buying decision is mainly about sales pipeline visibility.</li>
+        <li>✓ Reps need deal stages, activities, email sync and follow-up automation.</li>
+        <li>✓ You prefer per-seat CRM pricing over a broader agency operating system.</li>
+        <li>✓ You want a no-card trial before choosing a paid CRM plan.</li>
+      </ul>
+      <a data-cta="official" href="https://www.pipedrive.com/pricing" target="_blank" rel="noopener noreferrer" class="mt-6 block px-5 py-3 rounded-xl bg-slate-800 border border-slate-600 text-center font-extrabold">Start from official Pipedrive pricing →</a>
+    </div>
+    <div class="rounded-3xl border border-purple-500/35 bg-purple-500/5 p-7">
+      <div class="text-xs uppercase tracking-[0.16em] font-bold text-purple-300">Verified revenue alternative</div>
+      <h2 class="text-2xl font-black mt-2">HighLevel is worth comparing when…</h2>
+      <ul class="mt-5 space-y-3 text-sm text-slate-300">
+        <li>✓ You run an agency and need multiple client sub-accounts.</li>
+        <li>✓ CRM is only one part of a stack that also needs funnels, websites, calendars, messaging and automation.</li>
+        <li>✓ You want unlimited contacts/users under the current core plans rather than per-seat CRM pricing.</li>
+        <li>✓ SaaS mode or automated sub-account creation is part of the business model.</li>
+      </ul>
+      <div class="mt-5 text-xs text-slate-400">HighLevel currently lists Starter at $97/month, Unlimited at $297/month and Agency Pro at $497/month, each with a 14-day free trial on its official pricing page.</div>
+      <a data-cta="affiliate" data-tool-id="gohighlevel" data-cta-source="pipedrive_decision_agency_alternative" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="mt-6 block px-5 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-center font-extrabold">Try HighLevel via verified COSHUMA link →</a>
+    </div>
+  </section>
+
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-9">
+    <h2 class="text-2xl font-black">Pipedrive vs HighLevel: what are you actually buying?</h2>
+    <div class="overflow-x-auto mt-5">
+      <table class="w-full text-sm text-left">
+        <thead class="text-slate-400 border-b border-[#2a2d42]"><tr><th class="py-3 pr-4">Decision factor</th><th class="py-3 pr-4">Pipedrive</th><th class="py-3">HighLevel</th></tr></thead>
+        <tbody class="text-slate-300 divide-y divide-[#202334]">
+          <tr><td class="py-4 pr-4 font-bold text-white">Core job</td><td class="py-4 pr-4">Sales pipeline CRM</td><td class="py-4">Agency CRM + marketing/automation stack</td></tr>
+          <tr><td class="py-4 pr-4 font-bold text-white">Pricing model</td><td class="py-4 pr-4">Per-seat plans</td><td class="py-4">Core platform plans with unlimited contacts/users; sub-account limits vary by plan</td></tr>
+          <tr><td class="py-4 pr-4 font-bold text-white">Trial</td><td class="py-4 pr-4">14 days, no card advertised</td><td class="py-4">14 days advertised</td></tr>
+          <tr><td class="py-4 pr-4 font-bold text-white">Best fit</td><td class="py-4 pr-4">Sales teams that want focused CRM workflows</td><td class="py-4">Agencies consolidating CRM, funnels, sites, communications and automation</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-9">
+    <h2 class="text-2xl font-black">Bottom line</h2>
+    <p class="text-slate-300 mt-4 leading-relaxed">Do not pick HighLevel merely because COSHUMA has a partner link. If you only need a focused sales CRM, start with Pipedrive's official 14-day trial and evaluate the pipeline workflow. If you are an agency already paying separately for CRM, funnels, calendars, messaging and automation, compare the total stack cost against HighLevel before committing.</p>
+    <div class="flex flex-col sm:flex-row gap-3 mt-6">
+      <a data-cta="official" href="https://www.pipedrive.com/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-slate-800 border border-slate-600 text-center font-extrabold">Pipedrive official pricing</a>
+      <a data-cta="affiliate" data-tool-id="gohighlevel" data-cta-source="pipedrive_bottom_agency_alternative" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-purple-600 text-center font-extrabold">HighLevel verified partner link →</a>
+    </div>
+  </section>
+
+  <p class="text-xs text-slate-500 leading-relaxed">Source check: Pipedrive official pricing and plan documentation, plus HighLevel official pricing, verified Sep 6, 2026. COSHUMA's Pipedrive affiliate application remains separate from this page; no Pipedrive revenue attribution is claimed until an exact customer-facing tracking link is verified.</p>
+</main>
+<footer class="border-t border-[#222538] mt-12"><div class="max-w-5xl mx-auto px-5 py-8 text-xs text-slate-500">© 2026 COSHUMA · Independent software buyer guides</div></footer>
+<script src="/affiliate-attribution.js" defer></script>
+</body>
 </html>
-


### PR DESCRIPTION
Revenue-focused rewrite of the existing Pipedrive page using current official pricing checked Sep 6, 2026. Pipedrive remains official-only because its PartnerStack application is still pending and no exact customer-facing tracking URL is verified. The page now targets the existing `pipedrive pricing` search intent with current Lite/Growth/Premium/Ultimate pricing, the 14-day no-card trial, clearer plan fit, and three clearly disclosed HighLevel affiliate CTAs for agency visitors who need a broader all-in-one stack. HighLevel pricing/trial copy is grounded in its current official pricing page. No paid services, guessed links, duplicate applications, or Pipedrive affiliate claims.