### PR TITLE
Optimize LoopCV buyer-intent affiliate landing

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/loopcv.html
+++ b/projects/GlobalSaaSHub/public/tool/loopcv.html
@@ -1,169 +1,108 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>LoopCV Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="LoopCV leverages AI to automate the laborious job application process, finding matching roles across multiple boards and applying on the user's behalf... Discover features, pricing (See official pricing), and official links for LoopCV on GlobalSaaSHub." />
-    <link rel="canonical" href="https://coshuma.com/tool/loopcv.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://coshuma.com/tool/loopcv.html" />
-    <meta property="og:title" content="LoopCV Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="LoopCV leverages AI to automate the laborious job application process, finding matching roles across multiple boards and applying on the user's behalf... Check rating, pricing, and features." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>LoopCV Pricing, Auto Apply & Review (2026) | COSHUMA</title>
+  <meta name="description" content="LoopCV review for job seekers comparing AI auto-apply, one-click apply, ATS autofill and pricing. See the free plan, paid-plan starting price, best-fit guidance and COSHUMA's verified LoopCV partner link." />
+  <link rel="canonical" href="https://coshuma.com/tool/loopcv.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://coshuma.com/tool/loopcv.html" />
+  <meta property="og:title" content="LoopCV Pricing & AI Auto-Apply Review (2026) | COSHUMA" />
+  <meta property="og:description" content="LoopCV helps job seekers automate job discovery and applications. Compare its free plan, auto-apply workflow, manual control mode and current pricing entry point." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"SoftwareApplication",
+    "name":"LoopCV",
+    "operatingSystem":"Web",
+    "applicationCategory":"BusinessApplication",
+    "description":"Cloud-based job-search automation that can find matching roles, autofill applications and submit supported applications automatically or let the user review matches before applying.",
+    "offers":{"@type":"Offer","price":"0","priceCurrency":"EUR","description":"LoopCV advertises a free plan with no credit card required; paid plans currently start from €9.99/month on its official pricing pages. Regional pricing may vary."}
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"Does LoopCV have a free plan?","acceptedAnswer":{"@type":"Answer","text":"Yes. LoopCV currently advertises a free plan with no credit card required. Check the live pricing page before upgrading because plan limits and regional pricing can change."}},
+      {"@type":"Question","name":"Can LoopCV apply to jobs automatically?","acceptedAnswer":{"@type":"Answer","text":"Yes. LoopCV offers an Auto-Apply workflow that can scan supported job boards and submit compatible applications from the cloud after you configure your profile and job-search criteria."}},
+      {"@type":"Question","name":"Can I review jobs before LoopCV applies?","acceptedAnswer":{"@type":"Answer","text":"Yes. LoopCV also offers a manual or one-click workflow where it finds matching roles but lets you choose which applications to send."}}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}
+  </style>
+</head>
+<body class="min-h-screen bg-[#0b0c10] text-slate-100">
+  <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur sticky top-0 z-50 py-4 px-6">
+    <div class="max-w-5xl mx-auto flex items-center justify-between">
+      <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-black">C</div><span class="font-extrabold text-lg">COSHUMA</span></a>
+      <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">← Browse all tools</a>
+    </div>
+  </header>
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "LoopCV",
-      "operatingSystem": "Web",
-      "applicationCategory": "Email & Outreach",
-      "description": "LoopCV leverages AI to automate the laborious job application process, finding matching roles across multiple boards and applying on the user's behalf. It significantly streamlines the job search, saving users valuable time and effort."
-    }
-    </script>
-
-    <!-- Tailwind & Fonts -->
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+  <main class="max-w-5xl mx-auto px-4 py-12 space-y-8">
+    <section class="rounded-3xl bg-[#131520] border border-[#222538] p-7 md:p-10 shadow-2xl">
+      <div class="flex flex-col md:flex-row gap-7 md:items-center md:justify-between">
+        <div class="max-w-2xl">
+          <div class="flex items-center gap-4 mb-5"><img src="https://www.google.com/s2/favicons?domain=loopcv.pro&sz=128" alt="LoopCV logo" class="h-14 w-14 rounded-2xl bg-slate-900 p-2 border border-[#222538]"/><div><div class="text-xs font-bold text-purple-300">AI Job Search Automation</div><h1 class="text-4xl md:text-5xl font-black tracking-tight">LoopCV</h1></div></div>
+          <p class="text-lg text-slate-300 leading-relaxed">Best for job seekers who want to reduce repetitive application work. LoopCV can scan multiple job boards, fill supported ATS forms and auto-submit matching applications from the cloud — or let you review matches before applying.</p>
+          <p class="text-xs text-slate-500 mt-3">Product and pricing facts rechecked from LoopCV's official pages on Sep 6, 2026.</p>
+        </div>
+        <div class="flex flex-col gap-3 min-w-[240px]">
+          <a data-cta="affiliate" data-tool-id="loopcv" data-cta-source="tool_detail_hero" href="https://loopcv.pro?via=sang-kwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-center">Try LoopCV via COSHUMA →</a>
+          <a data-cta="official" href="https://www.loopcv.pro/pricing/" target="_blank" rel="noopener noreferrer" class="px-6 py-3 rounded-xl border border-slate-600 bg-slate-800 text-center font-bold text-sm">Check official pricing</a>
+        </div>
       </div>
