### PR TITLE
Improve Descript proven-click conversion and COSHUMA trust

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/descript.html
+++ b/projects/GlobalSaaSHub/public/tool/descript.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Descript Pricing, Free Plan & AI Video Editor Review (2026) | GlobalSaaSHub</title>
-  <meta name="description" content="Compare Descript's free plan, Hobbyist and Creator pricing, AI video editing features, transcription, Studio Sound, Underlord and best-fit use cases. Start free through the verified Descript partner link." />
+  <title>Descript Pricing, Free Plan & AI Video Editor Review (2026) | COSHUMA</title>
+  <meta name="description" content="Compare Descript Free, Hobbyist, Creator and Business pricing, AI credits, media hours and export limits. Start free through COSHUMA's verified Descript partner link." />
   <link rel="canonical" href="https://coshuma.com/tool/descript.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://coshuma.com/tool/descript.html" />
-  <meta property="og:title" content="Descript Pricing, Free Plan & AI Video Editor Review (2026)" />
-  <meta property="og:description" content="Descript pricing and buyer guide for text-based video editing, transcription, Studio Sound, clips and AI-assisted editing." />
+  <meta property="og:title" content="Descript Pricing, Free Plan & AI Video Editor Review (2026) | COSHUMA" />
+  <meta property="og:description" content="A current Descript buyer guide for text-based video editing, transcription, Underlord, Studio Sound and plan selection." />
   <script type="application/ld+json">
   {
     "@context":"https://schema.org",
@@ -21,78 +21,99 @@
     "offers":{"@type":"Offer","price":"0","priceCurrency":"USD","description":"Free plan available"}
   }
   </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"Does Descript have a free plan?","acceptedAnswer":{"@type":"Answer","text":"Yes. Descript currently offers a Free plan with 1 media hour per month, 100 AI credits per month and 720p watermark-free export. Descript says no credit card is required to try the Free plan."}},
+      {"@type":"Question","name":"How much does Descript cost in 2026?","acceptedAnswer":{"@type":"Answer","text":"Descript currently lists Hobbyist at $16 per person per month on annual billing or $24 monthly, Creator at $24 annual or $35 monthly, and Business at $50 annual or $65 monthly. Live checkout is the final source of pricing."}},
+      {"@type":"Question","name":"Which Descript plan is best for creators?","acceptedAnswer":{"@type":"Answer","text":"Free is best for testing the workflow, Hobbyist fits lighter 1080p solo work, Creator adds 4K export and more AI capacity, and Business is aimed at teams needing more media hours, AI credits and collaboration features."}}
+    ]
+  }
+  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <script defer src="/affiliate-attribution.js"></script>
-  <style>
-    body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}
-  </style>
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
 </head>
 <body class="min-h-screen flex flex-col justify-between">
 <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
   <div class="max-w-6xl mx-auto flex items-center justify-between">
-    <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div><span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span></a>
+    <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div><span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span></a>
     <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
   </div>
 </header>
-<main class="max-w-4xl mx-auto px-4 py-12 w-full">
+<main class="max-w-5xl mx-auto px-4 py-12 w-full">
   <div class="p-6 md:p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
     <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
       <div class="flex items-center gap-5">
         <img src="https://www.google.com/s2/favicons?domain=descript.com&sz=128" alt="Descript logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" />
         <div><div class="inline-flex items-center px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">AI Video & Audio Editing</div><h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Descript Pricing & Free Plan</h1></div>
       </div>
-      <div class="bg-emerald-500/10 border border-emerald-500/20 text-emerald-300 px-4 py-2 rounded-xl text-sm font-bold">Free plan available</div>
+      <div class="bg-emerald-500/10 border border-emerald-500/20 text-emerald-300 px-4 py-2 rounded-xl text-sm font-bold">Free plan · no card required</div>
     </div>
 
     <section class="space-y-4">
