### PR TITLE
Optimize Beefree search traffic into verified AWeber revenue path

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/beefree-vs-aweber.html
+++ b/projects/GlobalSaaSHub/public/compare/beefree-vs-aweber.html
@@ -3,34 +3,28 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Beefree vs AWeber Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Beefree vs AWeber. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
-
+    <title>Beefree vs AWeber: Email Design vs Email Marketing (2026) | COSHUMA</title>
+    <meta name="description" content="Beefree vs AWeber explained by real buying intent: email design and export workflow versus subscriber management, sending and automation. See current AWeber pricing and choose the right stack." />
     <link rel="canonical" href="https://coshuma.com/compare/beefree-vs-aweber.html" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/compare/beefree-vs-aweber.html" />
-    <meta property="og:title" content="Beefree vs AWeber Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Beefree and AWeber by pricing, features, and verified public information." />
-
+    <meta property="og:title" content="Beefree vs AWeber: Email Design vs Email Marketing (2026) | COSHUMA" />
+    <meta property="og:description" content="Choose Beefree for design-first production or AWeber for sending, subscribers and automation. Current buyer guidance verified September 6, 2026." />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebPage",
-      "name": "Beefree vs AWeber Comparison",
+      "name": "Beefree vs AWeber: Email Design vs Email Marketing",
       "url": "https://coshuma.com/compare/beefree-vs-aweber.html",
-      "description": "Compare Beefree and AWeber by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
+      "description": "A buyer-focused comparison of Beefree/RGE Studio and AWeber for email design, sending, subscribers and automation.",
+      "dateModified": "2026-09-06",
+      "isPartOf": {"@type": "WebSite", "name": "COSHUMA", "url": "https://coshuma.com/"},
       "about": [
-        {"@type": "SoftwareApplication", "name": "Beefree", "url": "https://coshuma.com/tool/beefree.html"},
-        {"@type": "SoftwareApplication", "name": "AWeber", "url": "https://coshuma.com/tool/aweber.html"}
+        {"@type": "SoftwareApplication", "name": "RGE Studio (formerly Beefree)", "url": "https://beefree.io/"},
+        {"@type": "SoftwareApplication", "name": "AWeber", "url": "https://www.aweber.com/"}
       ]
     }
     </script>
-    
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -39,134 +33,105 @@
       body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
       h1, h2, h3 { font-family: 'Outfit', sans-serif; }
     </style>
+    <script defer src="/affiliate-attribution.js"></script>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div>
+          <span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/best/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">Buyer guides →</a>
       </div>
     </header>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
+    <main class="max-w-5xl mx-auto px-4 py-12 w-full space-y-8">
+      <section class="text-center space-y-5">
+        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Buyer decision guide · Verified Sep 6, 2026</div>
+        <h1 class="text-4xl md:text-6xl font-black text-white tracking-tight">Beefree vs AWeber</h1>
+        <p class="text-lg text-slate-300 max-w-3xl mx-auto leading-relaxed">These products overlap around email creation, but they solve different parts of the workflow. <strong class="text-white">Beefree (now RGE Studio)</strong> is design-first. <strong class="text-white">AWeber</strong> adds subscriber management, sending and automation.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-2xl mx-auto pt-2">
+          <a href="https://beefree.io/" target="_blank" rel="noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold text-sm bg-slate-800 border border-slate-600 hover:bg-slate-700 transition-all">Open Beefree / RGE Studio →</a>
+          <a data-cta="affiliate" data-tool-id="aweber" data-cta-source="compare_beefree_aweber_hero" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold text-sm bg-blue-600 border border-blue-500 hover:bg-blue-500 transition-all">Try AWeber via COSHUMA →</a>
         </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Beefree vs AWeber</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Email & Outreach tool.
-        </p>
-      </div>
+        <p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if you sign up or purchase through the AWeber partner link, at no extra cost beyond the offer AWeber shows you.</p>
+      </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-3">
+          <h2 class="text-xl font-black text-white">Choose Beefree / RGE Studio when…</h2>
+          <ul class="space-y-2 text-sm text-slate-300 leading-relaxed">
+            <li>• Your main job is designing responsive emails or landing-page content.</li>
+            <li>• You already have a sending platform and need a stronger visual production layer.</li>
+            <li>• Collaboration, reusable design assets and export workflow matter more than subscriber CRM.</li>
+          </ul>
+          <a href="https://beefree.io/" target="_blank" rel="noopener noreferrer" class="inline-flex text-sm font-bold text-purple-300 hover:text-purple-200">Visit the official Beefree site →</a>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Beefree if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose AWeber if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
+        <div class="p-6 rounded-3xl bg-[#131520] border border-blue-500/30 space-y-3">
+          <h2 class="text-xl font-black text-white">Choose AWeber when…</h2>
+          <ul class="space-y-2 text-sm text-slate-300 leading-relaxed">
+            <li>• You need to collect and manage subscribers, not just design the message.</li>
+            <li>• You want email sends, automations, landing pages and segmentation in one service.</li>
+            <li>• You prefer starting small and scaling with subscriber count.</li>
+          </ul>
+          <a data-cta="affiliate" data-tool-id="aweber" data-cta-source="compare_beefree_aweber_fit" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex text-sm font-bold text-blue-300 hover:text-blue-200">Check AWeber through the verified partner link →</a>
         </div>
