### PR TITLE
Optimize Beefree search traffic for RGE Studio rebrand and AWeber revenue

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/beefree.html
+++ b/projects/GlobalSaaSHub/public/tool/beefree.html
@@ -1,179 +1,151 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Beefree Pricing, Features & Alternatives (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Compare Beefree pricing, features, email-design workflow, and alternatives. See official Beefree details and compare AWeber as a full email-marketing alternative." />
-    <link rel="canonical" href="https://coshuma.com/tool/beefree.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://coshuma.com/tool/beefree.html" />
-    <meta property="og:title" content="Beefree Pricing, Features & Alternatives (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Review Beefree for email and landing-page design, then compare alternatives including AWeber for broader email-marketing workflows." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Beefree Is Now RGE Studio: Pricing, Trial & Alternatives (2026) | COSHUMA</title>
+  <meta name="description" content="Beefree is now RGE Studio. See current 2026 pricing, the 15-day no-card Professional trial, what the product is best for, and when AWeber is the better email-marketing stack." />
+  <link rel="canonical" href="https://coshuma.com/tool/beefree.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://coshuma.com/tool/beefree.html" />
+  <meta property="og:title" content="Beefree Is Now RGE Studio: Pricing, Trial & Alternatives (2026) | COSHUMA" />
+  <meta property="og:description" content="Current Beefree/RGE Studio pricing and a practical email-design vs email-marketing buying guide." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"SoftwareApplication",
+    "name":"RGE Studio",
+    "alternateName":"Beefree",
+    "applicationCategory":"DesignApplication",
+    "operatingSystem":"Web",
+    "url":"https://beefree.io/",
+    "description":"RGE Studio, formerly Beefree App, is an email and landing-page design suite for creating, collaborating on, exporting and hosting responsive designs."
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"Is Beefree still called Beefree?","acceptedAnswer":{"@type":"Answer","text":"Beefree App was renamed RGE Studio in 2026. The product remains an email and landing-page design suite, while some official pages may still use the Beefree name during the transition."}},
+      {"@type":"Question","name":"How much does RGE Studio, formerly Beefree, cost?","acceptedAnswer":{"@type":"Answer","text":"Official product help currently lists Starter as free, Professional from $30 per month or $300 per year, Business from $160 per month or $1,600 per year, and Enterprise as custom pricing."}},
+      {"@type":"Question","name":"Does RGE Studio have a free trial?","acceptedAnswer":{"@type":"Answer","text":"Official product help says the Professional plan can be tried for 15 days without providing credit-card information."}},
+      {"@type":"Question","name":"Is AWeber a direct replacement for RGE Studio?","acceptedAnswer":{"@type":"Answer","text":"Not exactly. RGE Studio is primarily an email and landing-page design workflow, while AWeber is a broader email-marketing platform for subscriber management, sending, automations and landing pages. Choose based on whether design production or campaign delivery is the main job."}}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen bg-[#0b0c10]">
+<header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50">
+  <div class="max-w-6xl mx-auto px-5 py-4 flex items-center justify-between">
+    <a href="/" class="font-black text-white tracking-tight text-lg">COSHUMA</a>
+    <a href="/compare/beefree-vs-aweber.html" class="text-xs font-bold px-4 py-2 rounded-full border border-fuchsia-500/30 bg-fuchsia-500/10 text-fuchsia-300">Beefree vs AWeber</a>
+  </div>
+</header>
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "Beefree",
-      "operatingSystem": "Web",
-      "applicationCategory": "Email & Outreach",
-      "description": "Beefree is a drag-and-drop editor for creating beautiful, responsive emails and landing pages quickly and without coding, ideal for marketers and designers."
-    }
-    </script>
-
-    <!-- Tailwind & Fonts -->
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+<main class="max-w-5xl mx-auto px-5 py-12 space-y-8">
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-10 shadow-2xl">
+    <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-8">
+      <div class="max-w-2xl">
+        <div class="text-xs font-extrabold uppercase tracking-[0.18em] text-fuchsia-300">Verified Sep 6, 2026</div>
+        <h1 class="text-4xl md:text-5xl font-black tracking-tight mt-3">Looking for Beefree? The app is now RGE Studio.</h1>
+        <p class="text-slate-300 mt-5 leading-relaxed">Beefree App was renamed <strong class="text-white">RGE Studio</strong> in 2026. The core job is still fast, code-free email and landing-page design, collaboration, export and hosting. If your actual goal is subscriber management, newsletters and automated campaigns, compare a full email-marketing platform such as AWeber instead of treating the two products as identical.</p>
+        <div class="flex flex-col sm:flex-row gap-3 mt-7">
+          <a data-cta="official" href="https://beefree.io/plans-pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-slate-800 border border-slate-600 text-white font-extrabold text-center">Check RGE Studio pricing →</a>
+          <a data-cta="affiliate" data-tool-id="aweber" data-cta-source="beefree_hero_email_marketing_alternative" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-fuchsia-600 hover:bg-fuchsia-500 text-white font-extrabold text-center">Compare AWeber for sending & automation →</a>
+        </div>
+        <p class="text-[11px] text-slate-500 mt-3">Affiliate disclosure: COSHUMA may earn a commission if you sign up for AWeber through the partner link. RGE Studio/Beefree links on this page are standard official links because COSHUMA does not currently publish a verified RGE Studio customer referral URL.</p>
       </div>