-      <h2 class="text-xl font-bold text-white">Best for creators who want to edit video by editing text</h2>
-      <p class="text-slate-300 leading-relaxed">Descript turns recorded audio and video into editable text, so deleting words can edit the underlying media. It combines transcription, screen recording, captions, audio cleanup, short-form clip creation and AI-assisted editing in one workflow.</p>
-      <div class="p-4 rounded-2xl bg-amber-500/5 border border-amber-500/20 text-sm text-slate-300"><strong class="text-amber-300">Affiliate disclosure:</strong> GlobalSaaSHub may earn a commission if you sign up through the verified Descript partner link below, at no additional cost to you.</div>
+      <h2 class="text-xl font-bold text-white">Fast answer: who should choose Descript?</h2>
+      <p class="text-slate-300 leading-relaxed">Descript is strongest for creators and teams that want to edit video and audio by editing the transcript. It combines recording, transcription, captions, Studio Sound, filler-word removal, short-form clips and the Underlord AI co-editor in one workflow.</p>
+      <div class="p-4 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 text-sm text-slate-300"><strong class="text-emerald-300">Low-risk starting point:</strong> Descript's current Free plan includes 1 media hour and 100 AI credits per month, plus 720p watermark-free export, and Descript says no credit card is required.</div>
+      <div class="p-4 rounded-2xl bg-amber-500/5 border border-amber-500/20 text-sm text-slate-300"><strong class="text-amber-300">Affiliate disclosure:</strong> COSHUMA may earn a commission if you sign up through the verified Descript partner link below, at no additional cost to you.</div>
       <div class="grid sm:grid-cols-2 gap-3">
-        <a data-cta="affiliate" data-tool-id="descript" href="https://get.descript.com/ole5fu20j5sq" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold text-center bg-gradient-to-r from-purple-600 to-indigo-600 text-white shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start Descript Free →</a>
-        <a data-cta="official" href="https://www.descript.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold text-center bg-slate-800 border border-slate-600 hover:bg-slate-700">Visit Descript Official Site</a>
+        <a data-cta="affiliate" data-tool-id="descript" data-cta-source="descript-hero" href="https://get.descript.com/ole5fu20j5sq" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold text-center bg-gradient-to-r from-purple-600 to-indigo-600 text-white shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start Descript Free →</a>
+        <a data-cta="official" href="https://www.descript.com/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold text-center bg-slate-800 border border-slate-600 hover:bg-slate-700">Verify Official Pricing</a>
       </div>
-      <p class="text-xs text-slate-500 text-center">Descript states that its Free plan does not require a credit card. Confirm current plan limits and checkout pricing on Descript before purchasing.</p>
     </section>
 
     <section class="space-y-4 pt-2 border-t border-[#222538]">
-      <h2 class="text-xl font-bold text-white">Current public pricing signals</h2>
-      <div class="grid sm:grid-cols-3 gap-3">
-        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-sm font-bold text-white">Free</div><div class="text-2xl font-black text-emerald-400 mt-1">$0</div><p class="text-xs text-slate-400 mt-2">1 media hour/month, 100 AI credits/month, 720p watermark-free export, limited Underlord and AI tools.</p></div>
-        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-sm font-bold text-white">Hobbyist</div><div class="text-2xl font-black text-emerald-400 mt-1">$16–$24</div><p class="text-xs text-slate-400 mt-2">Per person/month depending on annual vs monthly billing. 10 media hours, 400 AI credits and 1080p watermark-free export.</p></div>
-        <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30"><div class="text-sm font-bold text-white">Creator</div><div class="text-2xl font-black text-emerald-400 mt-1">$24–$35</div><p class="text-xs text-slate-400 mt-2">Per person/month depending on annual vs monthly billing. 30 media hours, 800 AI credits and 4K watermark-free export.</p></div>
+      <h2 class="text-xl font-bold text-white">Descript pricing in 2026</h2>
+      <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-3">
+        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-sm font-bold text-white">Free</div><div class="text-2xl font-black text-emerald-400 mt-1">$0</div><p class="text-xs text-slate-400 mt-2">1 media hour/month · 100 AI credits · 720p watermark-free export · limited Underlord and AI tools.</p></div>
+        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-sm font-bold text-white">Hobbyist</div><div class="text-2xl font-black text-emerald-400 mt-1">$16 / $24</div><p class="text-xs text-slate-400 mt-2">Annual / monthly rate per person · 10 media hours · 400 AI credits · 1080p export.</p></div>
+        <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30"><div class="text-sm font-bold text-white">Creator</div><div class="text-2xl font-black text-emerald-400 mt-1">$24 / $35</div><p class="text-xs text-slate-400 mt-2">Annual / monthly rate per person · 30 media hours · 800 AI credits · 4K export · broader AI tools.</p></div>
+        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-sm font-bold text-white">Business</div><div class="text-2xl font-black text-emerald-400 mt-1">$50 / $65</div><p class="text-xs text-slate-400 mt-2">Annual / monthly rate per person · 40 media hours · 1,500 AI credits · team Brand Studio and advanced support.</p></div>
       </div>