-    </header>
+      <p class="mt-5 text-[11px] text-slate-400 leading-relaxed"><strong class="text-slate-300">Affiliate disclosure:</strong> COSHUMA may earn a commission if you sign up or purchase through the verified LoopCV partner link. The official-pricing button is a normal non-affiliate source link.</p>
+    </section>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
-          <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=loopcv.pro&sz=128" alt="LoopCV logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
-            <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Email & Outreach</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">LoopCV</h1>
-            </div>
-          </div>
+    <section class="grid md:grid-cols-3 gap-4">
+      <div class="p-5 rounded-2xl bg-[#131520] border border-[#222538]"><div class="text-xs uppercase tracking-wider text-slate-500 font-bold">Free entry</div><div class="text-2xl font-black text-emerald-400 mt-1">€0 plan</div><p class="text-sm text-slate-300 mt-2">LoopCV currently advertises a free plan with no credit card required.</p></div>
+      <div class="p-5 rounded-2xl bg-[#131520] border border-[#222538]"><div class="text-xs uppercase tracking-wider text-slate-500 font-bold">Paid entry</div><div class="text-2xl font-black text-white mt-1">From €9.99/mo</div><p class="text-sm text-slate-300 mt-2">Official localized pricing pages currently list paid plans from €9.99/month. Currency and offers may vary by region.</p></div>
+      <div class="p-5 rounded-2xl bg-[#131520] border border-[#222538]"><div class="text-xs uppercase tracking-wider text-slate-500 font-bold">Automation</div><div class="text-2xl font-black text-white mt-1">30+ job boards</div><p class="text-sm text-slate-300 mt-2">LoopCV says its auto-apply workflow scans LinkedIn, Indeed and 30+ other job boards.</p></div>
+    </section>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
-        </div>
-
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">LoopCV leverages AI to automate the laborious job application process, finding matching roles across multiple boards and applying on the user's behalf. It significantly streamlines the job search, saving users valuable time and effort.</p>
-        </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI-powered job application automation</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Finds matching roles across 30+ job boards</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Applies to jobs on user's behalf</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Automated email communication with recruiters</div>
-          </div>
-        </div>
-
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to LoopCV</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/convertkit.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=kit.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Kit (formerly ConvertKit)</span></div><span class="text-[10px] font-extrabold text-emerald-400">Free plan; Creator plan from $33/month for 1,000 subscribers</span></a>
-<a href="/tool/aweber.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=aweber.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">AWeber</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/moosend.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=moosend.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Moosend</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
-
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://loopcv.pro/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official LoopCV Site</span><span>→</span></a>
-<a data-cta="affiliate" href="https://loopcv.pro?via=sang-kwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Visit LoopCV via Verified Affiliate Link</span><span>→</span></a>
-        </div>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of LoopCV?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim LoopCV Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/loopcv.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="LoopCV Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
+    <section class="rounded-3xl bg-[#131520] border border-[#222538] p-7 space-y-6">
+      <div><h2 class="text-2xl font-black">What LoopCV actually automates</h2><p class="text-slate-400 mt-2">The strongest value is not just form autofill — it is moving job discovery and supported applications into a repeatable cloud workflow.</p></div>
+      <div class="grid md:grid-cols-2 gap-4">
+        <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><h3 class="font-bold text-white">Auto-Apply</h3><p class="text-sm text-slate-300 mt-2">Set role, location, keywords and other criteria. LoopCV can continuously find compatible listings and submit supported applications automatically.</p></div>
+        <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><h3 class="font-bold text-white">ATS form autofill</h3><p class="text-sm text-slate-300 mt-2">LoopCV lists support for major application systems including Workday, Greenhouse, Lever, Ashby, SmartRecruiters and iCIMS.</p></div>
+        <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><h3 class="font-bold text-white">One-click / manual control</h3><p class="text-sm text-slate-300 mt-2">If you do not want fully automatic submissions, LoopCV can collect matches for review and let you decide which applications to send.</p></div>
+        <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]"><h3 class="font-bold text-white">Cloud execution</h3><p class="text-sm text-slate-300 mt-2">The service runs in the cloud rather than depending on a browser tab staying open, which is useful for ongoing searches.</p></div>
       </div>
