### PR TITLE
Optimize vidIQ vs TubeBuddy buyer-intent revenue page

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/vidiq-vs-tubebuddy.html
+++ b/projects/GlobalSaaSHub/public/compare/vidiq-vs-tubebuddy.html
@@ -3,34 +3,42 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>VidIQ vs TubeBuddy: Pricing, Features & Best Fit (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Compare VidIQ vs TubeBuddy for YouTube keyword research, SEO, AI content tools, bulk processing, and pricing. See which workflow fits your channel before you choose." />
-
+    <title>vidIQ vs TubeBuddy (2026): Pricing, AI Credits, SEO & Best Fit | COSHUMA</title>
+    <meta name="description" content="Compare vidIQ vs TubeBuddy in 2026 by pricing, AI credits, keyword research, YouTube SEO, A/B testing, bulk tools and creator workflow. Includes verified COSHUMA partner links." />
     <link rel="canonical" href="https://coshuma.com/compare/vidiq-vs-tubebuddy.html" />
+
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/compare/vidiq-vs-tubebuddy.html" />
-    <meta property="og:title" content="VidIQ vs TubeBuddy: Pricing, Features & Best Fit (2026)" />
-    <meta property="og:description" content="Compare VidIQ and TubeBuddy for YouTube keyword research, SEO, AI content tools, bulk processing, and pricing before you choose." />
+    <meta property="og:title" content="vidIQ vs TubeBuddy (2026): Pricing, AI Credits, SEO & Best Fit | COSHUMA" />
+    <meta property="og:description" content="A practical 2026 buyer guide to vidIQ vs TubeBuddy for YouTube research, AI workflow, SEO, testing and channel operations." />
 
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebPage",
-      "name": "VidIQ vs TubeBuddy Comparison",
+      "name": "vidIQ vs TubeBuddy Comparison",
       "url": "https://coshuma.com/compare/vidiq-vs-tubebuddy.html",
-      "description": "Compare VidIQ and TubeBuddy by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
+      "description": "Independent buyer guide comparing vidIQ and TubeBuddy using current public product and pricing information.",
+      "isPartOf": {"@type":"WebSite","name":"COSHUMA","url":"https://coshuma.com/"},
       "about": [
-        {"@type": "SoftwareApplication", "name": "VidIQ", "url": "https://coshuma.com/tool/vidiq.html"},
-        {"@type": "SoftwareApplication", "name": "TubeBuddy", "url": "https://coshuma.com/tool/tubebuddy.html"}
+        {"@type":"SoftwareApplication","name":"vidIQ","url":"https://coshuma.com/tool/vidiq.html"},
+        {"@type":"SoftwareApplication","name":"TubeBuddy","url":"https://coshuma.com/tool/tubebuddy.html"}
       ]
     }
     </script>
-    
+    <script type="application/ld+json">
+    {
+      "@context":"https://schema.org",
+      "@type":"FAQPage",
+      "mainEntity":[
+        {"@type":"Question","name":"Is vidIQ or TubeBuddy better for AI-assisted YouTube research?","acceptedAnswer":{"@type":"Answer","text":"vidIQ is the stronger fit when AI credits, AI Coach, ideas, Outliers, script and thumbnail workflows are central to your process. TubeBuddy is a stronger fit when your priority is YouTube Studio-oriented SEO, bulk operations, A/B testing and channel productivity."}},
+        {"@type":"Question","name":"Does vidIQ have a free plan?","acceptedAnswer":{"@type":"Answer","text":"Yes. vidIQ currently offers a free plan with 150 monthly AI credits and limited access to research and creator tools."}},
+        {"@type":"Question","name":"Does TubeBuddy have a free option?","acceptedAnswer":{"@type":"Answer","text":"Yes. TubeBuddy offers free access with limited functionality and lets creators upgrade for advanced features. Its live pricing page should be checked before purchase because pricing and discounts can vary."}},
+        {"@type":"Question","name":"Are the COSHUMA links on this page affiliate links?","acceptedAnswer":{"@type":"Answer","text":"Yes. The vidIQ and TubeBuddy purchase-path buttons use verified COSHUMA partner URLs. COSHUMA may earn a commission from qualifying purchases at no extra cost to the buyer."}}
+      ]
+    }
+    </script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -42,132 +50,90 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+    <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div><span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span></a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← All AI & SaaS Tools</a>
       </div>
     </header>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ YouTube Growth Tool Comparison
