### PR TITLE
Optimize Relevance AI buyer-intent affiliate landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/relevance-ai.html
+++ b/projects/GlobalSaaSHub/public/tool/relevance-ai.html
@@ -3,29 +3,24 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Relevance AI Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="B2B workforce platform to build, train, and deploy autonomous AI agents and automated workflows.... Discover features, pricing (Free plan available; credit-based usage starting at $234/month), and official links for Relevance AI on GlobalSaaSHub." />
+    <title>Relevance AI Pricing & Buyer Guide (2026) | COSHUMA</title>
+    <meta name="description" content="Relevance AI buyer guide for AI agent teams: current product positioning, pricing reality, free entry path, enterprise controls, integrations, and a verified COSHUMA partner link." />
     <link rel="canonical" href="https://coshuma.com/tool/relevance-ai.html" />
-    
-    <!-- Open Graph SEO Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/relevance-ai.html" />
-    <meta property="og:title" content="Relevance AI Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="B2B workforce platform to build, train, and deploy autonomous AI agents and automated workflows.... Check rating, pricing, and features." />
-
-    <!-- JSON-LD Structured Data for Google Indexing -->
+    <meta property="og:title" content="Relevance AI Pricing & Buyer Guide (2026) | COSHUMA" />
+    <meta property="og:description" content="Decide whether Relevance AI fits your AI-agent workflow, then use COSHUMA's verified partner route or the official pricing page." />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Relevance AI",
       "operatingSystem": "Web",
-      "applicationCategory": "Coding & Dev Tools",
-      "description": "B2B workforce platform to build, train, and deploy autonomous AI agents and automated workflows."
+      "applicationCategory": "BusinessApplication",
+      "description": "AI workforce platform for specialist agents, multi-agent workflows, integrations, evaluations and enterprise controls.",
+      "url": "https://relevanceai.com/"
     }
     </script>
-
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -37,132 +32,108 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div>
+          <span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Browse all tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
+    <main class="max-w-5xl mx-auto px-4 py-12 w-full space-y-6">
+      <section class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-7">
+        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=relevanceai.com&sz=128" alt="Relevance AI logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=relevanceai.com&sz=128" alt="Relevance AI logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Coding & Dev Tools</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Relevance AI</h1>
+              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">AI Agents & Automation</div>
+              <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Relevance AI</h1>
+              <p class="text-slate-400 mt-2">Buyer guide verified against current official product and pricing pages · Sep 6, 2026</p>
             </div>
           </div>
-
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
+          <div class="text-xs font-bold px-3 py-1 rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-300">Verified partner route</div>
         </div>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">B2B workforce platform to build, train, and deploy autonomous AI agents and automated workflows.</p>
-        </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> No-Code AI Agent Builder</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> B2B Workflow Automation</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Multi-Agent Orchestration</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Custom API Integrations</div>
-          </div>
-        </div>
-
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (Free plan available; credit-based usage starting at $234/month)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Relevance AI</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/agentworks.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=agentworks.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">AgentWorks</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
-
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">Free plan available; credit-based usage starting at $234/month</div>
-          </div>
-          <a data-cta="official" href="https://relevanceai.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Relevance AI Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://relevanceai.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit Relevance AI via Verified Affiliate Link</span><span>→</span></a>
-        </div>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Relevance AI?</span>
+        <div class="grid md:grid-cols-[1.25fr_.75fr] gap-6 items-start border-t border-[#222538] pt-7">
+          <div class="space-y-4">
+            <h2 class="text-2xl font-extrabold text-white">Best for teams turning repeatable work into specialist AI agents</h2>
+            <p class="text-slate-300 leading-relaxed">Relevance AI positions its platform around specialist agents that own narrow tasks, can be coordinated into larger workforces, connect to business apps, and be monitored with evaluations and tracing. It is a stronger fit when you want governed AI workers rather than a simple trigger-and-action automation.</p>
+            <div class="grid sm:grid-cols-2 gap-3 text-sm">
+              <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><span class="font-bold text-white">Choose it for:</span><br><span class="text-slate-400">agent workflows, multi-agent coordination, app integrations, evaluations and enterprise controls.</span></div>
+              <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><span class="font-bold text-white">Skip it if:</span><br><span class="text-slate-400">you only need a few deterministic automations that Make, Zapier or n8n can handle more simply.</span></div>
             </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
           </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Relevance AI Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/relevance-ai.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Relevance AI Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
