### PR TITLE
Optimize Bookyourdata buyer path from partner resources

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/bookyourdata.html
+++ b/projects/GlobalSaaSHub/public/tool/bookyourdata.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Bookyourdata Review, Pricing & Free Leads (2026) | GlobalSaaSHub</title>
-  <meta name="description" content="Bookyourdata review for B2B prospecting: pay-as-you-go contact data, real-time email verification, a 97% deliverability guarantee and 10 free leads with no credit card." />
+  <title>Bookyourdata Review, Pricing & BeSpoke Lists (2026) | COSHUMA</title>
+  <meta name="description" content="Bookyourdata buyer guide for B2B prospecting: 10 free leads, pay-as-you-go verified contacts, 97% deliverability guarantee, Prospector, pre-built lists and 2026 BeSpoke list building." />
   <link rel="canonical" href="https://coshuma.com/tool/bookyourdata.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://coshuma.com/tool/bookyourdata.html" />
-  <meta property="og:title" content="Bookyourdata Review & Pricing (2026) | GlobalSaaSHub" />
-  <meta property="og:description" content="See who Bookyourdata is best for, how its pay-as-you-go model works, and where to start with 10 free leads." />
+  <meta property="og:title" content="Bookyourdata Review, Pricing & BeSpoke Lists (2026) | COSHUMA" />
+  <meta property="og:description" content="Compare Bookyourdata's three buying paths and test the platform with 10 free leads before buying credits." />
   <script type="application/ld+json">
   {
     "@context":"https://schema.org",
@@ -18,22 +18,31 @@
     "applicationCategory":"BusinessApplication",
     "operatingSystem":"Web",
     "url":"https://www.bookyourdata.com/",
-    "description":"A pay-as-you-go B2B prospecting platform with real-time email verification and verified contact data."
+    "description":"A pay-as-you-go B2B prospecting platform with real-time email verification, verified contact data and private list-building options."
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"Does Bookyourdata require a subscription?","acceptedAnswer":{"@type":"Answer","text":"Bookyourdata currently offers pay-as-you-go credits rather than requiring a recurring subscription. Credits do not expire."}},
+      {"@type":"Question","name":"Can I test Bookyourdata before paying?","acceptedAnswer":{"@type":"Answer","text":"Bookyourdata currently advertises 10 free leads with no credit card required."}},
+      {"@type":"Question","name":"What if the audience I need is not in the database?","acceptedAnswer":{"@type":"Answer","text":"Bookyourdata's 2026 BeSpoke service can hand-build private contact lists to a brief, starting with a free 10-row sample."}}
+    ]
   }
   </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <style>
-    body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}
-  </style>
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
 </head>
 <body class="min-h-screen bg-[#0b0c10]">
   <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur sticky top-0 z-50 py-4 px-6">
     <div class="max-w-5xl mx-auto flex items-center justify-between">
-      <a href="/" class="font-extrabold text-white">GlobalSaaSHub</a>
-      <a href="/" class="text-xs font-bold text-purple-300">← All tools</a>
+      <a href="/" class="font-extrabold text-white">COSHUMA</a>
+      <a href="/best/index.html" class="text-xs font-bold text-purple-300">Buyer guides →</a>
     </div>
   </header>
 
@@ -41,72 +50,91 @@
     <section class="rounded-3xl border border-purple-500/30 bg-[#131520] p-7 md:p-10">
       <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-6">
         <div class="max-w-3xl space-y-4">
-          <div class="text-xs font-bold uppercase tracking-wider text-purple-300">B2B prospecting data</div>
+          <div class="text-xs font-bold uppercase tracking-wider text-purple-300">B2B prospecting data · verified Sep 6, 2026</div>
           <h1 class="text-4xl md:text-5xl font-black text-white">Bookyourdata</h1>
-          <p class="text-lg text-slate-300 leading-relaxed">Best suited to sales, recruiting and marketing teams that need targeted B2B contact lists without committing to a recurring subscription.</p>
+          <p class="text-lg text-slate-300 leading-relaxed">A strong fit when you already know the industries, job titles or geographies you want to reach and prefer buying verified B2B data without committing to a recurring subscription.</p>
           <div class="flex flex-wrap gap-2 text-xs font-bold">
