### PR TITLE
Optimize SaneBox search traffic into verified email revenue paths

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/sanebox.html
+++ b/projects/GlobalSaaSHub/public/tool/sanebox.html
@@ -3,181 +3,183 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Sanebox Pricing, Features & Alternatives (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Compare Sanebox pricing, core inbox-management features, and alternatives for email workflows. Review Sanebox's official site and compare AWeber before choosing an email tool." />
+    <title>SaneBox Pricing & Alternatives (2026) | COSHUMA</title>
+    <meta name="description" content="SaneBox pricing, 7-day free trial, plan differences, and buyer guidance for 2026. Compare inbox triage with verified AWeber and Moosend email-marketing alternatives." />
     <link rel="canonical" href="https://coshuma.com/tool/sanebox.html" />
-    
-    <!-- Open Graph SEO Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/sanebox.html" />
-    <meta property="og:title" content="Sanebox Pricing, Features & Alternatives (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Sanebox's inbox-management features, official pricing path, and related email-workflow alternatives including AWeber." />
-
-    <!-- JSON-LD Structured Data for Google Indexing -->
+    <meta property="og:title" content="SaneBox Pricing & Alternatives (2026) | COSHUMA" />
+    <meta property="og:description" content="Current SaneBox pricing, free-trial details, plan fit, and a clear inbox-management vs email-marketing decision guide." />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
-      "name": "Sanebox",
+      "name": "SaneBox",
       "operatingSystem": "Web",
-      "applicationCategory": "Email & Outreach",
-      "description": "Sanebox is an AI-powered email management tool that helps users prioritize important emails, organize their inbox, and reduce clutter efficiently."
+      "applicationCategory": "BusinessApplication",
+      "url": "https://www.sanebox.com/",
+      "description": "SaneBox is an email-management service that prioritizes and organizes incoming email across major email providers and compatible mail servers."
     }
     </script>
