### PR TITLE
Optimize Brand24 search CTR and affiliate conversion

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/brand24.html
+++ b/projects/GlobalSaaSHub/public/tool/brand24.html
@@ -3,72 +3,60 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Brand24 Review & Pricing (2026): 14-Day Free Trial, Features & Best Fit | GlobalSaaSHub</title>
-    <meta name="description" content="Brand24 review for buyers: current 2026 pricing, 14-day free trial, AI social listening features, best-fit use cases, limitations, and a verified partner signup link." />
+    <title>Brand24 Pricing 2026: $249/mo, 14-Day Free Trial & AI Visibility | COSHUMA</title>
+    <meta name="description" content="Brand24 pricing starts at $249/mo ($199/mo billed annually). See the 14-day free trial, AI social listening features, $99 AI Visibility add-on, plan limits, and verified COSHUMA partner link." />
     <link rel="canonical" href="https://coshuma.com/tool/brand24.html" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/tool/brand24.html" />
-    <meta property="og:title" content="Brand24 Review & Pricing (2026): Is It Worth It for Social Listening?" />
-    <meta property="og:description" content="See Brand24 pricing, the 14-day free trial, AI monitoring features, and whether it fits your reputation, PR, or competitor-monitoring workflow." />
+    <meta property="og:title" content="Brand24 Pricing 2026: $249/mo + 14-Day Free Trial" />
+    <meta property="og:description" content="Compare current Brand24 plans, AI social listening features, the AI Visibility add-on, and whether Brand24 is worth the cost for your team." />
     <script type="application/ld+json">
     {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "Brand24",
-      "operatingSystem": "Web",
-      "applicationCategory": "BusinessApplication",
-      "url": "https://brand24.com/",
-      "description": "AI-powered social listening software for monitoring online mentions, sentiment, reach, trends, and brand reputation."
+      "@context":"https://schema.org",
+      "@type":"SoftwareApplication",
+      "name":"Brand24",
+      "operatingSystem":"Web",
+      "applicationCategory":"BusinessApplication",
+      "url":"https://brand24.com/",
+      "description":"AI-powered social listening and brand monitoring software with an optional AI Visibility layer."
     }
     </script>
     <script type="application/ld+json">
     {
-      "@context": "https://schema.org",
-      "@type": "FAQPage",
-      "mainEntity": [
+      "@context":"https://schema.org",
+      "@type":"FAQPage",
+      "mainEntity":[
         {
-          "@type": "Question",
-          "name": "Does Brand24 have a free trial?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Brand24's official pricing page states that the first 14 days are free and no credit card is required."
-          }
+          "@type":"Question",
+          "name":"How much does Brand24 cost in 2026?",
+          "acceptedAnswer":{"@type":"Answer","text":"As checked September 6, 2026, Brand24 lists Individual at $249/month or $199/month billed annually, Team at $349/month or $299/month billed annually, Pro at $499/month or $399/month billed annually, Business at $699/month or $599/month billed annually, and Enterprise from $1,499/month billed annually."}
         },
         {
-          "@type": "Question",
-          "name": "How much does Brand24 cost?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "As checked on September 3, 2026, Brand24 lists Individual at $249/month or $199/month billed annually, Team at $349/month or $299/month billed annually, Pro at $499/month or $399/month billed annually, Business at $699/month or $599/month billed annually, and Enterprise from $1,499/month billed annually."
-          }
+          "@type":"Question",
+          "name":"Does Brand24 have a free trial?",
+          "acceptedAnswer":{"@type":"Answer","text":"Yes. Brand24 states that the first 14 days are free and no credit card is required."}
         },
         {
-          "@type": "Question",
-          "name": "Who is Brand24 best for?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Brand24 is best suited to teams that need social listening, reputation monitoring, sentiment analysis, PR measurement, competitor monitoring, or alerts around online mentions."
-          }
+          "@type":"Question",
+          "name":"How much is Brand24 AI Visibility?",
+          "acceptedAnswer":{"@type":"Answer","text":"Brand24 currently lists its AI Visibility add-on at $99 per month on top of an active Brand24 subscription. The add-on can be tried during a free trial period."}
         }
       ]
     }
     </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script defer src="/affiliate-attribution.js"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700;800;900&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <style>