-      <p class="text-xs text-slate-500">Pricing checked against current Descript public pages on September 1, 2026. Descript also has older public pricing pages with legacy plan names and amounts, so the live checkout should be treated as final.</p>
-    </section>
-
-    <section class="space-y-4 pt-2 border-t border-[#222538]">
-      <h2 class="text-xl font-bold text-white">What you get</h2>
-      <div class="grid sm:grid-cols-2 gap-3 text-sm text-slate-200">
-        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Text-based video and audio editing</div>
-        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Automatic transcription</div>
-        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Underlord AI co-editor</div>
-        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Studio Sound noise and echo cleanup</div>
-        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Remove filler words and retakes</div>
-        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Create social clips and captions</div>
-        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Eye Contact and AI speech tools</div>
-        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Screen and remote recording workflows</div>
-      </div>
+      <p class="text-xs text-slate-500">Pricing and plan limits rechecked against Descript's official pricing page on September 7, 2026. Descript can change prices or inclusions; live checkout is final.</p>
     </section>
 
     <section class="space-y-4 pt-2 border-t border-[#222538]">
       <h2 class="text-xl font-bold text-white">Which plan fits?</h2>
-      <div class="space-y-3 text-sm text-slate-300">
-        <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">Try Free first</strong> if you want to test the text-based editing workflow, transcription and basic AI tools before paying.</div>
-        <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">Choose Hobbyist</strong> if 1080p output and 10 monthly media hours are enough for a solo creator workflow.</div>
-        <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">Choose Creator</strong> if you need 4K export, more media hours, more AI credits and broader AI creation tools.</div>
+      <div class="grid md:grid-cols-2 gap-3 text-sm text-slate-300">
+        <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">Free</strong><br>Best for checking whether transcript-based editing actually saves you time before paying.</div>
+        <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">Hobbyist</strong><br>Good for solo creators who mainly need 1080p output and moderate monthly editing volume.</div>
+        <div class="p-4 rounded-xl bg-[#181a29] border border-purple-500/30"><strong class="text-white">Creator</strong><br>Best general upgrade for 4K export, more media hours, more AI credits and deeper AI creation tools.</div>
+        <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">Business</strong><br>Better for teams that need more capacity, Brand Studio, translation/dubbing workflows and stronger support.</div>
+      </div>
+      <div class="text-center pt-2"><a data-cta="affiliate" data-tool-id="descript" data-cta-source="descript-plan-fit" href="https://get.descript.com/ole5fu20j5sq" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-3.5 rounded-xl font-extrabold bg-purple-600 hover:bg-purple-500 text-white">Try the Free plan before choosing a tier →</a></div>
+    </section>
+
+    <section class="space-y-4 pt-2 border-t border-[#222538]">
+      <h2 class="text-xl font-bold text-white">What buyers get</h2>
+      <div class="grid sm:grid-cols-2 gap-3 text-sm text-slate-200">
+        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Edit audio and video by editing text</div>
+        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Automatic transcription and captions</div>
+        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Underlord AI co-editor</div>
+        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Studio Sound noise and echo cleanup</div>
+        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Filler-word and retake cleanup</div>
+        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Create social clips and captions</div>
+        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Eye Contact and AI speech tools</div>
+        <div class="p-3 rounded-xl bg-[#181a29] border border-[#222538]">✓ Recording and collaboration workflows</div>
       </div>
     </section>
 
     <section class="space-y-4 pt-2 border-t border-[#222538]">