-        </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">VidIQ vs TubeBuddy</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Compare the YouTube SEO, keyword research, AI content, and channel-management workflows that matter before you choose a plan.
-        </p>
-        <p class="text-[11px] text-slate-500 max-w-2xl mx-auto">
-          Affiliate disclosure: pricing buttons on this page use verified partner links. GlobalSaaSHub may earn a commission at no extra cost to you.
-        </p>
-      </div>
-
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between gap-3 flex-wrap">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Quick Decision Guide</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Links and page copy reviewed September 1, 2026
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose VidIQ if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want YouTube keyword research plus AI video optimization, competitor analysis, and AI-assisted title or script creation in the same workflow.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Best-fit summary based on the features listed in this comparison.
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose TubeBuddy if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want video SEO and keyword research with bulk-processing tools and channel health reporting for day-to-day YouTube operations.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Best-fit summary based on the features listed in this comparison.
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/vidiq.html" class="hover:text-purple-300">VidIQ</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/tubebuddy.html" class="hover:text-blue-300">TubeBuddy</a>
-          </div>
+    <main class="max-w-5xl mx-auto px-4 py-10 w-full space-y-7">
+      <section class="p-7 md:p-9 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-6">
+        <div class="text-center space-y-3">
+          <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">YouTube Growth Tool Comparison</div>
+          <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">vidIQ vs TubeBuddy</h1>
+          <p class="text-slate-300 max-w-3xl mx-auto leading-relaxed">Choose based on the bottleneck you actually have: <strong class="text-white">research and AI-assisted content decisions</strong> versus <strong class="text-white">YouTube SEO, testing and channel operations</strong>.</p>
+          <p class="text-xs text-slate-500">Updated September 6, 2026. Pricing and feature availability can change; confirm the final vendor checkout before paying.</p>
         </div>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <article class="p-5 rounded-2xl bg-purple-500/10 border border-purple-500/30 space-y-3">
+            <div class="text-xs font-extrabold text-purple-300 uppercase tracking-wide">Choose vidIQ when</div>
+            <h2 class="text-xl font-black text-white">You want research + AI in one creator workflow</h2>
+            <p class="text-sm text-slate-300 leading-relaxed">Best fit for keyword and trend research, Outliers, competitor tracking, personalized ideas, AI Coach, scripts, thumbnails and other AI-assisted creator tasks that share a monthly credit pool.</p>
+            <a data-cta="affiliate" data-tool-id="vidiq" data-cta-source="vidiq-vs-tubebuddy-hero-vidiq" href="https://vidiq.com/coshuma" target="_blank" rel="sponsored noopener noreferrer" class="block px-5 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center hover:bg-purple-500 transition-all">Start with vidIQ via verified link →</a>
+          </article>
+          <article class="p-5 rounded-2xl bg-blue-500/10 border border-blue-500/30 space-y-3">
+            <div class="text-xs font-extrabold text-blue-300 uppercase tracking-wide">Choose TubeBuddy when</div>
+            <h2 class="text-xl font-black text-white">You want SEO + testing + channel operations</h2>
+            <p class="text-sm text-slate-300 leading-relaxed">Best fit for SEO Studio, keyword tools, A/B testing, bulk processing, channel analysis, Shorts linking and productivity features closely tied to an established YouTube workflow.</p>
+            <a data-cta="affiliate" data-tool-id="tubebuddy" data-cta-source="vidiq-vs-tubebuddy-hero-tubebuddy" href="https://www.tubebuddy.com/pricing?a=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="block px-5 py-3.5 rounded-xl font-extrabold text-sm bg-blue-600 text-white text-center hover:bg-blue-500 transition-all">Check TubeBuddy plans via verified link →</a>
+          </article>
         </div>