-    </header>
-
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
-          <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=beefree.io&sz=128" alt="Beefree logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
-            <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Email & Outreach</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Beefree</h1>
-            </div>
-          </div>
-
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
-        </div>
-
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">Beefree is a drag-and-drop editor for creating beautiful, responsive emails and landing pages quickly and without coding, ideal for marketers and designers.</p>
-        </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Drag-and-drop editor</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Responsive email design</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Landing page creation</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> No coding required</div>
-          </div>
-        </div>
-
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Beefree</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/convertkit.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=kit.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Kit (formerly ConvertKit)</span></div><span class="text-[10px] font-extrabold text-emerald-400">Free plan; Creator plan from $33/month for 1,000 subscribers</span></a>
-<a href="/tool/aweber.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=aweber.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">AWeber</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/moosend.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=moosend.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Moosend</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
-
-        <!-- Revenue-aware comparison path -->
-        <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/20 space-y-3">
-          <h3 class="text-base font-bold text-white">Need email marketing beyond design?</h3>
-          <p class="text-sm text-slate-300 leading-relaxed">Beefree is centered on creating email and landing-page content. If you also need subscriber management, campaigns, and automation, compare AWeber before choosing your workflow.</p>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <a href="/compare/beefree-vs-aweber.html" class="px-5 py-3 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Compare Beefree vs AWeber →</a>
-            <a data-cta="affiliate" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center hover:brightness-110 transition-all">Try AWeber via Verified Affiliate Link →</a>
-          </div>
-          <p class="text-[11px] text-slate-500">Affiliate disclosure: GlobalSaaSHub may earn a commission if you purchase through the AWeber link, at no extra cost to you.</p>
-        </div>
-
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://beefree.io/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Beefree Site</span><span>→</span></a>
-        </div>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Beefree?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Beefree Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/beefree.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Beefree Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
+      <div class="min-w-[250px] p-5 rounded-2xl border border-emerald-500/20 bg-emerald-500/5">
+        <div class="text-xs uppercase tracking-wider font-bold text-emerald-300">Fast decision</div>
+        <p class="text-sm text-slate-300 mt-2"><strong class="text-white">Choose RGE Studio</strong> when the main job is designing, reviewing and exporting polished emails or landing pages.</p>
+        <p class="text-sm text-slate-300 mt-3"><strong class="text-white">Compare AWeber</strong> when the main job is building a subscriber list, sending campaigns and running automations from one platform.</p>
       </div>
-    </main>
+    </div>
+  </section>
 
-    <!-- Footer -->
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-9">
+    <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-3">
+      <div>
+        <h2 class="text-2xl font-black">Current RGE Studio pricing snapshot</h2>
+        <p class="text-sm text-slate-400 mt-2">Official RGE Studio help-center pricing checked Sep 6, 2026. Final checkout pricing can change, so verify before purchase.</p>
       </div>