-
-    <!-- Tailwind & Fonts -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "How much does SaneBox cost?",
+          "acceptedAnswer": {"@type": "Answer", "text": "SaneBox currently lists Snack at $4.54/month, Lunch at $7.46/month, and Dinner at $22.04/month when paid biyearly. Billing options and prices can change, so check SaneBox's live pricing page before purchase."}
+        },
+        {
+          "@type": "Question",
+          "name": "Does SaneBox have a free trial?",
+          "acceptedAnswer": {"@type": "Answer", "text": "SaneBox's current pricing page offers a 7-day free trial with all features for up to four email accounts."}
+        },
+        {
+          "@type": "Question",
+          "name": "Is AWeber an alternative to SaneBox?",
+          "acceptedAnswer": {"@type": "Answer", "text": "Only for a different job. SaneBox manages incoming inbox clutter; AWeber is for subscriber lists, campaigns, landing pages, and marketing automation."}
+        }
+      ]
+    }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
+      body { font-family: 'Inter', sans-serif; background:#0b0c10; color:#f1f5f9; }
+      h1,h2,h3 { font-family:'Outfit',sans-serif; }
     </style>
   </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
+  <body class="min-h-screen bg-[#0b0c10]">
+    <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+      <div class="max-w-5xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white">C</div>
+          <span class="font-extrabold text-lg text-white">COSHUMA</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/best/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20">Buyer guides →</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
+    <main class="max-w-5xl mx-auto px-4 py-10 space-y-7">
+      <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-9 shadow-2xl">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=sanebox.com&sz=128" alt="Sanebox logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=sanebox.com&sz=128" alt="SaneBox logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Email & Outreach</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Sanebox</h1>
+              <div class="text-xs font-bold text-purple-300 mb-2">Inbox management · pricing verified Sep 6, 2026</div>
+              <h1 class="text-4xl md:text-5xl font-black text-white">SaneBox pricing: is it worth it?</h1>
+              <p class="text-slate-400 mt-2 max-w-2xl">For people who want a cleaner incoming inbox — not a newsletter or marketing platform.</p>
             </div>
           </div>
+          <a data-cta="official" href="https://www.sanebox.com/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 whitespace-nowrap">Check SaneBox pricing →</a>
+        </div>
+      </section>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
+      <section class="grid md:grid-cols-3 gap-4">
+        <article class="rounded-2xl border border-[#222538] bg-[#131520] p-5">
+          <div class="text-xs font-extrabold text-purple-300 uppercase tracking-wider">Snack</div>
+          <div class="text-3xl font-black text-white mt-2">$4.54<span class="text-sm text-slate-500">/mo</span></div>
+          <p class="text-xs text-slate-500 mt-1">Paid biyearly</p>
+          <p class="text-sm text-slate-300 mt-4">1 email account · choose 2 SaneBox features.</p>
+        </article>
+        <article class="rounded-2xl border border-purple-500/30 bg-purple-500/5 p-5">
+          <div class="text-xs font-extrabold text-purple-300 uppercase tracking-wider">Lunch</div>
+          <div class="text-3xl font-black text-white mt-2">$7.46<span class="text-sm text-slate-500">/mo</span></div>
+          <p class="text-xs text-slate-500 mt-1">Paid biyearly</p>
+          <p class="text-sm text-slate-300 mt-4">2 email accounts · 6 selectable features per account.</p>
+        </article>
+        <article class="rounded-2xl border border-[#222538] bg-[#131520] p-5">
+          <div class="text-xs font-extrabold text-purple-300 uppercase tracking-wider">Dinner</div>
+          <div class="text-3xl font-black text-white mt-2">$22.04<span class="text-sm text-slate-500">/mo</span></div>
+          <p class="text-xs text-slate-500 mt-1">Paid biyearly</p>
+          <p class="text-sm text-slate-300 mt-4">4 email accounts · all listed SaneBox features.</p>
+        </article>
+      </section>
+
+      <section class="rounded-2xl border border-emerald-500/20 bg-emerald-500/5 p-6 md:p-7">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-5">
+          <div>
+            <div class="text-xs uppercase font-bold text-emerald-300 tracking-wider">Current trial</div>
+            <h2 class="text-2xl font-extrabold text-white mt-1">7 days with all features</h2>
+            <p class="text-sm text-slate-300 mt-2 max-w-2xl">SaneBox says the free trial includes all features for up to four email accounts. Use the trial to test whether prioritization and folders actually reduce your inbox workload before paying.</p>
           </div>
+          <a data-cta="official" href="https://www.sanebox.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-emerald-600 text-white text-center hover:bg-emerald-500 whitespace-nowrap">Try SaneBox officially →</a>
         </div>
+      </section>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">Sanebox is an AI-powered email management tool that helps users prioritize important emails, organize their inbox, and reduce clutter efficiently.</p>
+      <section class="rounded-2xl border border-[#222538] bg-[#131520] p-6 md:p-7 space-y-5">
+        <div>
+          <div class="text-xs uppercase font-bold text-slate-500 tracking-wider">Buying decision</div>
+          <h2 class="text-2xl font-extrabold text-white mt-1">Choose by the job you actually need done</h2>
         </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI email prioritization</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Automated inbox organization</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Spam and clutter reduction</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Do Not Disturb feature</div>
-          </div>
-        </div>
-
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
+        <div class="grid md:grid-cols-2 gap-4">
+          <div class="rounded-xl border border-slate-700 bg-[#0b0c10] p-5">
+            <h3 class="font-extrabold text-white">Choose SaneBox when…</h3>
+            <ul class="mt-3 space-y-2 text-sm text-slate-300 list-disc list-inside">
+              <li>Your main problem is incoming-email overload.</li>
+              <li>You want SaneLater, reminders, Do Not Disturb, screening, or automatic prioritization.</li>
+              <li>You use Gmail, Microsoft 365, iCloud, Yahoo, Fastmail, IMAP, Exchange, or ActiveSync.</li>
             </ul>
           </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
+          <div class="rounded-xl border border-purple-500/30 bg-purple-500/5 p-5">
+            <h3 class="font-extrabold text-white">Choose an email-marketing platform when…</h3>
+            <ul class="mt-3 space-y-2 text-sm text-slate-300 list-disc list-inside">
+              <li>You need to collect subscribers and send campaigns.</li>
+              <li>You need landing pages, autoresponders, segmentation, or marketing automation.</li>
+              <li>Your goal is audience growth or sales rather than personal inbox triage.</li>
             </ul>
           </div>
         </div>
+      </section>
 
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Sanebox</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/convertkit.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=kit.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Kit (formerly ConvertKit)</span></div><span class="text-[10px] font-extrabold text-emerald-400">Free plan; Creator plan from $33/month for 1,000 subscribers</span></a>
-<a href="/tool/aweber.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=aweber.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">AWeber</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/moosend.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=moosend.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Moosend</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-          <a href="/compare/sanebox-vs-aweber.html" class="inline-flex items-center gap-2 text-sm font-bold text-purple-300 hover:text-purple-200 transition-colors">Compare Sanebox vs AWeber →</a>
+      <section class="rounded-3xl border border-purple-500/30 bg-gradient-to-br from-purple-500/10 to-[#131520] p-6 md:p-8 space-y-6">
+        <div>
+          <div class="text-xs uppercase font-bold text-purple-300 tracking-wider">Verified revenue alternatives</div>
+          <h2 class="text-2xl font-extrabold text-white mt-1">Need to send marketing email instead?</h2>
+          <p class="text-sm text-slate-300 mt-2">These are different products from SaneBox. COSHUMA has verified customer-facing partner routes for both, so only these buttons are marked as affiliate links.</p>
         </div>
-
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://sanebox.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Sanebox Site</span><span>→</span></a>
-        </div>
-
-        <!-- Verified Revenue Alternative -->
-        <div class="p-6 rounded-2xl bg-purple-500/5 border border-purple-500/25 space-y-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-purple-300 tracking-wider">Related Email Marketing Alternative</div>
-            <h2 class="text-xl font-extrabold text-white mt-1">Need email marketing automation rather than inbox triage?</h2>
-            <p class="text-sm text-slate-300 mt-2 leading-relaxed">AWeber serves a different primary use case from Sanebox, but it can be relevant if your goal is subscriber email marketing, campaigns, and automation rather than inbox prioritization.</p>
-          </div>
-          <div class="flex flex-col sm:flex-row gap-3">
-            <a href="/compare/sanebox-vs-aweber.html" class="px-5 py-3 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Compare Sanebox vs AWeber</a>
-            <a data-cta="affiliate" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center hover:bg-purple-500 transition-all">Visit AWeber via Verified Partner Link →</a>
-          </div>
-          <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: GlobalSaaSHub may earn a commission if you purchase through the AWeber partner link, at no additional cost to you. Sanebox's official link above is not presented as an affiliate link.</p>
-        </div>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Sanebox?</span>
+        <div class="grid md:grid-cols-2 gap-4">
+          <article class="rounded-2xl border border-purple-500/30 bg-[#0b0c10]/70 p-5 space-y-3">
+            <h3 class="text-xl font-extrabold text-white">AWeber</h3>
+            <p class="text-sm text-slate-300">A straightforward fit for subscriber lists, newsletters, landing pages and automations. Current annual-rate pricing starts around $12.49/month for Lite and $19.99/month for Plus at the 0–500 subscriber tier; AWeber currently advertises a 14-day trial.</p>
+            <div class="flex flex-col sm:flex-row gap-2">
+              <a href="/compare/sanebox-vs-aweber.html" class="px-4 py-3 rounded-xl text-xs font-extrabold bg-slate-800 border border-slate-600 text-white text-center">Compare first</a>
+              <a data-cta="affiliate" data-tool-id="aweber" data-cta-source="sanebox-intent-aweber" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="px-4 py-3 rounded-xl text-xs font-extrabold bg-purple-600 text-white text-center hover:bg-purple-500">Start AWeber via COSHUMA →</a>
             </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Sanebox Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/sanebox.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Sanebox Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
+          </article>
+          <article class="rounded-2xl border border-purple-500/30 bg-[#0b0c10]/70 p-5 space-y-3">
+            <h3 class="text-xl font-extrabold text-white">Moosend</h3>
+            <p class="text-sm text-slate-300">Another email-marketing option when the job is campaigns and automation rather than inbox cleanup. Review its live plan terms before choosing.</p>
+            <div class="flex flex-col sm:flex-row gap-2">
+              <a href="/tool/moosend.html" class="px-4 py-3 rounded-xl text-xs font-extrabold bg-slate-800 border border-slate-600 text-white text-center">Review Moosend</a>
+              <a data-cta="affiliate" data-tool-id="moosend" data-cta-source="sanebox-intent-moosend" href="https://trymoo.moosend.com/6eappdpw04pw" target="_blank" rel="sponsored noopener noreferrer" class="px-4 py-3 rounded-xl text-xs font-extrabold bg-purple-600 text-white text-center hover:bg-purple-500">Try Moosend via COSHUMA →</a>
+            </div>
+          </article>
         </div>
+        <p class="text-[11px] leading-relaxed text-slate-500"><strong class="text-slate-400">Affiliate disclosure:</strong> COSHUMA may earn a commission if you sign up or purchase through the AWeber or Moosend partner links. The SaneBox buttons on this page are standard official links and are not presented as affiliate tracking links.</p>
+      </section>
 
+      <section class="rounded-2xl border border-[#222538] bg-[#131520] p-6 md:p-7">
+        <h2 class="text-2xl font-extrabold text-white">Bottom line</h2>
+        <p class="text-sm text-slate-300 mt-3 leading-relaxed">SaneBox is the more direct purchase when your pain is a crowded personal or work inbox. If you arrived searching for SaneBox but actually need to build a list and send automated marketing, compare AWeber or Moosend instead. COSHUMA keeps those two use cases separate so an affiliate link is not mistaken for a SaneBox recommendation.</p>
+        <div class="flex flex-col sm:flex-row gap-3 mt-5">
+          <a data-cta="official" href="https://www.sanebox.com/pricing" target="_blank" rel="noopener noreferrer" class="px-5 py-3 rounded-xl font-extrabold text-sm bg-slate-800 border border-slate-600 text-white text-center">See live SaneBox pricing</a>
+          <a href="/compare/sanebox-vs-aweber.html" class="px-5 py-3 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center hover:bg-purple-500">SaneBox vs AWeber guide →</a>
+        </div>
+      </section>
 
-      </div>
+      <section class="text-xs text-slate-500 px-1 leading-relaxed">
+        <strong class="text-slate-400">Source check:</strong> SaneBox official pricing and help pages checked September 6, 2026. AWeber pricing and trial information checked against AWeber's official pricing/help pages on the same date. Prices and promotions can change; the vendor checkout is the final source of truth.
+      </section>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-5xl mx-auto px-4">&copy; 2026 COSHUMA. Independent SaaS buyer guides.</div>
     </footer>
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>
-


### PR DESCRIPTION
Revenue-focused, zero-cost update for an existing search-visible page.

- COSHUMA's stored Search Console snapshot shows `sanebox` with 36 impressions and 0 clicks.
- Replaces stale GlobalSaaSHub branding, placeholder rating/pros copy, and generic pricing text with current SaneBox buyer guidance.
- Uses SaneBox's official pricing page only for SaneBox: 7-day trial and current biyearly rates ($4.54 Snack / $7.46 Lunch / $22.04 Dinner).
- Keeps SaneBox non-affiliate because COSHUMA has no verified customer-facing SaneBox tracking URL.
- Adds clear, use-case-separated verified partner CTAs for AWeber and Moosend, with `data-tool-id` and source-specific attribution metadata.
- Keeps affiliate disclosure explicit so email-marketing alternatives are not mistaken for SaneBox affiliate links.
- Removes the stale $49/year founder-claim section from this buyer-intent page.

Evidence: SaneBox official pricing/help checked Sep 6, 2026; AWeber official pricing/help checked Sep 6, 2026; AWeber and Moosend partner URLs already verified in repository data/sync logic. No paid service, new affiliate application, guessed tracking URL, or generic dashboard URL.