-      <h2 class="text-xl font-bold text-white">Related alternatives</h2>
+      <h2 class="text-xl font-bold text-white">Quick FAQ</h2>
+      <div class="space-y-3 text-sm text-slate-300">
+        <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">Do I need a credit card to test Descript?</strong><p class="mt-1">No. Descript's official pricing FAQ says the Free plan can be tried without entering a credit card.</p></div>
+        <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">Is annual billing cheaper?</strong><p class="mt-1">Yes. Descript currently shows lower per-person monthly rates when billed annually for Hobbyist, Creator and Business.</p></div>
+        <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">What is the main reason to upgrade from Free?</strong><p class="mt-1">Paid tiers increase monthly media hours, AI credits and export capability. Creator and Business also unlock more advanced creation and team features.</p></div>
+      </div>
+    </section>
+
+    <section class="space-y-4 pt-2 border-t border-[#222538]">
+      <h2 class="text-xl font-bold text-white">Related buyer guides</h2>
       <div class="grid sm:grid-cols-3 gap-3">
         <a href="/tool/pictory.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40"><div class="font-bold text-white">Pictory</div><div class="text-xs text-slate-400 mt-1">AI video creation and repurposing</div></a>
         <a href="/tool/castmagic.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40"><div class="font-bold text-white">Castmagic</div><div class="text-xs text-slate-400 mt-1">Audio/video content repurposing</div></a>
@@ -102,8 +123,8 @@
 
     <section class="p-6 rounded-2xl bg-purple-500/5 border border-purple-500/25 text-center space-y-3">
       <h2 class="text-xl font-black text-white">Ready to test Descript?</h2>
-      <p class="text-sm text-slate-300">The free plan is the lowest-risk way to see whether text-based editing saves you time before choosing a paid tier.</p>
-      <a data-cta="affiliate" data-tool-id="descript" href="https://get.descript.com/ole5fu20j5sq" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-4 rounded-xl font-extrabold bg-gradient-to-r from-purple-600 to-indigo-600 text-white hover:brightness-110">Start Descript Free via Verified Partner Link →</a>
+      <p class="text-sm text-slate-300">The Free plan is the lowest-risk way to see whether text-based editing fits your workflow before choosing a paid tier.</p>
+      <a data-cta="affiliate" data-tool-id="descript" data-cta-source="descript-bottom" href="https://get.descript.com/ole5fu20j5sq" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-4 rounded-xl font-extrabold bg-gradient-to-r from-purple-600 to-indigo-600 text-white hover:brightness-110">Start Descript Free via Verified Partner Link →</a>
     </section>
 
     <section class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
@@ -114,6 +135,6 @@
     </section>
   </div>
 </main>
-<footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div></footer>
+<footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Global AI SaaS Decision Platform. All rights reserved.</div></footer>
 </body>
 </html>


### PR DESCRIPTION
Revenue-first, zero-cost CRO refresh for a partner path that has already produced verified affiliate clicks.

Evidence rechecked Sep 7, 2026:
- Descript's affiliate team previously confirmed the exact customer-facing referral URL `https://get.descript.com/ole5fu20j5sq` and confirmed it had already earned clicks.
- Descript's official pricing page currently lists Free at $0, Hobbyist at $16 annual / $24 monthly, Creator at $24 / $35, and Business at $50 / $65 per person/month; Free includes 1 media hour, 100 AI credits and 720p watermark-free export with no card required.

Changes:
- replace remaining GlobalSaaSHub user-facing branding with COSHUMA on the Descript money page
- add distinct hero / plan-fit / bottom CTA-source attribution while preserving the exact verified referral URL
- add a mid-page low-risk Free-plan CTA to reduce buyer drop-off
- add the current Business tier and refresh the pricing verification date
- add buyer-focused FAQ copy plus FAQ structured data
- keep the official pricing link separate from the sponsored partner CTA

No paid service, new subscription, guessed tracking parameter, or unsupported conversion claim is introduced.