### PR TITLE
Disable redundant Vercel preview deployments for COSHUMA

### DIFF
--- a/projects/GlobalSaaSHub/public/vercel.json
+++ b/projects/GlobalSaaSHub/public/vercel.json
@@ -1,0 +1,5 @@
+{
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
COSHUMA production is published from the GitHub Pages bundle, while the same gh-pages updates are also triggering redundant Vercel Git preview builds for legacy projects such as cosuma-market-b2b and coshuma-official. Those previews are repeatedly failing and generating noise.

This adds Vercel's documented `git.deploymentEnabled: false` setting to the static public bundle so the generated gh-pages root carries `vercel.json` and future Git pushes stop triggering automatic Vercel deployments.

No paid service, domain, affiliate link, or production content is changed.