+        <p class="text-[11px] text-slate-400 text-center"><strong class="text-slate-300">Affiliate disclosure:</strong> both vendor buttons above use verified COSHUMA partner URLs. COSHUMA may earn a commission from qualifying purchases at no extra cost to you.</p>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">Free plan available</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <div><h2 class="text-2xl font-black text-white">2026 pricing snapshot</h2><p class="text-sm text-slate-400 mt-2">The figures below use current public US pricing information. TubeBuddy's own pricing page can render final amounts dynamically, so treat the checkout page as the final source of truth.</p></div>
+        <div class="overflow-x-auto rounded-2xl border border-[#222538]">
+          <table class="w-full min-w-[680px] text-sm">
+            <thead class="bg-[#181a29] text-slate-300"><tr><th class="text-left p-4">Tier</th><th class="text-left p-4">vidIQ</th><th class="text-left p-4">TubeBuddy</th><th class="text-left p-4">Buyer takeaway</th></tr></thead>
+            <tbody class="divide-y divide-[#222538]">
+              <tr><td class="p-4 font-bold text-white">Free</td><td class="p-4 text-slate-300">$0 · 150 AI credits/month</td><td class="p-4 text-slate-300">Free access · limited feature set</td><td class="p-4 text-slate-400">Use free access to validate the workflow before upgrading.</td></tr>
+              <tr><td class="p-4 font-bold text-white">Entry paid</td><td class="p-4 text-slate-300">Boost: $19 monthly or $199/year</td><td class="p-4 text-slate-300">Pro: $15 monthly or $144/year*</td><td class="p-4 text-slate-400">vidIQ puts more weight on research and AI usage; TubeBuddy Pro focuses on creator SEO/productivity basics.</td></tr>
+              <tr><td class="p-4 font-bold text-white">Higher self-serve</td><td class="p-4 text-slate-300">Max: $49 monthly or $468/year</td><td class="p-4 text-slate-300">Legend: $32.99 monthly or about $316.68/year*</td><td class="p-4 text-slate-400">Compare feature depth, not just price: the two products allocate value differently.</td></tr>
+            </tbody>
+          </table>
         </div>
+        <p class="text-[11px] text-slate-500">*TubeBuddy figures are the US prices reported on vidIQ's official comparison page with pricing checked August 7, 2026. TubeBuddy's own pricing page was rechecked September 6, 2026 and confirms Pro, Legend, Enterprise, annual savings and the feature structure, but its server-rendered page does not expose a stable numeric Pro/Legend amount in every session. Confirm the live TubeBuddy checkout before paying.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <a data-cta="affiliate" data-tool-id="vidiq" data-cta-source="vidiq-vs-tubebuddy-pricing-vidiq" href="https://vidiq.com/coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 text-white text-center hover:bg-purple-500">Check vidIQ plans →</a>
+          <a data-cta="affiliate" data-tool-id="tubebuddy" data-cta-source="vidiq-vs-tubebuddy-pricing-tubebuddy" href="https://www.tubebuddy.com/pricing?a=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3.5 rounded-xl font-extrabold text-sm bg-blue-600 text-white text-center hover:bg-blue-500">Check TubeBuddy live pricing →</a>
+        </div>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">VidIQ Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ YouTube keyword research</div>
-              <div>✓ AI video optimization</div>
-              <div>✓ Competitor analysis</div>
-              <div>✓ AI content generation (titles, scripts)</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">TubeBuddy Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Video SEO optimization</div>
-              <div>✓ Keyword research tools</div>
-              <div>✓ Bulk processing features</div>
-              <div>✓ Channel health reports</div>
-            </div>
-          </div>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">The differences that matter more than price</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/25 space-y-3"><h3 class="font-black text-purple-300">vidIQ: stronger AI/research orientation</h3><ul class="text-sm text-slate-300 space-y-2"><li>✓ Free currently includes 150 monthly AI credits.</li><li>✓ Boost starts from 2,000 AI credits/month; Max starts from 6,000.</li><li>✓ Paid plans expand keyword research, Outliers, competitors, daily ideas and creator intelligence.</li><li>✓ AI credits are shared across AI Coach, thumbnails, clipping, script writing and other supported AI tools.</li><li>✓ vidIQ MCP is currently available across Free, Boost and Max during its launch period.</li></ul></div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/25 space-y-3"><h3 class="font-black text-blue-300">TubeBuddy: stronger Studio/operations orientation</h3><ul class="text-sm text-slate-300 space-y-2"><li>✓ Pro includes basic video/thumbnail tools, title/tag optimization and creator strategy utilities.</li><li>✓ Legend adds full search/SEO access, advanced reporting and bulk processing/editing.</li><li>✓ A/B Testing, SEO Studio, keyword tools and YouTube workflow utilities are central to the product.</li><li>✓ Shorts linking and topical-analysis workflows are included in the current plan structure.</li><li>✓ Enterprise is positioned for brands and teams managing multiple channels.</li></ul></div>
         </div>
