### PR TITLE
Optimize Unbounce CRO after confirmed partner click

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/unbounce.html
+++ b/projects/GlobalSaaSHub/public/tool/unbounce.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Unbounce Pricing, Free Trial & Partner Discount (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Unbounce pricing, 14-day free trial, landing-page optimization features, and COSHUMA's verified Unbounce partner offer: 20% off the first 3 months or 35% off the first annual subscription." />
+    <title>Unbounce Pricing 2026: $29 Starter + 20%/35% Partner Discount | COSHUMA</title>
+    <meta name="description" content="Unbounce pricing starts at $29/month. Compare current plans, the 14-day no-card trial, and COSHUMA's verified offer: 20% off 3 months or 35% off the first annual subscription." />
     <link rel="canonical" href="https://coshuma.com/tool/unbounce.html" />
 
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/tool/unbounce.html" />
-    <meta property="og:title" content="Unbounce Pricing, Free Trial & Partner Discount (2026)" />
-    <meta property="og:description" content="See current Unbounce pricing and start the 14-day trial through COSHUMA's verified partner link." />
+    <meta property="og:title" content="Unbounce Pricing 2026: $29 Starter + 20%/35% Partner Discount" />
+    <meta property="og:description" content="Current Unbounce pricing, 14-day trial, plan-fit guidance, and COSHUMA's verified customer partner offer." />
 
     <script type="application/ld+json">
     {
@@ -19,7 +19,8 @@
       "name": "Unbounce",
       "operatingSystem": "Web",
       "applicationCategory": "BusinessApplication",
-      "description": "A landing-page platform for marketers and agencies with no-code page building, A/B testing, AI optimization, and AI-assisted landing-page workflows.",
+      "url": "https://unbounce.com/",
+      "description": "Landing-page and conversion-optimization software with a drag-and-drop builder, A/B testing, AI-assisted workflows and Smart Traffic optimization.",
       "offers": {
         "@type": "AggregateOffer",
         "lowPrice": "29",
@@ -27,124 +28,194 @@
       }
     }
     </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "How much does Unbounce cost in 2026?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Unbounce's official pricing page currently lists Starter at $29/month, Build at $99/month, Experiment at $149/month and Optimize at $249/month. Concierge and Agency use sales-assisted pricing."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Does Unbounce have a free trial?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. Unbounce currently advertises a 14-day free trial with no credit card required on its pricing page."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What discount does COSHUMA's Unbounce partner link provide?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Unbounce's partner welcome email for COSHUMA states that the unique referral link gives eligible customers 20% off their first three months or 35% off their first annual subscription. Final eligibility and checkout pricing are controlled by Unbounce."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How long does the Unbounce partner cookie last?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Unbounce's partner welcome email states that COSHUMA's verified referral link uses a 90-day tracking cookie."
+          }
+        }
+      ]
+    }
+    </script>
 
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700;800;900&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
+      body { font-family: 'Inter', sans-serif; background:#0b0c10; color:#f1f5f9; }
+      h1,h2,h3 { font-family:'Outfit',sans-serif; }
     </style>
   </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
+  <body class="min-h-screen bg-[#0b0c10] text-slate-100">
+    <header class="sticky top-0 z-50 border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md">
+      <div class="max-w-5xl mx-auto px-5 py-4 flex items-center justify-between gap-4">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-9 w-9 rounded-xl bg-purple-600 flex items-center justify-center font-black text-white">C</div>
+          <span class="font-extrabold tracking-tight text-white">COSHUMA</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
+        <a href="/best/unbounce-discount.html" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 text-purple-200 hover:bg-purple-500/10">See exact discount guide →</a>
       </div>
     </header>
 
-    <main class="max-w-5xl mx-auto px-4 py-12 w-full space-y-7">
-      <section class="p-8 md:p-10 rounded-3xl bg-[#131520] border border-purple-500/30 shadow-2xl space-y-7">
-        <div class="flex flex-col md:flex-row md:items-center justify-between gap-6">
-          <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=unbounce.com&sz=128" alt="Unbounce logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
-            <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">Landing Pages & Conversion Optimization</div>
-              <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Unbounce: pricing, trial & partner offer</h1>
-              <p class="text-slate-400 mt-2 max-w-2xl">Build landing pages without code, run A/B tests, and use AI-assisted optimization. The verified COSHUMA partner link also unlocks a customer discount.</p>
+    <main class="max-w-5xl mx-auto px-5 py-10 md:py-14 space-y-8">
+      <section class="rounded-3xl border border-purple-500/30 bg-[#121520] p-6 md:p-10 shadow-2xl space-y-7">
+        <div class="grid md:grid-cols-[1fr_auto] gap-8 items-start">
+          <div class="space-y-5">
+            <div class="flex items-center gap-4">
+              <img src="https://www.google.com/s2/favicons?domain=unbounce.com&sz=128" alt="Unbounce logo" class="h-14 w-14 rounded-2xl border border-[#2a2e42] bg-slate-900 p-2" />
+              <div>
+                <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Landing pages & conversion optimization</div>
+                <h1 class="text-4xl md:text-5xl font-black text-white mt-1">Unbounce pricing, trial & verified partner discount</h1>
+              </div>
             </div>
+            <p class="text-lg text-slate-300 leading-relaxed max-w-3xl">Unbounce is built for marketers and agencies that need landing pages, A/B testing and AI-assisted conversion optimization without waiting on a development team.</p>
+
+            <div class="grid sm:grid-cols-3 gap-3">
+              <div class="rounded-2xl border border-emerald-500/20 bg-emerald-500/5 p-4">
+                <div class="text-[11px] uppercase tracking-wider font-extrabold text-emerald-300">Free entry</div>
+                <div class="text-xl font-black text-white mt-1">14-day trial</div>
+                <div class="text-xs text-slate-400 mt-1">No credit card required on the current official pricing page.</div>
+              </div>
+              <div class="rounded-2xl border border-purple-500/20 bg-purple-500/5 p-4">
+                <div class="text-[11px] uppercase tracking-wider font-extrabold text-purple-300">Partner offer</div>
+                <div class="text-xl font-black text-white mt-1">20% or 35% off</div>
+                <div class="text-xs text-slate-400 mt-1">20% off the first 3 months or 35% off the first annual subscription.</div>
+              </div>
+              <div class="rounded-2xl border border-blue-500/20 bg-blue-500/5 p-4">
+                <div class="text-[11px] uppercase tracking-wider font-extrabold text-blue-300">Tracking</div>
+                <div class="text-xl font-black text-white mt-1">90-day cookie</div>
+                <div class="text-xs text-slate-400 mt-1">Confirmed in COSHUMA's Unbounce partner welcome email.</div>
+              </div>
+            </div>
+
+            <div class="flex flex-col sm:flex-row gap-3">
+              <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="tool-hero" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="px-7 py-4 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white font-extrabold text-center hover:brightness-110 shadow-lg shadow-purple-950/40">Start 14-day trial + partner discount →</a>
+              <a data-cta="official" data-tool-id="unbounce" data-cta-source="tool-hero-pricing" href="https://unbounce.com/pricing/" target="_blank" rel="noopener noreferrer" class="px-7 py-4 rounded-xl border border-slate-600 bg-slate-800 text-white font-bold text-center hover:bg-slate-700">View official pricing →</a>
+            </div>
+            <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission if an eligible Unbounce purchase is attributed through the verified partner link, at no extra cost to you. Discount eligibility and final checkout pricing are controlled by Unbounce.</p>
           </div>
+
+          <aside class="w-full md:w-72 rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-5 space-y-4">
+            <div>
+              <div class="text-xs uppercase tracking-wider text-slate-500 font-bold">Best for</div>
+              <div class="mt-2 text-sm text-slate-200 leading-relaxed">Paid-traffic landing pages, campaign-specific lead generation, A/B testing and conversion-rate optimization.</div>
+            </div>
+            <div class="border-t border-[#222538] pt-4">
+              <div class="text-xs uppercase tracking-wider text-slate-500 font-bold">Skip if</div>
+              <div class="mt-2 text-sm text-slate-300 leading-relaxed">You mainly need backend automation, a broad CMS, or a low-cost site builder rather than dedicated landing-page optimization.</div>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-5">
+        <div>
+          <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Current public pricing</div>
+          <h2 class="text-3xl font-black text-white mt-1">Unbounce plans checked September 6, 2026</h2>
+          <p class="text-sm text-slate-400 mt-2">These USD prices are from Unbounce's current official pricing page. SaaS pricing can change, so verify before purchase.</p>
         </div>
 
-        <div class="grid md:grid-cols-3 gap-3">
-          <div class="p-4 rounded-2xl bg-emerald-500/5 border border-emerald-500/20">
-            <div class="text-[11px] uppercase tracking-wider font-extrabold text-emerald-300">Free entry</div>
-            <div class="text-lg font-black text-white mt-1">14-day trial</div>
-            <div class="text-xs text-slate-400 mt-1">No credit card required on the current official pricing page.</div>
-          </div>
-          <div class="p-4 rounded-2xl bg-purple-500/5 border border-purple-500/20">
-            <div class="text-[11px] uppercase tracking-wider font-extrabold text-purple-300">Verified partner discount</div>
-            <div class="text-lg font-black text-white mt-1">20% or 35% off</div>
-            <div class="text-xs text-slate-400 mt-1">20% off the first 3 months or 35% off the first annual subscription through COSHUMA's unique link.</div>
-          </div>
-          <div class="p-4 rounded-2xl bg-blue-500/5 border border-blue-500/20">
-            <div class="text-[11px] uppercase tracking-wider font-extrabold text-blue-300">Tracking window</div>
-            <div class="text-lg font-black text-white mt-1">90-day cookie</div>
-            <div class="text-xs text-slate-400 mt-1">Confirmed in the Unbounce partner welcome email received September 4, 2026 KST.</div>
-          </div>
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <div class="rounded-2xl bg-[#0d1018] border border-[#25293b] p-5"><div class="text-xs text-slate-400">Starter</div><div class="text-2xl font-black text-emerald-400 mt-1">$29/mo</div><div class="text-xs text-slate-500 mt-2">5 pages · up to 500 traffic · 1 user</div></div>
+          <div class="rounded-2xl bg-[#0d1018] border border-[#25293b] p-5"><div class="text-xs text-slate-400">Build</div><div class="text-2xl font-black text-emerald-400 mt-1">$99/mo</div><div class="text-xs text-slate-500 mt-2">Unlimited pages · up to 20k traffic</div></div>
+          <div class="rounded-2xl bg-[#0d1018] border border-[#25293b] p-5"><div class="text-xs text-slate-400">Experiment</div><div class="text-2xl font-black text-emerald-400 mt-1">$149/mo</div><div class="text-xs text-slate-500 mt-2">Unlimited A/B testing · up to 30k traffic · 3 users</div></div>
+          <div class="rounded-2xl bg-[#0d1018] border border-[#25293b] p-5"><div class="text-xs text-slate-400">Optimize</div><div class="text-2xl font-black text-emerald-400 mt-1">$249/mo</div><div class="text-xs text-slate-500 mt-2">Adds deeper AI optimization and Smart Traffic workflows</div></div>
         </div>
 
         <div class="flex flex-col sm:flex-row gap-3">
-          <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="tool-hero" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="px-7 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start Unbounce free trial + partner discount →</a>
-          <a data-cta="official" data-tool-id="unbounce" data-cta-source="tool-hero-pricing" href="https://unbounce.com/pricing/" target="_blank" rel="noopener noreferrer" class="px-7 py-4 rounded-xl font-bold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">View official pricing →</a>
+          <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="tool-pricing" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-extrabold text-center">Check the verified Unbounce offer →</a>
+          <a href="/best/unbounce-discount.html" class="px-6 py-3.5 rounded-xl border border-purple-500/30 bg-purple-500/5 text-purple-200 font-bold text-center hover:bg-purple-500/10">Compare monthly vs annual discount →</a>
         </div>
-        <p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if you become a paying Unbounce customer through the verified partner link. The partner offer and commission terms were confirmed in Unbounce's welcome email; product pricing below is checked against Unbounce's official pricing page.</p>
       </section>
 
-      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
-        <div>
-          <div class="text-[11px] uppercase font-extrabold tracking-wider text-purple-300">Current public pricing</div>
-          <h2 class="text-2xl font-black text-white mt-1">Which Unbounce plan fits?</h2>
-        </div>
-        <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-xs text-slate-400">Starter</div><div class="text-xl font-black text-emerald-400 mt-1">$29</div><div class="text-[11px] text-slate-500 mt-1">5 pages · up to 500 traffic · 1 user</div></div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-xs text-slate-400">Build</div><div class="text-xl font-black text-emerald-400 mt-1">$99</div><div class="text-[11px] text-slate-500 mt-1">For broader landing-page production needs</div></div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-xs text-slate-400">Experiment</div><div class="text-xl font-black text-emerald-400 mt-1">$149</div><div class="text-[11px] text-slate-500 mt-1">Adds deeper testing workflows</div></div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-xs text-slate-400">Optimize</div><div class="text-xl font-black text-emerald-400 mt-1">$249</div><div class="text-[11px] text-slate-500 mt-1">Includes Smart Traffic AI optimization</div></div>
-        </div>
-        <p class="text-xs text-slate-500">Prices shown in USD as displayed on Unbounce's official pricing page checked September 4, 2026. Unbounce also lists Concierge and Agency plans with sales-assisted pricing. Confirm limits and billing cadence before purchase.</p>
-      </section>
-
-      <section class="grid md:grid-cols-2 gap-4">
-        <div class="p-6 rounded-3xl bg-[#131520] border border-emerald-500/20 space-y-3">
-          <h2 class="text-xl font-bold text-white">Choose Unbounce when...</h2>
-          <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
-            <li>Your bottleneck is paid-campaign landing-page conversion, not backend workflow automation.</li>
-            <li>You want drag-and-drop landing pages plus native A/B testing in the same platform.</li>
-            <li>You want Smart Traffic to route visitors among page variants on supported plans.</li>
-            <li>You want to build or manage landing pages from AI assistants through Unbounce's MCP server, which Unbounce says is included across plans and the free trial.</li>
+      <section class="grid md:grid-cols-2 gap-5">
+        <div class="rounded-3xl border border-emerald-500/20 bg-emerald-500/5 p-6">
+          <h2 class="text-xl font-black text-white">Choose Unbounce when…</h2>
+          <ul class="mt-4 space-y-3 text-sm text-slate-300">
+            <li>✓ Your bottleneck is landing-page conversion for paid or campaign traffic.</li>
+            <li>✓ You want drag-and-drop page creation and native A/B testing in the same platform.</li>
+            <li>✓ You want to use Unbounce's MCP with AI assistants such as ChatGPT or Claude.</li>
+            <li>✓ You expect conversion improvements to justify a dedicated CRO platform.</li>
           </ul>
         </div>
-        <div class="p-6 rounded-3xl bg-[#131520] border border-amber-500/20 space-y-3">
-          <h2 class="text-xl font-bold text-white">Consider an alternative when...</h2>
-          <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside">
-            <li>You mainly need app-to-app automation, data routing, or operational workflows; Make.com is the more direct category fit.</li>
-            <li>You need a general-purpose website/CMS rather than campaign-specific landing pages.</li>
-            <li>Your traffic is very low and you do not expect to use testing or optimization features enough to justify a paid landing-page platform.</li>
+        <div class="rounded-3xl border border-amber-500/20 bg-amber-500/5 p-6">
+          <h2 class="text-xl font-black text-white">Consider another tool when…</h2>
+          <ul class="mt-4 space-y-3 text-sm text-slate-300">
+            <li>• You mainly need app-to-app workflow automation rather than landing pages.</li>
+            <li>• You need a general-purpose website/CMS instead of campaign-specific pages.</li>
+            <li>• Your traffic is too low to make testing and optimization features useful.</li>
+            <li>• You need an all-in-one CRM, funnel and sales-operations suite instead of a focused CRO tool.</li>
           </ul>
         </div>
       </section>
 
-      <section class="p-7 rounded-3xl bg-purple-500/5 border border-purple-500/30 space-y-4">
+      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-5">
         <div>
-          <div class="text-[11px] uppercase font-extrabold tracking-wider text-purple-300">High-intent decision path</div>
-          <h2 class="text-2xl font-black text-white mt-1">Unbounce vs Make.com</h2>
-          <p class="text-sm text-slate-300 mt-2">These products solve different bottlenecks. Choose Unbounce for landing-page creation and conversion optimization; choose Make.com for multi-app automation and workflow orchestration.</p>
+          <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Why the partner route matters</div>
+          <h2 class="text-3xl font-black text-white mt-1">Use the verified link before starting your trial</h2>
         </div>
-        <div class="grid sm:grid-cols-3 gap-3">
-          <a href="/compare/make-com-vs-unbounce.html" class="px-5 py-3.5 rounded-xl font-bold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Compare side by side →</a>
-          <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="tool-decision" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 hover:bg-purple-500 text-white text-center transition-all">Try Unbounce with discount →</a>
-          <a data-cta="affiliate" data-tool-id="make-com" data-cta-source="tool-decision" href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3.5 rounded-xl font-extrabold text-sm bg-blue-600 hover:bg-blue-500 text-white text-center transition-all">Explore Make.com →</a>
+        <p class="text-sm text-slate-300 leading-relaxed">Unbounce's partner welcome email for COSHUMA identifies <span class="text-white font-semibold">https://unbounce.partnerlinks.io/5ubjnt8lluqi</span> as the unique customer referral link, confirms the 20% / 35% customer offer, and states that the link uses a 90-day cookie. COSHUMA therefore keeps revenue CTAs on that exact verified route rather than replacing it with a generic homepage or dashboard URL.</p>
+        <div class="rounded-2xl border border-amber-500/20 bg-amber-500/5 p-5 text-sm text-slate-300">Attribution is ultimately controlled by Unbounce and PartnerStack. COSHUMA does not claim a referral or commission until the partner system confirms it.</div>
+      </section>
+
+      <section class="rounded-3xl border border-purple-500/30 bg-purple-500/5 p-6 md:p-8 text-center space-y-4">
+        <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Decision path</div>
+        <h2 class="text-3xl font-black text-white">Start free, validate the workflow, then choose monthly or annual</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto">If Unbounce fits your campaign workflow, use the verified route to preserve the current customer discount and partner attribution.</p>
+        <div class="flex flex-col sm:flex-row justify-center gap-3 pt-1">
+          <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="tool-bottom" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="px-7 py-4 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-extrabold">Start Unbounce trial + partner offer →</a>
+          <a href="/best/unbounce-discount.html" class="px-7 py-4 rounded-xl border border-slate-600 bg-slate-800 hover:bg-slate-700 text-white font-bold">Read the exact discount guide →</a>
         </div>
       </section>
 
-      <section class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between gap-4">
-          <div class="flex items-center gap-2 text-purple-300 font-bold text-sm"><span>🏆 Are you the founder of Unbounce?</span></div>
-          <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
+      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-4">
+        <div class="flex items-center justify-between gap-4 flex-wrap">
+          <div>
+            <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Represent Unbounce?</div>
+            <h2 class="text-2xl font-black text-white mt-1">Request a COSHUMA sponsored placement</h2>
+          </div>
+          <span class="text-xs font-bold px-3 py-1.5 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-200">One-time USD 49</span>
         </div>
-        <p class="text-xs text-slate-400 leading-relaxed">Claim this profile to update company information and manage verified profile details. Sponsorship does not guarantee or alter editorial rankings.</p>
-        <a href="/#submit" class="inline-block px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all">Claim Unbounce Profile ($49/yr)</a>
+        <p class="text-sm text-slate-300 leading-relaxed">Sponsorship is reviewed separately from editorial coverage. Payment does not guarantee acceptance, ranking, or an editorial rating.</p>
+        <a href="mailto:support@coshuma.com?subject=Unbounce%20COSHUMA%20sponsored%20placement" class="inline-block px-5 py-3 rounded-xl bg-slate-800 border border-slate-600 text-white font-bold hover:bg-slate-700">Email a sponsorship request →</a>
+        <p class="text-[11px] text-slate-500">This inquiry link does not create a charge.</p>
       </section>
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
+      <div class="max-w-5xl mx-auto px-5">© 2026 COSHUMA · Independent AI & SaaS buyer guides</div>
     </footer>
     <script src="/affiliate-attribution.js"></script>
   </body>


### PR DESCRIPTION
Revenue-focused, zero-cost rewrite of the highest-impression Search Console query page with fresh conversion evidence.

Evidence checked Sep 6, 2026:
- COSHUMA's stored Search Console snapshot lists `unbounce` as the top query with 82 impressions and 0 search clicks in the captured 3-month window.
- Unbounce emailed COSHUMA on Sep 5 confirming that the unique partner link received a click, so this is a real partner-funnel signal rather than a guessed opportunity.
- Unbounce's partner welcome email confirms the exact customer link `https://unbounce.partnerlinks.io/5ubjnt8lluqi`, the 20% first-three-month / 35% first-annual-subscription offer, and a 90-day cookie.
- Unbounce's official pricing page rechecked Sep 6 lists Starter $29, Build $99, Experiment $149, Optimize $249, plus a 14-day no-card trial.

Changes:
- refresh SEO title/description around the actual pricing + discount intent
- replace stale GlobalSaaSHub source branding with COSHUMA
- add FAQ structured data for pricing, trial, discount and tracking window
- keep the exact verified affiliate URL and separate official pricing URL
- add three source-tagged affiliate CTAs for attribution
- add internal links to the dedicated Unbounce discount guide
- preserve the existing $49 sponsored-placement inquiry path without implying payment or editorial preference

No paid service, new application, guessed tracking URL, unsupported conversion claim, or generic dashboard/onboarding URL is introduced.