-            <span class="rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-300 px-3 py-1.5">Pay as you go</span>
             <span class="rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-300 px-3 py-1.5">10 free leads</span>
-            <span class="rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-300 px-3 py-1.5">No credit card required</span>
+            <span class="rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-300 px-3 py-1.5">No credit card</span>
+            <span class="rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-300 px-3 py-1.5">Pay as you go</span>
+            <span class="rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-300 px-3 py-1.5">97% deliverability guarantee</span>
           </div>
         </div>
         <img src="https://www.google.com/s2/favicons?domain=bookyourdata.com&sz=128" alt="Bookyourdata logo" class="h-20 w-20 rounded-2xl border border-[#222538] bg-slate-900 p-3" />
       </div>
-
       <div class="mt-7 flex flex-col sm:flex-row gap-3">
-        <a data-cta="affiliate" data-tool-id="bookyourdata" href="https://join.bookyourdata.com/swcyqmumr3s5" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-purple-600 hover:bg-purple-500 px-6 py-3.5 text-center text-sm font-extrabold text-white">Get 10 free Bookyourdata leads →</a>
+        <a data-cta="affiliate" data-tool-id="bookyourdata" data-cta-source="tool_detail_hero_free_leads" href="https://join.bookyourdata.com/swcyqmumr3s5" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-purple-600 hover:bg-purple-500 px-6 py-3.5 text-center text-sm font-extrabold text-white">Get 10 free Bookyourdata leads →</a>
         <a data-cta="official" href="https://www.bookyourdata.com/pricing" target="_blank" rel="noopener noreferrer" class="rounded-xl border border-slate-600 bg-slate-800 hover:bg-slate-700 px-6 py-3.5 text-center text-sm font-bold text-white">View official pricing</a>
       </div>
-      <p class="mt-3 text-[11px] text-slate-500">Affiliate disclosure: GlobalSaaSHub may earn a commission if you purchase through the partner link, at no extra cost to you.</p>
+      <p class="mt-3 text-[11px] text-slate-500"><strong class="text-slate-400">Affiliate disclosure:</strong> COSHUMA may earn a commission if you sign up or purchase through the partner link. Bookyourdata supplied this exact customer-facing affiliate URL to COSHUMA through PartnerStack.</p>
+    </section>
+
+    <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 space-y-5">
+      <div>
+        <div class="text-xs font-bold uppercase tracking-wider text-purple-300">Choose the buying path that fits the job</div>
+        <h2 class="mt-2 text-2xl font-black text-white">Three ways to get a list in 2026</h2>
+      </div>
+      <div class="grid md:grid-cols-3 gap-4">
+        <div class="rounded-2xl bg-[#181a29] border border-[#222538] p-5">
+          <h3 class="font-extrabold text-white">Prospector</h3>
+          <p class="mt-2 text-sm leading-relaxed text-slate-300">Filter Bookyourdata's database by job title, management level, industry, company size, geography, technographics and more. Best when your ICP can be expressed with database filters.</p>
+        </div>
+        <div class="rounded-2xl bg-[#181a29] border border-[#222538] p-5">
+          <h3 class="font-extrabold text-white">Pre-Built Lists</h3>
+          <p class="mt-2 text-sm leading-relaxed text-slate-300">Use ready-made list packages when speed matters more than building a custom filter set from scratch.</p>
+        </div>
+        <div class="rounded-2xl bg-[#181a29] border border-purple-500/30 p-5">
+          <div class="text-[10px] font-bold uppercase tracking-wider text-purple-300">New in 2026</div>
+          <h3 class="mt-1 font-extrabold text-white">BeSpoke private list building</h3>
+          <p class="mt-2 text-sm leading-relaxed text-slate-300">For audiences a normal database cannot express, Bookyourdata says its research team can hand-build a private list to your brief, beginning with a free 10-row sample and a public source link on every row.</p>
+        </div>
+      </div>
     </section>
 
     <section class="grid md:grid-cols-3 gap-4">
       <div class="rounded-2xl border border-[#222538] bg-[#131520] p-5">