+      </section>
 
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 pt-2">
-          <a href="https://vidiq.com/coshuma" target="_blank" rel="sponsored noopener noreferrer" data-cta="affiliate" data-tool-id="vidiq" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Check VidIQ pricing →</a>
-          <a href="https://www.tubebuddy.com/pricing?a=coshuma" target="_blank" rel="sponsored noopener noreferrer" data-cta="affiliate" data-tool-id="tubebuddy" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Check TubeBuddy pricing →</a>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-2xl font-black text-white">Use this decision rule</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+          <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/20"><div class="font-extrabold text-white">Pick vidIQ first if...</div><p class="text-slate-300 mt-2 leading-relaxed">You frequently ask “what should I make next?”, need competitor/outlier discovery, want AI help with creator decisions, or expect research and generation to live in one workflow.</p></div>
+          <div class="p-5 rounded-2xl bg-blue-500/5 border border-blue-500/20"><div class="font-extrabold text-white">Pick TubeBuddy first if...</div><p class="text-slate-300 mt-2 leading-relaxed">You already publish consistently and the bottleneck is metadata SEO, testing, bulk changes, optimization discipline or repetitive YouTube channel management.</p></div>
+          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20"><div class="font-extrabold text-white">Stay free first if...</div><p class="text-slate-300 mt-2 leading-relaxed">You have not yet identified a repeatable publishing bottleneck. Paying for either tool before a workflow exists usually creates software cost without a clear return.</p></div>
+          <div class="p-5 rounded-2xl bg-amber-500/5 border border-amber-500/20"><div class="font-extrabold text-white">Check both before buying if...</div><p class="text-slate-300 mt-2 leading-relaxed">Your channel needs both research and operations. Open the two live plan pages, compare the exact features you will use weekly, then choose one first instead of paying for overlap.</p></div>
         </div>
-        <p class="text-[10px] text-slate-500 text-center">Vendor pricing and plan availability can change. Confirm current terms on the linked pricing page before purchase.</p>
-      </div>
+      </section>
+
+      <section class="p-7 rounded-3xl bg-gradient-to-r from-purple-500/10 to-blue-500/10 border border-purple-500/30 space-y-5 text-center">
+        <h2 class="text-2xl md:text-3xl font-black text-white">Choose the tool that removes the next bottleneck</h2>
+        <p class="text-sm text-slate-300 max-w-3xl mx-auto leading-relaxed">For research, ideas and AI-assisted creator intelligence, start with vidIQ. For SEO, testing and channel operations, check TubeBuddy. Both links below are verified COSHUMA partner routes.</p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-2xl mx-auto">
+          <a data-cta="affiliate" data-tool-id="vidiq" data-cta-source="vidiq-vs-tubebuddy-bottom-vidiq" href="https://vidiq.com/coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold text-sm bg-purple-600 text-white hover:bg-purple-500">Start with vidIQ →</a>
+          <a data-cta="affiliate" data-tool-id="tubebuddy" data-cta-source="vidiq-vs-tubebuddy-bottom-tubebuddy" href="https://www.tubebuddy.com/pricing?a=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold text-sm bg-blue-600 text-white hover:bg-blue-500">View TubeBuddy plans →</a>
+        </div>
+      </section>
+
+      <section class="p-5 rounded-2xl bg-[#10121b] border border-[#222538] text-xs text-slate-500 leading-relaxed">
+        <strong class="text-slate-300">Source note:</strong> vidIQ plan prices and the dated US TubeBuddy cross-check were taken from vidIQ's official comparison page (pricing checked August 7, 2026). vidIQ feature and AI-credit limits were rechecked against the official vidIQ Help Center on September 6, 2026. TubeBuddy's own pricing page was rechecked September 6, 2026 for the current Pro/Legend/Enterprise structure, SEO, bulk-processing, Shorts and annual-billing information. Affiliate URLs were preserved from COSHUMA's verified affiliate records; no generic homepage or dashboard URL was substituted.
+      </section>
     </main>
 
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
+    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS buyer guides. All rights reserved.</div></footer>
   </body>
 </html>


### PR DESCRIPTION
Revenue-focused CRO update for the existing vidIQ vs TubeBuddy comparison page.

- preserves only the already verified customer-facing partner URLs for vidIQ and TubeBuddy
- replaces legacy GlobalSaaSHub branding with COSHUMA
- removes unhelpful `Not rated` rows
- adds current pricing context with explicit source/date caveats
- adds current vidIQ AI-credit and TubeBuddy SEO/bulk workflow guidance
- adds six distinct `data-cta-source` positions so affiliate-click attribution can identify which vendor and placement converts
- adds FAQ structured data and clearer buyer decision rules
- no paid spend, new subscription, or unverified tracking parameter