### PR TITLE
feat(youtube-shorts): add unlisted/public upload_privacy option

### DIFF
--- a/.github/workflows/coshuma-youtube-shorts.yml
+++ b/.github/workflows/coshuma-youtube-shorts.yml
@@ -25,11 +25,16 @@ on:
         required: false
         default: ''
         type: string
-      upload_private:
-        description: 'Upload the rendered Short as PRIVATE after quality gate. Requires existing YouTube OAuth repository secrets.'
+      upload_privacy:
+        description: 'Upload the rendered Short to YouTube with this privacy after quality gate. Requires existing YouTube OAuth repository secrets. Leave as "none" to render/quality-gate only.'
         required: false
-        default: false
-        type: boolean
+        default: 'none'
+        type: choice
+        options:
+          - none
+          - private
+          - unlisted
+          - public
 
 concurrency:
   group: coshuma-youtube-shorts-${{ github.ref }}
@@ -94,11 +99,11 @@ jobs:
           retention-days: 3
 
       - name: Render requested Short through quality gate
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.render_tool != '' && inputs.upload_private != true }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.render_tool != '' && inputs.upload_privacy == 'none' }}
         run: python3 scripts/youtube_shorts/run_pipeline.py "${{ inputs.render_tool }}"
 
-      - name: Verify OAuth secret presence for private upload
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.render_tool != '' && inputs.upload_private == true }}
+      - name: Verify OAuth secret presence for upload
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.render_tool != '' && inputs.upload_privacy != 'none' }}
         env:
           YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
           YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
@@ -113,18 +118,18 @@ jobs:
             fi
           done
           if [ "$missing" -ne 0 ]; then
-            echo "Private upload blocked safely. Configure the missing OAuth secrets after the channel owner completes Google's one-time consent flow."
+            echo "Upload blocked safely. Configure the missing OAuth secrets after the channel owner completes Google's one-time consent flow."
             exit 1
           fi
           echo "Required YouTube OAuth secrets are present. Values were not printed."
 
-      - name: Render, quality-gate, and upload requested Short as private
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.render_tool != '' && inputs.upload_private == true }}
+      - name: Render, quality-gate, and upload requested Short
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.render_tool != '' && inputs.upload_privacy != 'none' }}
         env:
           YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
           YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
           YOUTUBE_REFRESH_TOKEN: ${{ secrets.YOUTUBE_REFRESH_TOKEN }}
-        run: python3 scripts/youtube_shorts/run_pipeline.py "${{ inputs.render_tool }}" --upload-private
+        run: python3 scripts/youtube_shorts/run_pipeline.py "${{ inputs.render_tool }}" --upload "${{ inputs.upload_privacy }}"
 
       - name: Upload rendered dry-run artifact
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.render_tool != '' }}
@@ -135,8 +140,8 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Upload private-upload manifest evidence
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.render_tool != '' && inputs.upload_private == true }}
+      - name: Upload upload-manifest evidence
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.render_tool != '' && inputs.upload_privacy != 'none' }}
         uses: actions/upload-artifact@v6
         with:
           name: coshuma-short-upload-manifest-${{ inputs.render_tool }}-${{ github.run_id }}

--- a/projects/GlobalSaaSHub/scripts/youtube_shorts/run_pipeline.py
+++ b/projects/GlobalSaaSHub/scripts/youtube_shorts/run_pipeline.py
@@ -3,8 +3,9 @@
 
 Default behavior is a safe dry production run: generate evidence-bounded copy,
 render an MP4, quality-gate it, and record `ready` in the manifest. Nothing is
-uploaded unless --upload-private is explicitly supplied and OAuth environment
-variables are available.
+uploaded unless --upload {private,unlisted,public} is explicitly supplied and
+OAuth environment variables are available. --upload-private is kept as a
+backward-compatible alias for --upload private.
 """
 from __future__ import annotations
 
@@ -62,7 +63,9 @@ def upsert_ready(script: dict, metadata: dict, rendered: dict, report: dict) -> 
     MANIFEST_JSON.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
 
-def run(tool_id: str, upload_private: bool = False) -> dict:
+def run(tool_id: str, upload_privacy: str | None = None) -> dict:
+    if upload_privacy is not None and upload_privacy not in {"private", "unlisted", "public"}:
+        raise ValueError("upload_privacy must be None, 'private', 'unlisted', or 'public'")
     script = generate_script.generate(tool_id)
     tool = generate_metadata.load_tool(tool_id)
     coshuma_url = generate_metadata.build_coshuma_url(script["source_page"], script["campaign_slug"])
@@ -97,23 +100,36 @@ def run(tool_id: str, upload_private: bool = False) -> dict:
     upsert_ready(script, metadata, rendered, report)
 
     result = {"script": script, "metadata": metadata, "render": rendered, "quality_gate": report}
-    if upload_private:
+    if upload_privacy:
         import upload_youtube
         video_id = upload_youtube.upload(
-            Path(rendered["output"]), metadata["title"], metadata["description"], privacy="private"
+            Path(rendered["output"]), metadata["title"], metadata["description"], privacy=upload_privacy
         )
-        upload_youtube.record_manifest(script["campaign_slug"], video_id, "private")
+        upload_youtube.record_manifest(script["campaign_slug"], video_id, upload_privacy)
         result["youtube_video_id"] = video_id
-        result["youtube_privacy"] = "private"
+        result["youtube_privacy"] = upload_privacy
     return result
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("tool_id")
-    parser.add_argument("--upload-private", action="store_true")
+    parser.add_argument(
+        "--upload",
+        dest="upload_privacy",
+        choices=["private", "unlisted", "public"],
+        default=None,
+        help="Upload the rendered Short to YouTube with this privacy status. Omit to render/quality-gate only.",
+    )
+    parser.add_argument(
+        "--upload-private",
+        dest="upload_privacy",
+        action="store_const",
+        const="private",
+        help="Deprecated alias for --upload private (kept for backward compatibility).",
+    )
     args = parser.parse_args()
-    print(json.dumps(run(args.tool_id, args.upload_private), indent=2, ensure_ascii=False))
+    print(json.dumps(run(args.tool_id, args.upload_privacy), indent=2, ensure_ascii=False))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a workflow_dispatch `upload_privacy` choice input (none/private/unlisted/public, default none) replacing the old `upload_private` boolean, and updates run_pipeline.py to accept `--upload {private,unlisted,public}` (with `--upload-private` kept as a backward-compatible alias for `--upload private`). upload_youtube.py already supported all three privacy values, so this only changes the workflow surface and run_pipeline.py's plumbing. All 28 youtube_shorts tests pass locally against this branch.

No behavior changes for existing manual dispatches that leave upload_privacy at its default `none` (render + quality-gate only, same as before).