+          <div class="space-y-3">
+            <a data-cta="affiliate" data-tool-id="relevance-ai" data-cta-source="tool_relevance_hero" href="https://relevanceai.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="w-full px-6 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg hover:brightness-110 transition-all flex items-center justify-center gap-2">Try Relevance AI via COSHUMA →</a>
+            <a href="https://relevanceai.com/pricing" target="_blank" rel="noopener noreferrer" class="w-full px-6 py-3.5 rounded-xl font-bold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all block">Check official pricing</a>
+            <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission if you sign up or purchase through the verified partner link. The official pricing button is non-affiliate.</p>
           </div>
         </div>
+      </section>
 
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-extrabold text-white">What you actually get</h2>
+        <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><h3 class="font-bold text-white">Specialist agents</h3><p class="text-sm text-slate-400 mt-1">Build agents around narrow, repeatable jobs instead of relying on one general assistant for everything.</p></div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><h3 class="font-bold text-white">Multi-agent workforces</h3><p class="text-sm text-slate-400 mt-1">Coordinate multiple agents for broader processes and long-running business workflows.</p></div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><h3 class="font-bold text-white">2,000+ integrations</h3><p class="text-sm text-slate-400 mt-1">The current pricing page advertises more than 2,000 integrations, including enterprise app triggers.</p></div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><h3 class="font-bold text-white">Evaluations & monitoring</h3><p class="text-sm text-slate-400 mt-1">Current product pages emphasize evaluations, tracing, analytics and cost visibility for live agent runs.</p></div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><h3 class="font-bold text-white">Enterprise controls</h3><p class="text-sm text-slate-400 mt-1">SSO, RBAC, audit logs, data residency, PII masking and human-in-the-loop controls are highlighted for governed deployments.</p></div>
+          <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><h3 class="font-bold text-white">Model flexibility</h3><p class="text-sm text-slate-400 mt-1">Relevance AI presents model selection and evaluation as part of optimizing agent cost and performance.</p></div>
+        </div>
+      </section>
 