-    </footer>
-  </body>
+      <a href="https://beefree.io/plans-pricing" target="_blank" rel="noopener noreferrer" class="text-sm font-bold text-fuchsia-300">Verify live pricing ↗</a>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-6">
+      <div class="rounded-2xl bg-[#181a29] border border-[#2a2d42] p-5"><div class="text-xs font-bold text-slate-400">Starter</div><div class="text-3xl font-black mt-2">Free</div><div class="text-xs text-slate-500">no-cost entry plan</div><p class="text-sm text-slate-300 mt-4">Create, edit, organize and export emails/pages with limits.</p></div>
+      <div class="rounded-2xl bg-[#181a29] border border-fuchsia-500/40 p-5"><div class="text-xs font-bold text-fuchsia-300">Professional</div><div class="text-3xl font-black mt-2">$30</div><div class="text-xs text-slate-500">per month, or $300/year</div><p class="text-sm text-slate-300 mt-4">Adds stronger collaboration, user management, folders and workspace controls.</p></div>
+      <div class="rounded-2xl bg-[#181a29] border border-[#2a2d42] p-5"><div class="text-xs font-bold text-slate-400">Business</div><div class="text-3xl font-black mt-2">$160</div><div class="text-xs text-slate-500">per month, or $1,600/year</div><p class="text-sm text-slate-300 mt-4">Adds workspace management, co-editing and more team-scale collaboration.</p></div>
+      <div class="rounded-2xl bg-[#181a29] border border-[#2a2d42] p-5"><div class="text-xs font-bold text-slate-400">Enterprise</div><div class="text-2xl font-black mt-2">Custom</div><div class="text-xs text-slate-500">contact sales</div><p class="text-sm text-slate-300 mt-4">Customized capacity and controls for complex organizations.</p></div>
+    </div>
+    <div class="mt-5 p-4 rounded-xl bg-emerald-500/5 border border-emerald-500/20 text-sm text-slate-300"><strong class="text-white">Trial note:</strong> RGE Studio's official help center says the Professional plan can be tried for 15 days without a credit card.</div>
+  </section>
+
+  <section class="grid grid-cols-1 lg:grid-cols-2 gap-5">
+    <div class="rounded-3xl border border-[#222538] bg-[#131520] p-7">
+      <div class="text-xs uppercase tracking-[0.16em] font-bold text-cyan-300">Design-first workflow</div>
+      <h2 class="text-2xl font-black mt-2">RGE Studio is the cleaner fit when…</h2>
+      <ul class="mt-5 space-y-3 text-sm text-slate-300">
+        <li>✓ Your team mainly needs to create responsive email and page designs quickly.</li>
+        <li>✓ Approval, commenting, co-editing or reusable design systems matter.</li>
+        <li>✓ You already have a sending platform and want a stronger design layer.</li>
+        <li>✓ Exporting HTML/ZIP or connecting finished designs into another platform is part of the workflow.</li>
+      </ul>
+      <a data-cta="official" href="https://beefree.io/plans-pricing" target="_blank" rel="noopener noreferrer" class="mt-6 block px-5 py-3 rounded-xl bg-slate-800 border border-slate-600 text-center font-extrabold">Start from official RGE Studio pricing →</a>
+    </div>
+    <div class="rounded-3xl border border-fuchsia-500/35 bg-fuchsia-500/5 p-7">
+      <div class="text-xs uppercase tracking-[0.16em] font-bold text-fuchsia-300">Verified revenue alternative</div>
+      <h2 class="text-2xl font-black mt-2">AWeber is worth comparing when…</h2>
+      <ul class="mt-5 space-y-3 text-sm text-slate-300">
+        <li>✓ You need subscriber management, broadcasts and automated email sequences.</li>
+        <li>✓ Landing pages, signup forms and campaign delivery should live in one account.</li>
+        <li>✓ You want a small-business email platform rather than a standalone design-production layer.</li>
+        <li>✓ Your buying decision depends on list size and monthly send capacity.</li>
+      </ul>
+      <div class="mt-5 text-xs text-slate-400">AWeber's current official pricing documentation lists a Free plan up to 500 subscribers, Lite from $15/month or $150/year, Plus from $30/month or $240/year, and Unlimited at $899/month. Its live pricing page also advertises a 14-day trial. Pricing scales with subscriber count.</div>
+      <a data-cta="affiliate" data-tool-id="aweber" data-cta-source="beefree_decision_email_marketing_alternative" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="mt-6 block px-5 py-3.5 rounded-xl bg-fuchsia-600 hover:bg-fuchsia-500 text-center font-extrabold">Try AWeber via verified COSHUMA link →</a>
+    </div>
+  </section>
+
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-9">
+    <h2 class="text-2xl font-black">RGE Studio vs AWeber: what are you actually buying?</h2>
+    <div class="overflow-x-auto mt-5">
+      <table class="w-full text-sm text-left">
+        <thead class="text-slate-400 border-b border-[#2a2d42]"><tr><th class="py-3 pr-4">Decision factor</th><th class="py-3 pr-4">RGE Studio (formerly Beefree)</th><th class="py-3">AWeber</th></tr></thead>
+        <tbody class="text-slate-300 divide-y divide-[#202334]">
+          <tr><td class="py-4 pr-4 font-bold text-white">Core job</td><td class="py-4 pr-4">Email/page design and collaboration</td><td class="py-4">Email marketing, list management and automation</td></tr>
+          <tr><td class="py-4 pr-4 font-bold text-white">Free entry</td><td class="py-4 pr-4">Starter plan is free</td><td class="py-4">Free plan available up to 500 subscribers in current documentation</td></tr>
+          <tr><td class="py-4 pr-4 font-bold text-white">Paid entry</td><td class="py-4 pr-4">Professional from $30/month</td><td class="py-4">Lite from $15/month; pricing scales by subscriber count</td></tr>
+          <tr><td class="py-4 pr-4 font-bold text-white">Best fit</td><td class="py-4 pr-4">Teams producing polished designs for multiple destinations</td><td class="py-4">Creators and small businesses that need to send and automate campaigns</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <a href="/compare/beefree-vs-aweber.html" class="mt-6 inline-flex text-sm font-bold text-fuchsia-300">Read the dedicated Beefree vs AWeber comparison →</a>
+  </section>
+
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-9">
+    <h2 class="text-2xl font-black">A monetization note COSHUMA is not hiding</h2>
+    <p class="text-slate-300 mt-4 leading-relaxed">RGE Studio currently runs an official Ambassador program that advertises 20% of first-year customer revenue and a 90-day referral cookie. COSHUMA has <strong class="text-white">not</strong> published an RGE Studio affiliate CTA here because we have not yet verified an account-specific customer referral URL. Until that exact tracking link is confirmed, all RGE Studio links remain ordinary official links.</p>
+  </section>
+
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-9">
+    <h2 class="text-2xl font-black">Bottom line</h2>
+    <p class="text-slate-300 mt-4 leading-relaxed">If you searched for Beefree because you need a fast drag-and-drop design workflow, evaluate RGE Studio first—the product name changed, but the design use case remains. If your real goal is to build a list, send newsletters and automate subscriber journeys, compare AWeber instead of buying a design tool and then discovering you still need a sending platform.</p>
+    <div class="flex flex-col sm:flex-row gap-3 mt-6">
+      <a data-cta="official" href="https://beefree.io/plans-pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-slate-800 border border-slate-600 text-center font-extrabold">RGE Studio official pricing</a>
+      <a data-cta="affiliate" data-tool-id="aweber" data-cta-source="beefree_bottom_email_marketing_alternative" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-fuchsia-600 text-center font-extrabold">AWeber verified partner link →</a>
+    </div>
+  </section>
+
+  <p class="text-xs text-slate-500 leading-relaxed">Source check: RGE Studio official help center and Ambassador program, plus AWeber official pricing documentation, rechecked Sep 6, 2026. COSHUMA keeps vendor-official links separate from verified revenue links and does not construct unverified tracking parameters.</p>
+</main>
+
+<footer class="border-t border-[#222538] mt-12"><div class="max-w-5xl mx-auto px-5 py-8 text-xs text-slate-500">© 2026 COSHUMA · Independent SaaS buyer guidance</div></footer>
+<script src="/affiliate-attribution.js" defer></script>
+</body>
 </html>
