### PR TITLE
fix(youtube-shorts): require checkable reference for verified claim_s…

### DIFF
--- a/projects/GlobalSaaSHub/data/youtube_shorts_campaigns.json
+++ b/projects/GlobalSaaSHub/data/youtube_shorts_campaigns.json
@@ -14,10 +14,12 @@
     "hashtags": ["Pictory", "AIVideo", "AITools"],
     "evidence": {
       "type": "affiliate_manager_email",
-      "sender": "Pictory Affiliate Manager",
-      "verified_at": "2026-09-04",
+      "sender": "Ashutosh Dhamija <ashutosh@pictory.ai>",
+      "verified_at": "2026-09-06",
       "claim_status": "verified_external_primary_source",
-      "note": "Primary-source partner email was re-read in the connected Gmail account on 2026-09-05. It explicitly confirms promo code coshuma20, a 20% discount, the then-current site-wide 40% annual offer, and combined savings over 52%.",
+      "note": "Re-verified 2026-09-06 by independently re-reading the primary-source email in the connected Gmail account (not just trusting this file's prior self-declared status). Message from ashutosh@pictory.ai, 2026-09-04T15:34:21Z, in thread 'There isn't one right way to promote Pictory', explicitly states: 'Promo code linked to your Affilaite account is \"coshuma20\"', 'your 20% discount', and 'our site-wide 40% discount combined with your promo code, subscribers can save over 52%.' gmail_thread_id/gmail_message_id below are the actual re-checkable Gmail identifiers, not prose, so any future run (human or automated) can re-open this exact message rather than trust this note.",
+      "gmail_thread_id": "1a06833b51e6cb00",
+      "gmail_message_id": "1a06d0ec1bf6a3a8",
       "verified_claims": {
         "promo_codes": ["COSHUMA20"],
         "discount_percentages": [20, 40, 52]

--- a/projects/GlobalSaaSHub/scripts/tests/test_youtube_shorts_claim_gate.py
+++ b/projects/GlobalSaaSHub/scripts/tests/test_youtube_shorts_claim_gate.py
@@ -22,7 +22,45 @@ def test_pictory_partner_email_claims_are_allowed_only_by_structured_verified_ev
     )
     assert report["failures"] == []
     assert report["checks"]["promotion_evidence"]["source_type"] == "affiliate_manager_email"
-    assert report["checks"]["promotion_evidence"]["verified_at"] == "2026-09-04"
+    assert report["checks"]["promotion_evidence"]["reference_field"] == "gmail_message_id"
+    assert report["checks"]["promotion_evidence"]["reference_value"] == "1a06d0ec1bf6a3a8"
+
+
+def test_verified_claim_without_checkable_reference_is_not_trusted(monkeypatch, tmp_path):
+    """claim_status alone is self-certification; it must not be trusted unless
+    it also carries a concrete, re-checkable reference (e.g. a Gmail message
+    id) to the primary source. This is a regression test for a real gap: an
+    earlier version of the evidence file only had a claim_status label and a
+    prose 'note', which anyone (or any future automated run) could set to
+    'verified_external_primary_source' without any way to audit it."""
+    campaigns_path = tmp_path / "youtube_shorts_campaigns.json"
+    campaigns_path.write_text(
+        """
+        {
+          "pictory": {
+            "campaign_slug": "pictory_coshuma20",
+            "evidence": {
+              "type": "affiliate_manager_email",
+              "claim_status": "verified_external_primary_source",
+              "note": "trust me, I read an email",
+              "verified_claims": {"promo_codes": ["COSHUMA20"], "discount_percentages": [20, 40, 52]}
+            }
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(quality_gate, "CAMPAIGNS_JSON", campaigns_path)
+
+    report = _report()
+    quality_gate.check_price_and_discount_claims(
+        "Use code COSHUMA20 for 20% off.",
+        "pictory",
+        "pictory_coshuma20",
+        report,
+    )
+    assert any("COSHUMA20" in failure for failure in report["failures"])
+    assert "promotion_evidence" not in report["checks"]
 
 
 def test_unknown_promo_code_fails_closed():

--- a/projects/GlobalSaaSHub/scripts/youtube_shorts/quality_gate.py
+++ b/projects/GlobalSaaSHub/scripts/youtube_shorts/quality_gate.py
@@ -223,6 +223,23 @@ def _campaign_verified_claims(affiliate_target: str, campaign_slug: str | None) 
     evidence = campaign.get("evidence") or {}
     if evidence.get("claim_status") != "verified_external_primary_source":
         return {}
+    # A "verified_external_primary_source" label is just prose someone typed
+    # into this JSON file unless it also carries a concrete, independently
+    # re-checkable reference to the primary source itself. Without this, the
+    # claim_status field is pure self-certification: anyone (or any future
+    # automated run) could mark a fabricated claim "verified" with no way to
+    # audit it. Require at least one checkable reference id.
+    reference_fields = (
+        "gmail_message_id",
+        "gmail_thread_id",
+        "source_url",
+        "screenshot_path",
+    )
+    matched_reference = next(
+        (field for field in reference_fields if evidence.get(field)), None
+    )
+    if not matched_reference:
+        return {}
     claims = evidence.get("verified_claims") or {}
     return {
         "promo_codes": {str(x).upper() for x in claims.get("promo_codes", [])},
@@ -230,6 +247,8 @@ def _campaign_verified_claims(affiliate_target: str, campaign_slug: str | None) 
         "prices": {str(x).replace(" ", "") for x in claims.get("prices", [])},
         "source_type": evidence.get("type"),
         "verified_at": evidence.get("verified_at"),
+        "reference_field": matched_reference,
+        "reference_value": evidence.get(matched_reference),
     }
 
 
@@ -268,6 +287,8 @@ def check_price_and_discount_claims(
             "source_type": verified.get("source_type"),
             "verified_at": verified.get("verified_at"),
             "campaign_slug": campaign_slug,
+            "reference_field": verified.get("reference_field"),
+            "reference_value": verified.get("reference_value"),
         }
 
     for price in price_claims:


### PR DESCRIPTION
…tatus

quality_gate.py's claim_status == "verified_external_primary_source" was pure self-certification: a prose note with no independently re-checkable reference. Hardened _campaign_verified_claims() to also require a concrete reference field (gmail_message_id, gmail_thread_id, source_url, or screenshot_path); otherwise it fails closed exactly like an unverified claim. Independently re-verified the Pictory COSHUMA20 claim by re-reading the real primary-source email (Gmail thread 1a06833b51e6cb00, message 1a06d0ec1bf6a3a8, from ashutosh@pictory.ai) and recorded those ids as the checkable reference. Added a regression test.