-    </main>
+    </section>
 
-    <!-- Footer -->
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
+    <section class="grid md:grid-cols-2 gap-5">
+      <div class="p-6 rounded-3xl bg-emerald-500/5 border border-emerald-500/20"><h2 class="text-xl font-black text-emerald-300">Good fit if…</h2><ul class="mt-4 space-y-3 text-sm text-slate-300 list-disc list-inside"><li>You are applying to many similar roles and repeatedly entering the same profile data.</li><li>You want an always-on search across several job boards.</li><li>You prefer a free starting point before paying for higher application volume.</li><li>You want the option to switch between automatic and review-first workflows.</li></ul></div>
+      <div class="p-6 rounded-3xl bg-amber-500/5 border border-amber-500/20"><h2 class="text-xl font-black text-amber-300">Think twice if…</h2><ul class="mt-4 space-y-3 text-sm text-slate-300 list-disc list-inside"><li>Every application requires heavy role-specific writing, portfolios or bespoke answers.</li><li>You are targeting a very small list of employers where careful manual applications matter more than volume.</li><li>An employer or job board restricts automated submissions; review the relevant platform and employer rules before enabling auto-apply.</li><li>You need guaranteed interview outcomes — automation can save time, but it cannot guarantee recruiter responses.</li></ul></div>
+    </section>
+
+    <section class="rounded-3xl bg-[#131520] border border-[#222538] p-7">
+      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-5">
+        <div><div class="text-xs uppercase text-slate-500 font-bold tracking-wider">Low-risk way to evaluate</div><h2 class="text-2xl font-black mt-1">Start on the free plan, then measure response quality</h2><p class="text-sm text-slate-300 mt-2 max-w-2xl">Before increasing application volume, check whether matches are relevant, application details are correct and the jobs fit your target. Upgrade only if the automation is saving real time.</p></div>
+        <a data-cta="affiliate" data-tool-id="loopcv" data-cta-source="tool_detail_free_plan" href="https://loopcv.pro?via=sang-kwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-center min-w-[220px]">Start LoopCV free →</a>
       </div>
-    </footer>
-  </body>
+    </section>
+
+    <section class="rounded-3xl bg-[#131520] border border-[#222538] p-7">
+      <h2 class="text-2xl font-black">Bottom line</h2>
+      <p class="text-slate-300 mt-3 leading-relaxed">LoopCV makes the most sense when application volume is the bottleneck. Its free plan lowers the cost of testing the workflow, while the paid tiers are mainly about unlocking more volume and advanced controls. For highly selective roles, keep manual review in the loop.</p>
+      <div class="flex flex-col sm:flex-row gap-3 mt-6">
+        <a data-cta="affiliate" data-tool-id="loopcv" data-cta-source="tool_detail_final" href="https://loopcv.pro?via=sang-kwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-center">Try LoopCV via verified partner link →</a>
+        <a href="https://www.loopcv.pro/manual/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl border border-slate-600 bg-slate-800 font-bold text-center">See LoopCV's review-first mode</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-5xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS buyer guides.</div></footer>
+  <script src="/affiliate-attribution.js" defer></script>
+</body>
 </html>
-


### PR DESCRIPTION
Revenue-focused, zero-cost rewrite of the existing LoopCV tool page.

- Preserves the repository-verified customer-facing partner URL `https://loopcv.pro?via=sang-kwon` (Rewardful source) and moves it into three buyer-intent CTA positions with source-level attribution.
- Replaces stale GlobalSaaSHub branding, placeholder review/pros copy, irrelevant email-marketing alternatives, and the obsolete $49/year founder-claim block.
- Grounds product copy in LoopCV's current official pages rechecked Sep 6, 2026: cloud Auto-Apply, 30+ job boards, ATS autofill across major platforms, and review-first/one-click control.
- Grounds pricing conservatively in current official localized pricing pages: free plan with no card required; paid plans currently start from €9.99/month, with a regional-pricing caveat.
- Adds FAQ structured data, clear fit/skip guidance, affiliate disclosure, and `/affiliate-attribution.js`.

No paid service, new affiliate application, guessed tracking parameter, dashboard/onboarding URL, or guaranteed job/interview outcome is introduced.