-


### PR DESCRIPTION
Revenue-focused zero-cost update for an existing Search Console opportunity.

Evidence rechecked Sep 6, 2026:
- COSHUMA's stored Search Console snapshot lists `beefree` with 36 impressions and 0 clicks.
- RGE Studio's official help center confirms Beefree App was renamed RGE Studio in 2026, with Starter free, Professional from $30/month or $300/year, Business from $160/month or $1,600/year, Enterprise custom, and a 15-day Professional trial without a card.
- RGE Studio's official Ambassador page is live again and advertises 20% of first-year revenue with a 90-day cookie, but COSHUMA still has no verified account-specific RGE Studio referral URL, so no RGE affiliate CTA is published.
- AWeber's existing customer-facing partner URL remains verified in repository data: `https://www.aweber.com/easy-email.htm?id=561868`.

Changes:
- replace stale GlobalSaaSHub branding with COSHUMA
- preserve the high-intent `Beefree` query while explaining the RGE Studio rename immediately
- refresh current pricing/trial information from official sources
- distinguish design-production intent from full email-marketing intent
- add three source-tagged AWeber revenue CTAs using only the verified link
- add FAQ/SoftwareApplication structured data and a direct internal link to the Beefree-vs-AWeber comparison
- explicitly disclose that RGE Studio links are non-affiliate until an exact customer referral link is verified

No paid service, guessed tracking parameter, duplicate affiliate application, or generic dashboard/onboarding URL is introduced.