### PR TITLE
Monetize vidIQ educational resources from affiliate-provided deep links

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/vidiq.html
+++ b/projects/GlobalSaaSHub/public/tool/vidiq.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>VidIQ Pricing: Free, Boost & Max + YouTube Growth Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Compare VidIQ Free, Boost and Max for YouTube keyword research, AI Coach, thumbnails, competitor tracking and channel growth. See current 2026 pricing and start with the verified partner link." />
+    <title>VidIQ Pricing: Free, Boost & Max + YouTube Growth Review (2026) | COSHUMA</title>
+    <meta name="description" content="Compare VidIQ Free, Boost and Max for YouTube keyword research, AI Coach, thumbnails, competitor tracking and channel growth. See current 2026 pricing, educational growth resources and verified COSHUMA partner links." />
     <link rel="canonical" href="https://coshuma.com/tool/vidiq.html" />
 
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/tool/vidiq.html" />
     <meta property="og:title" content="VidIQ Pricing: Free, Boost & Max + YouTube Growth Review (2026)" />
-    <meta property="og:description" content="A practical 2026 guide to VidIQ Free, Boost and Max, including AI credits, keyword research, competitor tracking and verified pricing links." />
+    <meta property="og:description" content="A practical 2026 guide to VidIQ Free, Boost and Max, including AI credits, keyword research, competitor tracking and affiliate-enabled YouTube growth resources." />
 
     <script type="application/ld+json">
     {
@@ -44,8 +44,8 @@
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div>
+          <span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span>
         </a>
         <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
@@ -61,7 +61,7 @@
               <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">VidIQ Pricing & Review (2026)</h1>
             </div>
           </div>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-3 py-1.5 rounded-md">Pricing sources checked Sep 2, 2026</span>
+          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-3 py-1.5 rounded-md">Partner resources checked Sep 6, 2026</span>
         </div>
 
         <p class="text-slate-300 text-base md:text-lg leading-relaxed">
@@ -87,10 +87,10 @@
         </div>
 
         <div class="flex flex-col sm:flex-row gap-3">
-          <a data-cta="affiliate" data-tool-id="vidiq" href="https://vidiq.com/coshuma" target="_blank" rel="sponsored noopener noreferrer" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start VidIQ Free →</a>
+          <a data-cta="affiliate" data-tool-id="vidiq" data-cta-source="vidiq_tool_hero" href="https://vidiq.com/coshuma" target="_blank" rel="sponsored noopener noreferrer" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start VidIQ Free →</a>
           <a href="/compare/vidiq-vs-tubebuddy.html" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-[#181a29] border border-[#30344c] text-white text-center hover:border-purple-500/50 transition-all">Compare VidIQ vs TubeBuddy →</a>
         </div>
-        <p class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: the VidIQ button uses a verified COSHUMA partner link. GlobalSaaSHub may earn a commission if you purchase after using it, at no extra cost to you. Prices and regional offers can change; confirm the final amount at checkout.</p>
+        <p class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: the VidIQ button uses a verified COSHUMA partner link. COSHUMA may earn a commission if you purchase after using it, at no extra cost to you. Prices and regional offers can change; confirm the final amount at checkout.</p>
       </section>
 
       <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
@@ -123,6 +123,29 @@
         </div>
       </section>
 
+      <section class="p-6 rounded-3xl bg-[#131520] border border-emerald-500/20 space-y-5">
+        <div class="space-y-2">
+          <div class="text-xs uppercase tracking-wider text-emerald-300 font-bold">Free educational paths with affiliate attribution</div>
+          <h2 class="text-2xl font-black text-white">Start with the YouTube milestone you are trying to reach</h2>
+          <p class="text-sm text-slate-300 leading-relaxed">VidIQ's affiliate team supplied these exact article links to COSHUMA on September 6, 2026 and stated that the affiliate parameters are already inserted, so a reader who later signs up can still be credited to COSHUMA. These links go to educational content first rather than directly to checkout.</p>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <a data-cta="affiliate" data-tool-id="vidiq" data-cta-source="vidiq_resource_1000_subscribers" href="https://vidiq.com/blog/post/how-to-get-your-first-1000-youtube-subscribers/?afmc=coshuma&a=114282" target="_blank" rel="sponsored noopener noreferrer" class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] hover:border-emerald-500/40 transition-all">
+            <div class="text-sm font-bold text-white">Get your first 1,000 subscribers →</div>
+            <div class="text-xs text-slate-400 mt-2 leading-relaxed">A beginner-focused guide for the subscriber milestone that unlocks more channel opportunities.</div>
+          </a>
+          <a data-cta="affiliate" data-tool-id="vidiq" data-cta-source="vidiq_resource_4000_watch_hours" href="https://vidiq.com/blog/post/how-to-generate-4000-hours-watch-time-youtube/?afmc=coshuma&a=114282" target="_blank" rel="sponsored noopener noreferrer" class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] hover:border-emerald-500/40 transition-all">
+            <div class="text-sm font-bold text-white">Build toward 4,000 watch hours →</div>
+            <div class="text-xs text-slate-400 mt-2 leading-relaxed">Practical watch-time strategies for creators focused on monetization eligibility.</div>
+          </a>
+          <a data-cta="affiliate" data-tool-id="vidiq" data-cta-source="vidiq_resource_monetization_guide" href="https://vidiq.com/blog/post/how-to-monetize-youtube-channel-beginners-guide/?afmc=coshuma&a=114282" target="_blank" rel="sponsored noopener noreferrer" class="p-5 rounded-2xl bg-[#181a29] border border-[#222538] hover:border-emerald-500/40 transition-all">
+            <div class="text-sm font-bold text-white">Read the YouTube monetization guide →</div>
+            <div class="text-xs text-slate-400 mt-2 leading-relaxed">A step-by-step overview for creators planning the full monetization path.</div>
+          </a>
+        </div>
+        <p class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: the three educational links above are customer-facing URLs supplied by the VidIQ Affiliate Team with COSHUMA affiliate parameters already embedded. COSHUMA may earn a commission if a referred reader later signs up or purchases.</p>
+      </section>
+
       <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
         <h2 class="text-2xl font-black text-white">VidIQ vs TubeBuddy: quick choice</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -141,17 +164,17 @@
       <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4 text-center">
         <h2 class="text-2xl font-black text-white">Best low-risk starting point: test the free plan</h2>
         <p class="text-sm text-slate-300 max-w-2xl mx-auto leading-relaxed">Use the free tier to see whether VidIQ's ideas, keyword data, competitor signals and AI workflow match the way you plan videos. Upgrade only when the free limits are clearly holding back your workflow.</p>
-        <a data-cta="affiliate" data-tool-id="vidiq" href="https://vidiq.com/coshuma" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Try VidIQ Free via COSHUMA →</a>
+        <a data-cta="affiliate" data-tool-id="vidiq" data-cta-source="vidiq_tool_bottom" href="https://vidiq.com/coshuma" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Try VidIQ Free via COSHUMA →</a>
         <p class="text-[10px] text-slate-500">Verified partner URL: vidiq.com/coshuma. Final pricing, taxes, discounts and regional availability are controlled by VidIQ.</p>
       </section>
 
       <section class="p-5 rounded-2xl bg-[#10121b] border border-[#222538] text-xs text-slate-500 leading-relaxed">
-        <strong class="text-slate-300">Source note:</strong> pricing references are based on VidIQ's official 2026 plan/help pages and its official VidIQ-vs-TubeBuddy comparison, which states U.S. pricing checked August 7, 2026. Feature limits are based on VidIQ's May 6, 2026 plan-credit documentation. This page does not claim hands-on testing where none was performed.
+        <strong class="text-slate-300">Source note:</strong> pricing references are based on VidIQ's official 2026 plan/help pages and its official VidIQ-vs-TubeBuddy comparison, which states U.S. pricing checked August 7, 2026. Feature limits are based on VidIQ's May 6, 2026 plan-credit documentation. The educational deep links were supplied directly by the VidIQ Affiliate Team to COSHUMA on September 6, 2026 with affiliate parameters already inserted. This page does not claim hands-on testing where none was performed.
       </section>
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. AI SaaS decision and buyer-guide platform. All rights reserved.</div>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
Revenue-focused update using fresh primary-source affiliate evidence received Sep 6, 2026. VidIQ's affiliate team explicitly supplied six educational article URLs with COSHUMA affiliate parameters already inserted and stated that referred signups remain credited. This PR adds three of the highest-intent educational paths (1,000 subscribers, 4,000 watch hours, YouTube monetization guide) to the existing VidIQ buyer page with source-level affiliate attribution and disclosure. It also removes stale GlobalSaaSHub branding from that page. No paid service, guessed parameter, duplicate application, or generic dashboard/onboarding URL is introduced.