-        <h2 class="font-extrabold text-white">Why it stands out</h2>
-        <p class="mt-2 text-sm leading-relaxed text-slate-300">Bookyourdata says every exported email is checked in real time and backed by a 97% deliverability guarantee.</p>
+        <h2 class="font-extrabold text-white">Verified at export</h2>
+        <p class="mt-2 text-sm leading-relaxed text-slate-300">Bookyourdata says exported emails are checked in real time and backed by a 97% deliverability guarantee, with replacement credits when a list falls below the guarantee.</p>
       </div>
       <div class="rounded-2xl border border-[#222538] bg-[#131520] p-5">
-        <h2 class="font-extrabold text-white">Pricing model</h2>
-        <p class="mt-2 text-sm leading-relaxed text-slate-300">Credits are sold on a pay-as-you-go basis rather than a mandatory subscription, and the company says purchased credits do not expire.</p>
+        <h2 class="font-extrabold text-white">100+ attributes</h2>
+        <p class="mt-2 text-sm leading-relaxed text-slate-300">Available attributes include job title, function, management level, geography, industry, revenue, employee count, technologies, funding and job-posting data.</p>
       </div>
       <div class="rounded-2xl border border-[#222538] bg-[#131520] p-5">
-        <h2 class="font-extrabold text-white">Best first test</h2>
-        <p class="mt-2 text-sm leading-relaxed text-slate-300">Use the 10 free leads to check targeting quality and deliverability against your own ideal customer profile before buying credits.</p>
+        <h2 class="font-extrabold text-white">Credits do not expire</h2>
+        <p class="mt-2 text-sm leading-relaxed text-slate-300">The current pricing page says credits are pay-as-you-go, get cheaper with volume and do not expire, which can be useful for irregular prospecting campaigns.</p>
+      </div>
+    </section>
+
+    <section class="rounded-3xl border border-emerald-500/20 bg-emerald-500/5 p-7 space-y-5">
+      <div class="max-w-3xl">
+        <div class="text-xs font-bold uppercase tracking-wider text-emerald-300">Lowest-risk first move</div>
+        <h2 class="mt-2 text-2xl font-black text-white">Test your exact ICP before buying a larger batch</h2>
+        <p class="mt-2 text-sm leading-relaxed text-slate-300">Bookyourdata's affiliate team specifically recommends promotion around industry, job-title and geographic targeting. A practical test is to define one narrow segment, use the free leads, check CRM fit and hard-bounce quality, then buy credits only if the sample matches the audience you actually need.</p>
+      </div>
+      <div class="flex flex-col sm:flex-row gap-3">
+        <a data-cta="affiliate" data-tool-id="bookyourdata" data-cta-source="tool_detail_icp_test" href="https://join.bookyourdata.com/swcyqmumr3s5" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-emerald-600 hover:bg-emerald-500 px-6 py-3.5 text-center text-sm font-extrabold text-white">Run the 10-lead test →</a>
+        <a href="/best/b2b-email-list-providers.html" class="rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-6 py-3.5 text-center text-sm font-bold text-emerald-100 hover:bg-emerald-500/20">Compare B2B data providers</a>
       </div>
     </section>
 
     <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 space-y-5">
-      <h2 class="text-2xl font-black text-white">What you get</h2>
+      <h2 class="text-2xl font-black text-white">Who should skip it?</h2>
       <div class="grid sm:grid-cols-2 gap-3 text-sm text-slate-300">
-        <div class="rounded-xl bg-[#181a29] border border-[#222538] p-4">✓ Real-time email verification at export</div>
-        <div class="rounded-xl bg-[#181a29] border border-[#222538] p-4">✓ Targeting across B2B contacts and companies</div>
-        <div class="rounded-xl bg-[#181a29] border border-[#222538] p-4">✓ 100+ contact and company data attributes</div>
-        <div class="rounded-xl bg-[#181a29] border border-[#222538] p-4">✓ Pay-as-you-go credits that do not expire</div>
+        <div class="rounded-xl bg-[#181a29] border border-[#222538] p-4"><strong class="text-white">You need outreach software, not data.</strong><br/>Bookyourdata supplies prospect data; email sequencing and sales engagement require a separate outreach tool.</div>
+        <div class="rounded-xl bg-[#181a29] border border-[#222538] p-4"><strong class="text-white">Your ICP is still vague.</strong><br/>Buying a larger list before defining industry, role, geography and exclusion rules can waste credits even when the underlying records are valid.</div>
       </div>