-      </div>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-extrabold text-white">Pricing reality in September 2026</h2>
+        <div class="grid md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20">
+            <div class="text-xs uppercase tracking-wider text-emerald-400 font-bold">Low-risk entry</div>
+            <h3 class="text-xl font-extrabold text-white mt-1">A free, no-card entry path is still documented</h3>
+            <p class="text-sm text-slate-300 mt-2 leading-relaxed">Relevance AI's current product/API pages and documentation still advertise a free plan that does not require a credit card. This makes the verified partner route suitable for visitors who want to test the platform before a paid decision.</p>
+            <a data-cta="affiliate" data-tool-id="relevance-ai" data-cta-source="tool_relevance_free_entry" href="https://relevanceai.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex mt-4 px-5 py-3 rounded-xl bg-emerald-600 hover:bg-emerald-500 text-white text-sm font-extrabold">Start with the verified partner route →</a>
+          </div>
+          <div class="p-5 rounded-2xl bg-amber-500/5 border border-amber-500/20">
+            <div class="text-xs uppercase tracking-wider text-amber-400 font-bold">Important pricing caution</div>
+            <h3 class="text-xl font-extrabold text-white mt-1">The live primary pricing page now emphasizes Enterprise</h3>
+            <p class="text-sm text-slate-300 mt-2 leading-relaxed">The current main pricing page prominently shows Enterprise as custom-priced. Relevance AI documentation still describes self-serve Free, Pro and Team plans, but buyers should verify current in-app availability and checkout terms rather than relying on older fixed numbers.</p>
+            <a href="https://relevanceai.com/pricing" target="_blank" rel="noopener noreferrer" class="inline-flex mt-4 px-5 py-3 rounded-xl bg-slate-800 border border-slate-600 hover:bg-slate-700 text-white text-sm font-bold">Verify live pricing →</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-extrabold text-white">Buying decision</h2>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm text-left border-collapse">
+            <thead><tr class="text-slate-400 border-b border-[#222538]"><th class="py-3 pr-4">Need</th><th class="py-3 pr-4">Relevance AI fit</th><th class="py-3">What to consider instead</th></tr></thead>
+            <tbody class="text-slate-300">
+              <tr class="border-b border-[#222538]"><td class="py-4 pr-4 font-semibold text-white">Autonomous specialist agents</td><td class="py-4 pr-4">Strong fit</td><td class="py-4">General copilots if the work is still exploratory and changes every day</td></tr>
+              <tr class="border-b border-[#222538]"><td class="py-4 pr-4 font-semibold text-white">Simple deterministic automation</td><td class="py-4 pr-4">Can be more platform than you need</td><td class="py-4"><a href="/tool/make-com.html" class="text-purple-300 hover:text-purple-200">Make.com</a> or n8n-style workflow tools</td></tr>
+              <tr><td class="py-4 pr-4 font-semibold text-white">Enterprise governance</td><td class="py-4 pr-4">Strong fit when SSO, RBAC, audit logs and evaluations matter</td><td class="py-4">Compare total implementation and usage cost before committing</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="flex flex-wrap gap-3">
+          <a href="/compare/agentworks-vs-relevance-ai.html" class="px-4 py-2.5 rounded-xl border border-purple-500/30 bg-purple-500/10 text-purple-300 text-xs font-bold">Compare Relevance AI vs AgentWorks</a>
+          <a href="/tool/make-com.html" class="px-4 py-2.5 rounded-xl border border-[#33364a] bg-[#181a29] text-slate-300 text-xs font-bold">See Make.com</a>
+        </div>
+      </section>
+
+      <section class="p-7 rounded-3xl bg-gradient-to-br from-purple-500/10 to-indigo-500/5 border border-purple-500/25 text-center space-y-4">
+        <h2 class="text-2xl font-extrabold text-white">Ready to test Relevance AI?</h2>
+        <p class="text-slate-300 max-w-2xl mx-auto">Use the verified COSHUMA partner route for the free-entry path, then confirm current plan availability and checkout terms directly with Relevance AI before upgrading.</p>
+        <div class="flex flex-col sm:flex-row justify-center gap-3">
+          <a data-cta="affiliate" data-tool-id="relevance-ai" data-cta-source="tool_relevance_final" href="https://relevanceai.com?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 hover:bg-purple-500 text-white">Try Relevance AI via COSHUMA →</a>
+          <a href="https://relevanceai.com/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-bold text-sm bg-slate-800 border border-slate-600 hover:bg-slate-700 text-white">Official pricing</a>
+        </div>
+        <p class="text-[11px] text-slate-500">COSHUMA may earn a commission from the partner link. No commission is earned from the official pricing link.</p>
+      </section>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS buyer guides. All rights reserved.</div>
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
Revenue-focused, zero-cost rewrite of the existing Relevance AI tool page.

- Preserves the repository-verified customer-facing partner route `https://relevanceai.com?via=sangkwon` and moves it into three buyer-intent CTA positions with source-level attribution.
- Removes stale GlobalSaaSHub branding, placeholder review copy, and the obsolete `$234/month starting` claim from the old page.
- Grounds product positioning in Relevance AI's current official homepage/pricing pages: specialist agents, workforces, 2,000+ integrations, evaluations/monitoring, and enterprise governance controls.
- Handles pricing conservatively: the current primary pricing page emphasizes Enterprise custom pricing, while current Relevance AI docs/product pages still advertise a free no-card entry path; the page tells buyers to verify live in-app plan availability before upgrading.
- Removes the stale `$49/yr` founder-claim section from this buyer page.
- Keeps the official pricing URL clearly separated as non-affiliate.

Evidence checked Sep 6, 2026: Relevance AI homepage, current `/pricing`, current pricing documentation/API pages, plus repository `approved_tracking` data for the partner URL. No new paid service, application, guessed tracking URL, or unsupported fixed pricing claim.