### PR TITLE
Turn HubSpot traffic into an agency-focused HighLevel revenue funnel

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/hubspot.html
+++ b/projects/GlobalSaaSHub/public/tool/hubspot.html
@@ -3,166 +3,174 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>HubSpot Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="A powerful CRM platform offering integrated tools for marketing, sales, customer service, and content management to grow businesses.... Discover features, pricing (See official pricing), and official links for HubSpot on GlobalSaaSHub." />
+    <title>HubSpot Pricing & Review (2026): Free vs Starter vs Pro | COSHUMA</title>
+    <meta name="description" content="HubSpot pricing and buyer guide for 2026: compare Free, Starter, Professional and Enterprise, see where costs rise, and decide when HighLevel may fit agencies better." />
     <link rel="canonical" href="https://coshuma.com/tool/hubspot.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/tool/hubspot.html" />
-    <meta property="og:title" content="HubSpot Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="A powerful CRM platform offering integrated tools for marketing, sales, customer service, and content management to grow businesses.... Check rating, pricing, and features." />
-
-    <!-- JSON-LD Structured Data for Google Indexing -->
+    <meta property="og:site_name" content="COSHUMA" />
+    <meta property="og:title" content="HubSpot Pricing & Review (2026): Free vs Starter vs Pro" />
+    <meta property="og:description" content="A practical HubSpot buyer guide with current Customer Platform pricing, plan trade-offs and an agency-focused HighLevel comparison." />
     <script type="application/ld+json">
     {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "HubSpot",
-      "operatingSystem": "Web",
-      "applicationCategory": "Sales & CRM",
-      "description": "A powerful CRM platform offering integrated tools for marketing, sales, customer service, and content management to grow businesses."
+      "@context":"https://schema.org",
+      "@type":"WebPage",
+      "name":"HubSpot Pricing & Review (2026)",
+      "url":"https://coshuma.com/tool/hubspot.html",
+      "description":"Independent buyer guide to HubSpot pricing, plan fit and agency alternatives.",
+      "about":{"@type":"SoftwareApplication","name":"HubSpot","applicationCategory":"BusinessApplication","operatingSystem":"Web","sameAs":"https://www.hubspot.com/"},
+      "isPartOf":{"@type":"WebSite","name":"COSHUMA","url":"https://coshuma.com/"}
     }
     </script>