-      <div class="rounded-2xl border border-amber-500/20 bg-amber-500/5 p-5">
-        <h3 class="font-bold text-amber-300">Before you buy</h3>
-        <p class="mt-2 text-sm text-slate-300 leading-relaxed">Contact databases are most valuable when your targeting rules are already clear. Test a small list first, verify fit against your CRM and outreach workflow, then scale only if the data produces qualified conversations.</p>
-      </div>
-    </section>
-
-    <section class="rounded-3xl border border-emerald-500/20 bg-emerald-500/5 p-7 md:flex md:items-center md:justify-between md:gap-8">
-      <div class="max-w-2xl">
-        <div class="text-xs font-bold uppercase tracking-wider text-emerald-300">High-intent use case</div>
-        <h2 class="mt-2 text-2xl font-black text-white">Need physician or doctor contacts?</h2>
-        <p class="mt-2 text-sm leading-relaxed text-slate-300">Use our physician email-list buying checklist to compare verification timing, deliverability protection, sample testing and targeting before spending on a larger list.</p>
-      </div>
-      <a href="/physician-email-list.html" class="mt-5 inline-block rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-6 py-3.5 text-center text-sm font-extrabold text-emerald-200 hover:bg-emerald-500/20 md:mt-0">Physician email list guide →</a>
     </section>
 
     <section class="rounded-3xl border border-purple-500/30 bg-[#131520] p-7 text-center space-y-4">
-      <h2 class="text-2xl font-black text-white">Start with the free sample before buying credits</h2>
-      <p class="text-sm text-slate-300">Bookyourdata currently advertises 10 free leads with no credit card requirement.</p>
-      <a data-cta="affiliate" data-tool-id="bookyourdata" href="https://join.bookyourdata.com/swcyqmumr3s5" target="_blank" rel="sponsored noopener noreferrer" class="inline-block rounded-xl bg-purple-600 hover:bg-purple-500 px-7 py-3.5 text-sm font-extrabold text-white">Try Bookyourdata through our partner link →</a>
-      <div class="text-[10px] text-slate-500">Product facts checked against Bookyourdata public pricing, data and email-verification pages on September 5, 2026.</div>
+      <h2 class="text-2xl font-black text-white">Start with proof, not a large purchase</h2>
+      <p class="text-sm text-slate-300">Bookyourdata currently advertises 10 free leads with no credit card required. Use that sample to validate the segment first.</p>
+      <a data-cta="affiliate" data-tool-id="bookyourdata" data-cta-source="tool_detail_bottom_free_leads" href="https://join.bookyourdata.com/swcyqmumr3s5" target="_blank" rel="sponsored noopener noreferrer" class="inline-block rounded-xl bg-purple-600 hover:bg-purple-500 px-7 py-3.5 text-sm font-extrabold text-white">Try Bookyourdata through COSHUMA →</a>
+      <div class="text-[10px] text-slate-500">Product facts checked against Bookyourdata's public pricing, data, guarantees and company pages on September 6, 2026. Final offer terms can change; verify the live checkout before purchasing.</div>
     </section>
   </main>
 
-  <footer class="border-t border-[#222538] py-8 text-center text-xs text-slate-500">© 2026 GlobalSaaSHub. Independent SaaS decision support.</footer>
+  <footer class="border-t border-[#222538] py-8 text-center text-xs text-slate-500">© 2026 COSHUMA. Independent SaaS decision support.</footer>
   <script src="/affiliate-attribution.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Revenue-focused refresh grounded in Bookyourdata's September 5 PartnerStack resource email and current official 2026 product pages.

Changes:
- keep the exact verified customer-facing affiliate URL supplied by Bookyourdata
- replace stale GlobalSaaSHub branding with COSHUMA
- add distinct hero / ICP-test / bottom CTA attribution sources
- explain the current three buying paths: Prospector, pre-built lists, and the 2026 BeSpoke private-list service
- surface current official 10-free-lead/no-card, pay-as-you-go, non-expiring-credit, 100+ attribute and 97% deliverability facts
- add FAQ schema and buyer-fit / skip guidance
- keep official pricing as a separate non-affiliate destination

No new paid service, application, guessed tracking parameter, or unsupported conversion claim.