-      </div>
+      </section>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/beefree.html" class="hover:text-purple-300">Beefree</a>
+      <section class="p-6 md:p-8 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
+        <div>
+          <h2 class="text-2xl font-black text-white">Current AWeber entry pricing</h2>
+          <p class="text-sm text-slate-400 mt-2">AWeber's official pricing/help pages were rechecked September 6, 2026. Final checkout terms can change, so verify the live offer before paying.</p>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
+            <div class="text-xs font-bold text-slate-400 uppercase">Free</div>
+            <div class="text-2xl font-black text-white mt-1">$0</div>
+            <p class="text-xs text-slate-400 mt-2">Official help lists up to 500 subscribers and 3,000 emails per month.</p>
           </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/aweber.html" class="hover:text-blue-300">AWeber</a>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/30">
+            <div class="text-xs font-bold text-blue-300 uppercase">Lite</div>
+            <div class="text-2xl font-black text-white mt-1">From $12.49/mo</div>
+            <p class="text-xs text-slate-400 mt-2">Current annual-billing display for the smallest subscriber tier.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/30">
+            <div class="text-xs font-bold text-blue-300 uppercase">Plus</div>
+            <div class="text-2xl font-black text-white mt-1">From $19.99/mo</div>
+            <p class="text-xs text-slate-400 mt-2">Current annual-billing display with unlimited automations and landing pages.</p>
           </div>
         </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
+        <div class="rounded-2xl bg-blue-500/10 border border-blue-500/20 p-5 flex flex-col md:flex-row gap-4 md:items-center md:justify-between">
           <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
+            <div class="font-extrabold text-white">Need sending + automation, not just design?</div>
+            <p class="text-sm text-slate-300 mt-1">AWeber's current public pricing page advertises a 14-day trial on paid plans.</p>
           </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
+          <a data-cta="affiliate" data-tool-id="aweber" data-cta-source="compare_beefree_aweber_pricing" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="shrink-0 px-5 py-3 rounded-xl font-extrabold text-sm bg-blue-600 hover:bg-blue-500 transition-all text-center">Start with AWeber →</a>
         </div>
+      </section>
 
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
+      <section class="p-6 md:p-8 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">The simplest decision</h2>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm text-left">
+            <thead class="text-slate-400 border-b border-[#222538]"><tr><th class="py-3 pr-4">Need</th><th class="py-3 pr-4">Better fit</th><th class="py-3">Why</th></tr></thead>
+            <tbody class="divide-y divide-[#222538] text-slate-300">
+              <tr><td class="py-4 pr-4">Design emails visually</td><td class="py-4 pr-4 font-bold text-purple-300">Beefree / RGE Studio</td><td class="py-4">Design and production are the center of the product.</td></tr>
+              <tr><td class="py-4 pr-4">Manage subscribers</td><td class="py-4 pr-4 font-bold text-blue-300">AWeber</td><td class="py-4">Subscriber lists and segmentation are native parts of the service.</td></tr>
+              <tr><td class="py-4 pr-4">Send campaigns</td><td class="py-4 pr-4 font-bold text-blue-300">AWeber</td><td class="py-4">Sending is part of the core product instead of an export handoff.</td></tr>
+              <tr><td class="py-4 pr-4">Automate follow-ups</td><td class="py-4 pr-4 font-bold text-blue-300">AWeber</td><td class="py-4">Automated sequences and workflows are built in.</td></tr>
+            </tbody>
+          </table>
         </div>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Beefree Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Drag-and-drop editor</div>
-<div>✓ Responsive email design</div>
-<div>✓ Landing page creation</div>
-<div>✓ No coding required</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">AWeber Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Email Campaign Creation</div>
-<div>✓ Automated Email Sequences</div>
-<div>✓ Landing Page Builder</div>
-<div>✓ Subscriber Management & Segmentation</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://beefree.io/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Beefree →</a>
-          <a href="https://www.aweber.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get AWeber →</a>
-        </div>
-      </div>
+      <section class="p-6 rounded-3xl bg-[#10121b] border border-[#222538] text-sm text-slate-400 leading-relaxed">
+        <strong class="text-slate-200">Verification note.</strong> Beefree's official site now presents the design product as RGE Studio (formerly Beefree). AWeber pricing and plan limits were checked against AWeber's official pricing and help documentation on September 6, 2026. The AWeber outbound revenue URL is the same account-specific affiliate route already verified in COSHUMA's repository; Beefree remains an ordinary official link because no verified COSHUMA Beefree tracking URL is being claimed here.
+      </section>
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent software buyer guides.</div>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
Revenue-focused rewrite of the existing Beefree vs AWeber comparison. COSHUMA already has Search Console visibility for the `beefree` query, while Beefree has no verified COSHUMA affiliate URL. This keeps Beefree as an ordinary official link and routes only the AWeber side through the existing repository-verified customer-facing AWeber affiliate URL. It removes placeholder `Not rated` copy, explains the actual design-vs-email-marketing decision, uses current AWeber pricing/help facts rechecked Sep 6, 2026, adds three source-tagged AWeber affiliate CTAs, and keeps affiliate disclosure/attribution explicit. No paid services, guessed links, new applications, or unverified revenue claims.