-
-    <!-- Tailwind & Fonts -->
+    <script type="application/ld+json">
+    {
+      "@context":"https://schema.org",
+      "@type":"FAQPage",
+      "mainEntity":[
+        {"@type":"Question","name":"Does HubSpot have a free plan?","acceptedAnswer":{"@type":"Answer","text":"Yes. HubSpot's current Customer Platform pricing page lists a $0 free tier for up to two users with no credit card required."}},
+        {"@type":"Question","name":"How much is HubSpot Starter?","acceptedAnswer":{"@type":"Answer","text":"On September 6, 2026, HubSpot's official Customer Platform pricing page displayed a limited-time Starter offer from $7 per seat per month on annual billing, alongside a $20 per seat monthly price. Offers can change, so verify the live checkout."}},
+        {"@type":"Question","name":"When can HighLevel make more sense than HubSpot?","acceptedAnswer":{"@type":"Answer","text":"HighLevel is worth comparing when you run an agency or service business that values client sub-accounts, funnels, booking and automation under one platform. HubSpot is generally stronger when a broader CRM ecosystem, reporting depth and a large integration marketplace are the priority."}}
+      ]
+    }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="/affiliate-attribution.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
+      body { font-family: 'Inter', sans-serif; background-color:#08090d; color:#f1f5f9; }
+      h1,h2,h3 { font-family:'Outfit', sans-serif; }
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
+    <header class="border-b border-white/10 bg-[#0c0e14]/95 backdrop-blur-md sticky top-0 z-50">
+      <div class="max-w-6xl mx-auto px-5 py-4 flex items-center justify-between gap-4">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white">C</div>
+          <span class="font-extrabold tracking-tight text-white">COSHUMA</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/best/crm-for-marketing-agencies.html" class="text-xs font-bold rounded-full border border-purple-500/30 bg-purple-500/10 px-4 py-2 text-purple-200 hover:bg-purple-500/20">Best CRM for Agencies →</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
-          <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=hubspot.com&sz=128" alt="HubSpot logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
-            <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Sales & CRM</span>
+    <main class="max-w-6xl mx-auto px-5 py-10 sm:py-14 w-full space-y-8">
+      <section class="rounded-3xl border border-white/10 bg-[#11131a] p-6 sm:p-9 shadow-2xl">
+        <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-7">
+          <div class="max-w-3xl">
+            <div class="flex items-center gap-4 mb-5">
+              <img src="https://www.google.com/s2/favicons?domain=hubspot.com&sz=128" alt="HubSpot logo" class="h-14 w-14 rounded-2xl border border-white/10 bg-white p-2 object-contain" onError="this.style.display='none'" />
+              <div>
+                <div class="text-xs font-black uppercase tracking-[0.16em] text-orange-300">CRM · Marketing · Sales · Service</div>
+                <h1 class="text-4xl sm:text-5xl font-black tracking-[-0.04em] text-white">HubSpot Pricing & Review</h1>
               </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">HubSpot</h1>
             </div>
+            <p class="text-base sm:text-lg leading-8 text-slate-300">HubSpot is a broad customer platform spanning CRM, marketing, sales, service, content and data tools. Its biggest advantage is ecosystem depth: a business can start free and add more sophisticated automation, reporting and AI features as it grows. The trade-off is that pricing becomes more complex as seats, contacts, credits and higher-tier products enter the stack.</p>
+            <div class="mt-5 inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">Official pricing checked Sep 6, 2026</div>
           </div>
-
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
-        </div>
-
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">A powerful CRM platform offering integrated tools for marketing, sales, customer service, and content management to grow businesses.</p>
-        </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Comprehensive CRM Database</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Marketing Automation</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Sales Pipeline Management</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Customer Service & Support Tools</div>
+          <div class="w-full lg:w-80 rounded-2xl border border-orange-400/20 bg-orange-500/5 p-5 space-y-3">
+            <div class="text-sm font-black text-white">Fast verdict</div>
+            <p class="text-sm leading-6 text-slate-300">Choose HubSpot when you want a mature CRM ecosystem and expect to expand into deeper sales, marketing and reporting workflows. If you run an agency with many client accounts, compare HighLevel before committing to higher HubSpot tiers.</p>
+            <a href="https://www.hubspot.com/pricing/suite" target="_blank" rel="noopener noreferrer" class="block rounded-xl bg-orange-500 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-orange-400">View Official HubSpot Pricing →</a>
           </div>
         </div>
+      </section>
 
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
+      <section class="grid gap-4 md:grid-cols-4">
+        <article class="rounded-2xl border border-white/10 bg-[#11131a] p-5">
+          <div class="text-xs font-black uppercase tracking-widest text-slate-400">Free</div>
+          <div class="mt-2 text-3xl font-black text-white">$0</div>
+          <p class="mt-3 text-sm leading-6 text-slate-400">Free for up to 2 users. No credit card required on the current official pricing page.</p>
+        </article>
+        <article class="rounded-2xl border border-emerald-400/25 bg-emerald-500/5 p-5">
+          <div class="text-xs font-black uppercase tracking-widest text-emerald-300">Starter</div>
+          <div class="mt-2 text-3xl font-black text-white">From $7/seat</div>
+          <p class="mt-3 text-sm leading-6 text-slate-300">Limited-time annual-billing offer shown Sep 6; the page also displays $20/seat on monthly billing.</p>
+        </article>
+        <article class="rounded-2xl border border-purple-400/25 bg-purple-500/5 p-5">
+          <div class="text-xs font-black uppercase tracking-widest text-purple-300">Professional</div>
+          <div class="mt-2 text-3xl font-black text-white">From $1,300/mo</div>
+          <p class="mt-3 text-sm leading-6 text-slate-300">Customer Platform Professional currently includes 6 seats and 5,000 HubSpot Credits.</p>
+        </article>
+        <article class="rounded-2xl border border-blue-400/25 bg-blue-500/5 p-5">
+          <div class="text-xs font-black uppercase tracking-widest text-blue-300">Enterprise</div>
+          <div class="mt-2 text-3xl font-black text-white">From $4,700/mo</div>
+          <p class="mt-3 text-sm leading-6 text-slate-300">Customer Platform Enterprise currently includes 8 seats and 10,000 HubSpot Credits.</p>
+        </article>
+      </section>
 
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to HubSpot</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/privy.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=privy.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Privy</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/reply-io.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=reply.io&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Reply.io</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/omnisend.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=omnisend.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Omnisend</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
-
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+      <section class="rounded-3xl border border-violet-400/30 bg-gradient-to-br from-violet-500/10 to-cyan-500/5 p-6 sm:p-8">
+        <div class="grid gap-7 lg:grid-cols-[1.25fr_.75fr] lg:items-center">
           <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://www.hubspot.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official HubSpot Site</span><span>→</span></a>
-        </div>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of HubSpot?</span>
+            <div class="text-xs font-black uppercase tracking-[0.18em] text-violet-300">Agency buyer checkpoint</div>
+            <h2 class="mt-2 text-3xl font-black text-white">HubSpot vs HighLevel is the comparison agencies should make before paying</h2>
+            <p class="mt-4 text-sm sm:text-base leading-7 text-slate-300">HubSpot can start much cheaper because it has a free tier and low-cost Starter entry. HighLevel starts higher at $97/month, but its agency model is built around client sub-accounts, funnels, calendars and automation. HighLevel's official public page currently lists Starter at $97/month and Unlimited at $297/month, with a 14-day free trial. Agency Pro is positioned for SaaS Mode and rebilling workflows.</p>
+            <div class="mt-5 grid gap-3 sm:grid-cols-2 text-sm">
+              <div class="rounded-xl border border-white/10 bg-black/20 p-4"><strong class="text-white">HubSpot tends to fit:</strong><span class="text-slate-400"> single-company CRM teams, inbound marketing, deeper reporting and large integration ecosystems.</span></div>
+              <div class="rounded-xl border border-violet-400/20 bg-violet-500/10 p-4"><strong class="text-white">HighLevel tends to fit:</strong><span class="text-slate-300"> agencies, local-service operators and businesses managing many client or location workflows.</span></div>
             </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
           </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim HubSpot Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/hubspot.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="HubSpot Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
+          <div class="rounded-2xl border border-violet-400/30 bg-[#0d0f16] p-5 space-y-3">
+            <div class="text-sm font-black text-white">Want the agency-first route?</div>
+            <p class="text-xs leading-6 text-slate-400">COSHUMA's HighLevel button uses a verified partner URL. We may earn a commission if you become a paying customer, at no extra cost to you.</p>
+            <a data-cta="affiliate" data-tool-id="gohighlevel" data-cta-source="hubspot-agency-alternative" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="block rounded-xl bg-violet-600 px-5 py-4 text-center text-sm font-black text-white hover:bg-violet-500">Start the 14-Day HighLevel Trial →</a>
+            <a href="/tool/gohighlevel.html" class="block rounded-xl border border-white/10 px-5 py-3 text-center text-sm font-bold text-slate-300 hover:bg-white/5">Read the HighLevel Buyer Guide</a>
           </div>
         </div>
+      </section>
 
+      <section class="grid gap-5 lg:grid-cols-2">
+        <article class="rounded-3xl border border-white/10 bg-[#11131a] p-6">
+          <h2 class="text-2xl font-black text-white">Where HubSpot is strongest</h2>
+          <div class="mt-4 space-y-3 text-sm leading-6 text-slate-300">
+            <p><strong>Low-friction entry:</strong> the free tier supports basic CRM use without requiring a card, which makes it easy to test before buying.</p>
+            <p><strong>Broad platform:</strong> marketing, sales, service, content and data products can share the same CRM foundation.</p>
+            <p><strong>Reporting and ecosystem:</strong> higher tiers are designed for more structured teams that need deeper governance, automation and integration coverage.</p>
+          </div>
+        </article>
+        <article class="rounded-3xl border border-white/10 bg-[#11131a] p-6">
+          <h2 class="text-2xl font-black text-white">What to calculate before upgrading</h2>
+          <div class="mt-4 space-y-3 text-sm leading-6 text-slate-300">
+            <p><strong>Seat count:</strong> costs rise as more paid users need access.</p>
+            <p><strong>Marketing contacts and credits:</strong> usage and contact volume can materially change total cost beyond a headline seat price.</p>
+            <p><strong>Tier jump:</strong> moving from Starter into Professional or Enterprise is a much larger commitment, so map required features before upgrading.</p>
+          </div>
+        </article>
+      </section>
 
-      </div>
+      <section class="rounded-3xl border border-white/10 bg-[#11131a] p-6 sm:p-8">
+        <div class="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+          <div class="max-w-3xl">
+            <div class="text-xs font-black uppercase tracking-[0.18em] text-cyan-300">Decision guide</div>
+            <h2 class="mt-2 text-3xl font-black text-white">Choose based on operating model, not the cheapest entry price</h2>
+            <p class="mt-4 text-sm leading-7 text-slate-300">HubSpot's free and Starter tiers are compelling for teams that want to enter a broad CRM ecosystem gradually. HighLevel becomes more compelling when your economics depend on client sub-accounts and bundled agency workflows. Pipedrive remains worth considering when you mainly need a focused sales pipeline rather than a full marketing platform.</p>
+          </div>
+          <a href="/best/crm-for-marketing-agencies.html" class="shrink-0 rounded-xl border border-cyan-400/30 bg-cyan-500/10 px-5 py-3.5 text-center text-sm font-black text-cyan-200 hover:bg-cyan-500/15">Compare CRM Options for Agencies →</a>
+        </div>
+      </section>
+
+      <section class="rounded-3xl border border-white/10 bg-[#11131a] p-6 sm:p-8">
+        <h2 class="text-2xl font-black text-white">Sources and verification</h2>
+        <p class="mt-3 text-sm leading-7 text-slate-400">Pricing on this page was checked on September 6, 2026 against HubSpot's official Customer Platform and CRM pricing pages. HighLevel trial and plan figures were checked against HighLevel's official public pricing page. Promotional prices, feature limits, credits, onboarding requirements and billing terms can change, so the vendor checkout remains the final source of truth.</p>
+        <div class="mt-5 flex flex-col sm:flex-row gap-3">
+          <a href="https://www.hubspot.com/pricing/suite" target="_blank" rel="noopener noreferrer" class="rounded-xl border border-white/10 px-5 py-3 text-center text-sm font-bold text-slate-200 hover:bg-white/5">HubSpot Official Pricing →</a>
+          <a href="https://www.hubspot.com/pricing/crm" target="_blank" rel="noopener noreferrer" class="rounded-xl border border-white/10 px-5 py-3 text-center text-sm font-bold text-slate-200 hover:bg-white/5">HubSpot Free CRM Details →</a>
+        </div>
+      </section>
+
+      <section class="rounded-3xl border border-purple-500/20 bg-purple-500/5 p-6 sm:p-8">
+        <div class="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <h2 class="text-xl font-black text-white">Vendor or agency working with HubSpot?</h2>
+            <p class="mt-2 text-sm text-slate-400">COSHUMA keeps editorial content independent while offering a separate profile-claim route for vendors that want to maintain company details.</p>
+          </div>
+          <a href="/#submit" class="shrink-0 rounded-xl bg-purple-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-purple-500">Claim HubSpot Profile ($49/yr) →</a>
+        </div>
+      </section>
     </main>
 
-    <!-- Footer -->
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+    <footer class="border-t border-white/10 bg-[#07080c] py-8 text-center text-xs text-slate-500">
+      <div class="max-w-6xl mx-auto px-4">© 2026 COSHUMA. Independent AI & SaaS buyer guides.</div>
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
## Why
HubSpot is an existing non-monetized tool page while HighLevel has a verified revenue URL. This refresh converts HubSpot search traffic into a clearer agency decision path without pretending HubSpot itself is monetized.

## What changed
- Rebuilt the weak generic HubSpot page into a current 2026 buyer guide.
- Added official HubSpot Free/Starter/Professional/Enterprise pricing context checked against vendor pages on Sep 6, 2026.
- Replaced old GlobalSaaSHub branding with COSHUMA.
- Added a clearly disclosed HighLevel agency-alternative CTA using the existing verified partner URL.
- Added affiliate attribution to the HighLevel CTA.
- Preserved the direct-revenue vendor profile claim route.
- Added FAQ/WebPage structured data and stronger internal links to the agency CRM guide and HighLevel buyer guide.

## Safety
- HubSpot remains an official non-affiliate route; no rejected HubSpot affiliate link was added.
- HighLevel CTA uses the already verified customer-facing referral URL.
- No paid services or new subscriptions were introduced.