-      body { font-family: 'Inter', sans-serif; background: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
+      body{font-family:Inter,system-ui,sans-serif;background:#0b0c10;color:#f1f5f9}
+      h1,h2,h3{font-family:Inter,system-ui,sans-serif}
     </style>
   </head>
   <body class="min-h-screen bg-[#0b0c10] text-slate-100">
     <header class="sticky top-0 z-50 border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md">
       <div class="max-w-5xl mx-auto px-5 py-4 flex items-center justify-between gap-4">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-9 w-9 rounded-xl bg-purple-600 flex items-center justify-center font-black text-white">G</div>
-          <span class="font-extrabold tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-9 w-9 rounded-xl bg-purple-600 flex items-center justify-center font-black text-white">C</div>
+          <span class="font-extrabold tracking-tight text-white">COSHUMA</span>
         </a>
         <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 text-purple-200 hover:bg-purple-500/10">Browse AI & SaaS tools</a>
       </div>
@@ -81,144 +69,105 @@
             <div class="flex items-center gap-4">
               <img src="https://www.google.com/s2/favicons?domain=brand24.com&sz=128" alt="Brand24 logo" class="h-14 w-14 rounded-2xl border border-[#2a2e42] bg-slate-900 p-2" />
               <div>
-                <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">AI social listening</div>
-                <h1 class="text-4xl md:text-5xl font-black text-white mt-1">Brand24 Review & Pricing</h1>
+                <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">AI social listening + AI visibility</div>
+                <h1 class="text-4xl md:text-5xl font-black text-white mt-1">Brand24 Pricing & Review 2026</h1>
               </div>
             </div>
-            <p class="text-lg text-slate-300 leading-relaxed max-w-3xl">Brand24 is built for teams that need to catch online mentions, understand sentiment, track brand reputation, and turn social-listening data into reports and AI-assisted insights.</p>
+            <p class="text-lg text-slate-300 leading-relaxed max-w-3xl">Brand24 combines social listening, sentiment and reputation monitoring with an optional AI Visibility layer for tracking how brands appear in ChatGPT, Gemini, Perplexity and other AI answers.</p>
             <div class="flex flex-wrap gap-2 text-xs font-bold">
+              <span class="px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/25 text-emerald-300">Starts at $249/mo</span>
               <span class="px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/25 text-emerald-300">14-day free trial</span>
-              <span class="px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/25 text-emerald-300">No credit card required</span>
-              <span class="px-3 py-1.5 rounded-full bg-purple-500/10 border border-purple-500/25 text-purple-200">Verified COSHUMA partner link</span>
+              <span class="px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/25 text-emerald-300">No credit card</span>
+              <span class="px-3 py-1.5 rounded-full bg-purple-500/10 border border-purple-500/25 text-purple-200">Verified partner tracking</span>
             </div>
             <div class="flex flex-col sm:flex-row gap-3 pt-1">
-              <a data-cta="affiliate" data-tool-id="brand24" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white font-extrabold text-center hover:brightness-110 shadow-lg shadow-purple-950/40">Try Brand24 via Verified Partner Link →</a>
+              <a data-cta="affiliate" data-tool-id="brand24" data-cta-source="brand24-hero" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white font-extrabold text-center hover:brightness-110 shadow-lg shadow-purple-950/40">Start Brand24 14-Day Trial →</a>
               <a data-cta="official" href="https://brand24.com/prices/" target="_blank" rel="noopener noreferrer" class="px-6 py-4 rounded-xl border border-slate-600 bg-slate-800/60 text-white font-bold text-center hover:bg-slate-700">Check official pricing</a>
             </div>
-            <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission when an eligible purchase is attributed through the verified Brand24 partner link, at no extra cost to you.</p>
+            <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission if an eligible purchase is attributed through the verified Brand24 partner link, at no extra cost to you.</p>
           </div>
           <aside class="w-full md:w-72 rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-5 space-y-4">
             <div>
               <div class="text-xs uppercase tracking-wider text-slate-500 font-bold">Best for</div>
-              <div class="mt-2 text-sm text-slate-200 leading-relaxed">PR, reputation, competitor monitoring, customer-insight and social-listening teams.</div>
+              <div class="mt-2 text-sm text-slate-200 leading-relaxed">PR, reputation, SEO/GEO, competitor-monitoring and customer-insight teams.</div>
             </div>
             <div class="border-t border-[#222538] pt-4">
-              <div class="text-xs uppercase tracking-wider text-slate-500 font-bold">Watch out for</div>
-              <div class="mt-2 text-sm text-slate-300 leading-relaxed">The entry plan is relatively expensive for casual monitoring. Buyers should match keyword, mention, user and update-frequency limits to their workload.</div>
+              <div class="text-xs uppercase tracking-wider text-slate-500 font-bold">Main trade-off</div>
+              <div class="mt-2 text-sm text-slate-300 leading-relaxed">The entry price is high for light monitoring. Match keyword, mention, update-frequency and AI needs to the right plan before paying.</div>
             </div>
           </aside>
-        </div>
-      </section>
-
-      <section class="grid md:grid-cols-3 gap-4">
-        <div class="rounded-2xl border border-[#25293b] bg-[#121520] p-5">
-          <div class="text-purple-300 font-bold text-sm">Monitor broadly</div>
-          <p class="text-sm text-slate-300 mt-2 leading-relaxed">Brand24 says it monitors mentions across social media, news, blogs, videos, forums, podcasts, reviews and other online sources.</p>
-        </div>
-        <div class="rounded-2xl border border-[#25293b] bg-[#121520] p-5">
-          <div class="text-purple-300 font-bold text-sm">Understand sentiment</div>
-          <p class="text-sm text-slate-300 mt-2 leading-relaxed">Sentiment analysis separates positive, negative and neutral mentions so teams can prioritize reputation and customer-response work.</p>
-        </div>
-        <div class="rounded-2xl border border-[#25293b] bg-[#121520] p-5">
-          <div class="text-purple-300 font-bold text-sm">Use AI for triage</div>
-          <p class="text-sm text-slate-300 mt-2 leading-relaxed">Brand24 lists AI Insights, topic analysis, anomaly detection and Brand Assistant capabilities across its product and higher-tier plans.</p>
         </div>
       </section>
 
       <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-5">
         <div>
           <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Current pricing</div>
-          <h2 class="text-2xl md:text-3xl font-black text-white mt-1">Brand24 pricing checked September 3, 2026</h2>
-          <p class="text-sm text-slate-400 mt-2">Prices below are taken from Brand24's official pricing page. Software pricing can change, so verify before purchase.</p>
+          <h2 class="text-2xl md:text-3xl font-black text-white mt-1">Brand24 plans checked September 6, 2026</h2>
+          <p class="text-sm text-slate-400 mt-2">These figures were rechecked against Brand24's official pricing page. Pricing can change, so verify before purchase.</p>
         </div>
         <div class="overflow-x-auto rounded-2xl border border-[#2a2e42]">
-          <table class="w-full min-w-[720px] text-left text-sm">
+          <table class="w-full min-w-[760px] text-left text-sm">
             <thead class="bg-[#0d1018] text-slate-300">
-              <tr>
-                <th class="p-4">Plan</th>
-                <th class="p-4">Monthly</th>
-                <th class="p-4">Annual billing</th>
-                <th class="p-4">Useful official limits / notes</th>
-              </tr>
+              <tr><th class="p-4">Plan</th><th class="p-4">Monthly</th><th class="p-4">Annual billing</th><th class="p-4">Key official limits</th></tr>
             </thead>
             <tbody class="divide-y divide-[#25293b] text-slate-300">
-              <tr><td class="p-4 font-bold text-white">Individual</td><td class="p-4">$249/mo</td><td class="p-4">$199/mo</td><td class="p-4">3 keywords, 2K mentions/mo, 1 user, updates every 12h</td></tr>
-              <tr><td class="p-4 font-bold text-white">Team</td><td class="p-4">$349/mo</td><td class="p-4">$299/mo</td><td class="p-4">7 keywords, 10K mentions/mo, unlimited users, hourly updates</td></tr>
-              <tr><td class="p-4 font-bold text-white">Pro</td><td class="p-4">$499/mo</td><td class="p-4">$399/mo</td><td class="p-4">12 keywords, 40K mentions/mo, unlimited users, real-time updates</td></tr>
-              <tr><td class="p-4 font-bold text-white">Business</td><td class="p-4">$699/mo</td><td class="p-4">$599/mo</td><td class="p-4">25 keywords, 100K mentions/mo, real-time updates, broader AI/reporting features</td></tr>
-              <tr><td class="p-4 font-bold text-white">Enterprise</td><td class="p-4">From $1,499/mo</td><td class="p-4">From $1,499/mo</td><td class="p-4">Custom keyword and mention limits, enterprise support and advanced features</td></tr>
+              <tr><td class="p-4 font-bold text-white">Individual</td><td class="p-4">$249/mo</td><td class="p-4">$199/mo</td><td class="p-4">3 keywords · 2K mentions/mo · 1 user · 12h updates</td></tr>
+              <tr><td class="p-4 font-bold text-white">Team</td><td class="p-4">$349/mo</td><td class="p-4">$299/mo</td><td class="p-4">7 keywords · 10K mentions/mo · unlimited users · hourly updates</td></tr>
+              <tr><td class="p-4 font-bold text-white">Pro</td><td class="p-4">$499/mo</td><td class="p-4">$399/mo</td><td class="p-4">12 keywords · 40K mentions/mo · real-time updates · advanced AI tools</td></tr>
+              <tr><td class="p-4 font-bold text-white">Business</td><td class="p-4">$699/mo</td><td class="p-4">$599/mo</td><td class="p-4">25 keywords · 100K mentions/mo · real-time updates · advanced reports</td></tr>
+              <tr><td class="p-4 font-bold text-white">Enterprise</td><td class="p-4">From $1,499/mo</td><td class="p-4">From $1,499/mo</td><td class="p-4">Custom limits · enterprise support · AI Visibility module listed</td></tr>
             </tbody>
           </table>
         </div>
-        <div class="flex flex-col sm:flex-row gap-3">
-          <a data-cta="affiliate" data-tool-id="brand24" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3.5 rounded-xl bg-purple-600 text-white font-extrabold text-center hover:bg-purple-500">Try Brand24 with the verified partner link →</a>
-          <a href="https://brand24.com/prices/" target="_blank" rel="noopener noreferrer" class="px-5 py-3.5 rounded-xl border border-slate-600 text-slate-200 font-bold text-center hover:bg-slate-800">Verify latest pricing at Brand24</a>
+        <div class="grid sm:grid-cols-2 gap-3">
+          <a data-cta="affiliate" data-tool-id="brand24" data-cta-source="brand24-pricing" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3.5 rounded-xl bg-purple-600 text-white font-extrabold text-center hover:bg-purple-500">Try Brand24 before paying →</a>
+          <a href="https://brand24.com/prices/" target="_blank" rel="noopener noreferrer" class="px-5 py-3.5 rounded-xl border border-slate-600 text-slate-200 font-bold text-center hover:bg-slate-800">Verify latest plan limits</a>
         </div>
+      </section>
+
+      <section class="rounded-3xl border border-cyan-500/20 bg-cyan-500/5 p-6 md:p-8 space-y-4">
+        <div class="text-xs uppercase tracking-widest text-cyan-300 font-bold">New buyer angle</div>
+        <h2 class="text-2xl md:text-3xl font-black text-white">Brand24 now extends beyond social listening into AI search visibility</h2>
+        <p class="text-sm md:text-base text-slate-300 leading-relaxed">Brand24's AI Visibility layer tracks brand presence and position in AI-generated answers, competitor share of voice and citing sources. Brand24 currently lists the add-on at <strong class="text-white">$99/month</strong> on top of an active subscription, with a free trial available.</p>
+        <div class="grid sm:grid-cols-3 gap-3 text-sm">
+          <div class="rounded-2xl border border-cyan-500/15 bg-[#0d1018] p-4"><strong class="text-white">Prompt tracking</strong><p class="mt-2 text-slate-400">Monitor questions customers ask across major AI platforms.</p></div>
+          <div class="rounded-2xl border border-cyan-500/15 bg-[#0d1018] p-4"><strong class="text-white">Competitor benchmarking</strong><p class="mt-2 text-slate-400">Compare AI visibility and share of voice against competing brands.</p></div>
+          <div class="rounded-2xl border border-cyan-500/15 bg-[#0d1018] p-4"><strong class="text-white">Citation sources</strong><p class="mt-2 text-slate-400">Identify sources that appear to drive AI citations for your category.</p></div>
+        </div>
+        <a href="/best/brand24-ai-visibility.html" class="inline-flex items-center justify-center px-5 py-3 rounded-xl border border-cyan-400/30 text-cyan-200 font-bold hover:bg-cyan-500/10">See COSHUMA's Brand24 AI Visibility buyer guide →</a>
       </section>
 
       <section class="grid md:grid-cols-2 gap-5">
         <div class="rounded-3xl border border-emerald-500/20 bg-emerald-500/5 p-6">
           <h2 class="text-xl font-black text-white">Brand24 makes sense if…</h2>
           <ul class="mt-4 space-y-3 text-sm text-slate-300">
-            <li>✓ You need to monitor brand, product, competitor or campaign mentions across many online sources.</li>
-            <li>✓ You need sentiment and reach signals to prioritize PR or support responses.</li>
-            <li>✓ You need reports and alerts rather than only a social publishing calendar.</li>
-            <li>✓ The value of catching reputation issues or media opportunities justifies the subscription cost.</li>
+            <li>✓ You need broad online mention and reputation monitoring.</li>
+            <li>✓ You need sentiment, alerts and reporting rather than only social scheduling.</li>
+            <li>✓ You want to combine traditional brand monitoring with AI/GEO visibility signals.</li>
+            <li>✓ The value of catching reputation or competitive signals justifies the subscription cost.</li>
           </ul>
         </div>
         <div class="rounded-3xl border border-rose-500/20 bg-rose-500/5 p-6">
-          <h2 class="text-xl font-black text-white">Consider another tool if…</h2>
+          <h2 class="text-xl font-black text-white">Skip or compare alternatives if…</h2>
           <ul class="mt-4 space-y-3 text-sm text-slate-300">
-            <li>• You mainly need social posting, scheduling or content generation rather than listening.</li>
-            <li>• You are a solo user with light monitoring needs and the entry price is difficult to justify.</li>
-            <li>• You need to evaluate a very high mention volume but have not checked plan limits first.</li>
-            <li>• Your main requirement is a low-cost creator workflow rather than reputation intelligence.</li>
+            <li>• You mainly need low-cost social publishing or content scheduling.</li>
+            <li>• Your monitoring volume is small enough that the $249 entry price is hard to justify.</li>
+            <li>• You only need AI prompt tracking and do not need broader social listening.</li>
+            <li>• You have not mapped your required keyword and mention limits yet.</li>
           </ul>
         </div>
       </section>
 
-      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-5">
-        <h2 class="text-2xl font-black text-white">Feature reality check</h2>
-        <div class="grid sm:grid-cols-2 gap-4 text-sm">
-          <div class="rounded-2xl bg-[#0d1018] border border-[#25293b] p-5"><div class="font-bold text-white">AI Sentiment Analysis</div><p class="mt-2 text-slate-400 leading-relaxed">Available across the listed plans on the official pricing page.</p></div>
-          <div class="rounded-2xl bg-[#0d1018] border border-[#25293b] p-5"><div class="font-bold text-white">AI Insights & Topics</div><p class="mt-2 text-slate-400 leading-relaxed">Brand24 lists AI-generated insights and topic analysis, with availability and limits varying by plan.</p></div>
-          <div class="rounded-2xl bg-[#0d1018] border border-[#25293b] p-5"><div class="font-bold text-white">Alerts & anomaly detection</div><p class="mt-2 text-slate-400 leading-relaxed">Storm Alerts and AI anomaly detection are designed to surface sudden changes in mention volume or reach.</p></div>
-          <div class="rounded-2xl bg-[#0d1018] border border-[#25293b] p-5"><div class="font-bold text-white">Reports & exports</div><p class="mt-2 text-slate-400 leading-relaxed">Brand24 lists email reports plus Excel, PowerPoint and infographic reporting/export options.</p></div>
-        </div>
-      </section>
-
-      <section class="rounded-3xl border border-purple-500/25 bg-purple-500/5 p-6 md:p-8 space-y-4">
-        <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Alternative path</div>
-        <h2 class="text-2xl font-black text-white">Need social-media workflow automation more than social listening?</h2>
-        <p class="text-sm text-slate-300 leading-relaxed max-w-3xl">Brand24 is primarily a monitoring and intelligence tool. If your priority is AI-assisted social-media workflow management instead, review Followr before deciding.</p>
-        <div class="flex flex-col sm:flex-row gap-3">
-          <a href="/tool/followr.html" class="px-5 py-3 rounded-xl border border-purple-500/30 text-purple-100 font-bold text-center hover:bg-purple-500/10">Review Followr</a>
-          <a data-cta="affiliate" data-tool-id="followr" href="https://followr.ai/?ref=support22" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3 rounded-xl bg-purple-600 text-white font-extrabold text-center hover:bg-purple-500">Try Followr →</a>
-        </div>
-        <p class="text-[11px] text-slate-500">Affiliate disclosure: GlobalSaaSHub may earn a commission if you purchase through the Followr link, at no extra cost to you.</p>
-      </section>
-
       <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-4">
-        <h2 class="text-2xl font-black text-white">FAQ</h2>
-        <div class="space-y-4 text-sm">
-          <div><h3 class="font-bold text-white">Does Brand24 have a free trial?</h3><p class="text-slate-400 mt-1 leading-relaxed">Yes. Brand24's official pricing page states that the first 14 days are free and no credit card is required.</p></div>
-          <div><h3 class="font-bold text-white">Is Brand24 cheap?</h3><p class="text-slate-400 mt-1 leading-relaxed">Not for light use. The official monthly Individual plan was $249/month when checked on September 3, 2026. The value case is strongest when monitoring reputation, PR, competitors or customer sentiment has measurable business impact.</p></div>
-          <div><h3 class="font-bold text-white">What should I check before starting?</h3><p class="text-slate-400 mt-1 leading-relaxed">Check how many keywords and mentions you expect, how many users need access, how quickly mentions must update, and which AI/reporting features are included in the plan you are considering.</p></div>
-        </div>
-      </section>
-
-      <section class="rounded-3xl border border-purple-500/30 bg-gradient-to-br from-purple-500/10 to-indigo-500/5 p-7 md:p-9 text-center space-y-4">
-        <h2 class="text-3xl font-black text-white">Ready to test Brand24 with your own keywords?</h2>
-        <p class="text-sm text-slate-300 max-w-2xl mx-auto">Use the trial to validate mention quality, alert usefulness, sentiment accuracy for your market, and whether the plan limits match your real workload before committing.</p>
-        <a data-cta="affiliate" data-tool-id="brand24" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-4 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white font-extrabold hover:brightness-110 shadow-lg shadow-purple-950/40">Try Brand24 via Verified Partner Link →</a>
-        <p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn a commission from eligible purchases attributed through this partner link, at no extra cost to you.</p>
+        <h2 class="text-2xl font-black text-white">Bottom line</h2>
+        <p class="text-slate-300 leading-relaxed">Brand24 is easier to justify when online reputation, competitive intelligence or AI-search visibility is worth more than the subscription cost. For a small team, the safest path is to use the 14-day trial to test real keyword volume, alert quality and reporting before committing.</p>
+        <a data-cta="affiliate" data-tool-id="brand24" data-cta-source="brand24-bottom" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="block w-full sm:w-auto sm:inline-block px-6 py-4 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white font-extrabold text-center hover:brightness-110">Start the Brand24 free trial →</a>
       </section>
     </main>
 
-    <footer class="border-t border-[#222538] bg-[#07080c] mt-10">
-      <div class="max-w-5xl mx-auto px-5 py-8 text-xs text-slate-500 flex flex-col md:flex-row gap-2 md:items-center md:justify-between">
-        <span>© 2026 GlobalSaaSHub. Independent AI & SaaS decision support.</span>
-        <span>Brand24 pricing/features last checked September 3, 2026 against official Brand24 pages.</span>
+    <footer class="border-t border-[#222538] mt-10">
+      <div class="max-w-5xl mx-auto px-5 py-8 text-xs text-slate-500 leading-relaxed">
+        COSHUMA buyer guides use official product information and verified partner tracking where available. Pricing and product features can change; check the vendor before purchasing.
       </div>
     </footer>
   </body>


### PR DESCRIPTION
Revenue-focused CRO update for an existing Search Console opportunity.

Evidence used:
- Stored COSHUMA Search Console snapshot: `brand24` has 44 impressions and 0 clicks.
- Brand24 official pricing rechecked Sep 6, 2026: Individual $249/mo ($199/mo annual), Team $349/$299, Pro $499/$399, Business $699/$599, Enterprise from $1,499; 14-day free trial with no card.
- Brand24 official AI Visibility pages: optional AI Visibility add-on at $99/mo on top of an active Brand24 subscription.
- Existing verified partner URL preserved exactly: `https://try.brand24.com/8xqrjxybmsbt`.

Changes:
- Replace stale GlobalSaaSHub branding with COSHUMA.
- Tighten title/meta around high-intent Brand24 pricing + free-trial queries.
- Add CTA-source attribution for hero/pricing/bottom affiliate clicks.
- Add current AI Visibility buyer angle and internal link to the dedicated Brand24 AI Visibility guide.
- Keep official pricing as a separate non-affiliate verification link.

No paid services or new subscriptions.