### PR TITLE
Turn SaneBox comparison traffic into verified AWeber revenue

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/sanebox-vs-aweber.html
+++ b/projects/GlobalSaaSHub/public/compare/sanebox-vs-aweber.html
@@ -3,170 +3,193 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Sanebox vs AWeber Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Sanebox vs AWeber. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
-
+    <title>SaneBox vs AWeber: Inbox AI or Email Marketing? (2026) | COSHUMA</title>
+    <meta name="description" content="SaneBox vs AWeber for 2026: compare inbox cleanup with email marketing, current pricing, free trials, and which tool fits your workflow." />
     <link rel="canonical" href="https://coshuma.com/compare/sanebox-vs-aweber.html" />
+
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/compare/sanebox-vs-aweber.html" />
-    <meta property="og:title" content="Sanebox vs AWeber Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Sanebox and AWeber by pricing, features, and verified public information." />
+    <meta property="og:title" content="SaneBox vs AWeber: Inbox AI or Email Marketing? (2026) | COSHUMA" />
+    <meta property="og:description" content="Choose SaneBox for inbox organization or AWeber for newsletters, automations and subscriber growth. Current 2026 buyer guide." />
 
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebPage",
-      "name": "Sanebox vs AWeber Comparison",
+      "name": "SaneBox vs AWeber: Inbox AI or Email Marketing?",
       "url": "https://coshuma.com/compare/sanebox-vs-aweber.html",
-      "description": "Compare Sanebox and AWeber by pricing, features, and verified public information.",
+      "description": "A 2026 buyer comparison of SaneBox and AWeber, including current public pricing, trial information and workflow fit.",
       "isPartOf": {
         "@type": "WebSite",
-        "name": "GlobalSaaSHub",
+        "name": "COSHUMA",
         "url": "https://coshuma.com/"
       },
       "about": [
-        {"@type": "SoftwareApplication", "name": "Sanebox", "url": "https://coshuma.com/tool/sanebox.html"},
+        {"@type": "SoftwareApplication", "name": "SaneBox", "url": "https://coshuma.com/tool/sanebox.html"},
         {"@type": "SoftwareApplication", "name": "AWeber", "url": "https://coshuma.com/tool/aweber.html"}
       ]
     }
     </script>
-    
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "Is SaneBox or AWeber better for email?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "They solve different problems. SaneBox organizes an existing inbox and reduces clutter. AWeber is built for email marketing, subscriber lists, newsletters, landing pages and automations."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How much does SaneBox cost in 2026?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "SaneBox's official pricing page currently shows biyearly rates of $4.54 per month for Snack, $7.46 for Lunch and $22.04 for Dinner, with a 7-day free trial. Billing-cycle pricing can differ."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How much does AWeber cost in 2026?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "AWeber offers Free, Lite, Plus and Unlimited plans. Official AWeber documentation currently lists Lite from $15 monthly or $150 annually for up to 500 subscribers, Plus from $30 monthly or $240 annually, and Unlimited at $899 monthly."
+          }
+        }
+      ]
+    }
+    </script>
+
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
     <style>
       body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
       h1, h2, h3 { font-family: 'Outfit', sans-serif; }
     </style>
   </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
+  <body class="min-h-screen bg-[#0b0c10] text-slate-100">
+    <header class="sticky top-0 z-50 border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md">
+      <div class="max-w-5xl mx-auto px-5 py-4 flex items-center justify-between gap-4">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-9 w-9 rounded-xl bg-purple-600 flex items-center justify-center font-black text-white">C</div>
+          <span class="font-extrabold tracking-tight text-white">COSHUMA</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/tool/sanebox.html" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 text-purple-200 hover:bg-purple-500/10">SaneBox buyer guide →</a>
       </div>
     </header>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Sanebox vs AWeber</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Email & Outreach tool.
-        </p>
-      </div>
+    <main class="max-w-5xl mx-auto px-5 py-10 md:py-14 space-y-8">
+      <section class="rounded-3xl border border-purple-500/30 bg-[#121520] p-6 md:p-10 shadow-2xl space-y-6">
+        <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">2026 decision guide</div>
+        <h1 class="text-4xl md:text-5xl font-black text-white">SaneBox vs AWeber: inbox cleanup or email marketing?</h1>
+        <p class="text-lg text-slate-300 leading-relaxed max-w-4xl">This is not a like-for-like comparison. SaneBox helps you control the email already arriving in your inbox. AWeber helps you build an audience and send marketing email. Pick the workflow first, then the product.</p>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
+        <div class="grid md:grid-cols-2 gap-4">
+          <div class="rounded-2xl border border-purple-500/20 bg-purple-500/5 p-5 space-y-3">
+            <div class="text-xs uppercase tracking-wider font-extrabold text-purple-300">Choose SaneBox when</div>
+            <h2 class="text-2xl font-black text-white">Your problem is inbox overload</h2>
+            <ul class="text-sm text-slate-300 space-y-2">
+              <li>✓ Prioritize and sort incoming personal or work email.</li>
+              <li>✓ Reduce clutter without changing your existing email provider.</li>
+              <li>✓ Use tools such as SaneLater, SaneBlackHole and reminders.</li>
+            </ul>
+            <a data-cta="official" data-tool-id="sanebox" data-cta-source="compare-hero-sanebox" href="https://www.sanebox.com/pricing" target="_blank" rel="noopener noreferrer" class="block px-5 py-3.5 rounded-xl border border-purple-500/30 bg-purple-500/10 text-purple-100 font-extrabold text-center hover:bg-purple-500/20">Check SaneBox pricing →</a>
+          </div>
+
+          <div class="rounded-2xl border border-blue-500/20 bg-blue-500/5 p-5 space-y-3">
+            <div class="text-xs uppercase tracking-wider font-extrabold text-blue-300">Choose AWeber when</div>
+            <h2 class="text-2xl font-black text-white">Your goal is audience growth</h2>
+            <ul class="text-sm text-slate-300 space-y-2">
+              <li>✓ Send newsletters and automated sequences.</li>
+              <li>✓ Manage subscribers, segments, forms and landing pages.</li>
+              <li>✓ Start small and scale with list size.</li>
+            </ul>
+            <a data-cta="affiliate" data-tool-id="aweber" data-cta-source="compare-hero-aweber" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="block px-5 py-3.5 rounded-xl bg-blue-600 hover:bg-blue-500 text-white font-extrabold text-center">Start AWeber via COSHUMA →</a>
+          </div>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Sanebox if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
+        <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: SaneBox is linked to its official pricing page and is not presented here as an affiliate route. COSHUMA may earn a commission if an eligible AWeber purchase is attributed through the marked verified affiliate link, at no extra cost to you.</p>
+      </section>
+
+      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-5">
+        <div>
+          <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Current public pricing</div>
+          <h2 class="text-3xl font-black text-white mt-1">Pricing checked September 7, 2026</h2>
+          <p class="text-sm text-slate-400 mt-2">Prices below come from the vendors' official pricing or help pages. Billing cycle, subscriber count and promotions can change the final amount.</p>
+        </div>
+
+        <div class="grid md:grid-cols-2 gap-5">
+          <div class="rounded-2xl bg-[#0d1018] border border-[#25293b] p-5 space-y-4">
+            <div class="flex items-center justify-between gap-3">
+              <h3 class="text-xl font-black text-white">SaneBox</h3>
+              <span class="text-xs font-bold text-emerald-300">7-day trial</span>
             </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose AWeber if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
+            <div class="grid grid-cols-3 gap-2 text-center">
+              <div class="rounded-xl bg-[#151927] p-3"><div class="text-xs text-slate-400">Snack</div><div class="font-black text-emerald-400 mt-1">$4.54/mo</div></div>
+              <div class="rounded-xl bg-[#151927] p-3"><div class="text-xs text-slate-400">Lunch</div><div class="font-black text-emerald-400 mt-1">$7.46/mo</div></div>
+              <div class="rounded-xl bg-[#151927] p-3"><div class="text-xs text-slate-400">Dinner</div><div class="font-black text-emerald-400 mt-1">$22.04/mo</div></div>
             </div>
+            <p class="text-xs text-slate-400 leading-relaxed">The current pricing page shows these rates when billed biyearly. Snack supports 1 email account and 2 selectable features, Lunch 2 accounts and 6 features, and Dinner 4 accounts with all features.</p>
+            <a data-cta="official" data-tool-id="sanebox" data-cta-source="compare-pricing-sanebox" href="https://www.sanebox.com/pricing" target="_blank" rel="noopener noreferrer" class="block px-5 py-3 rounded-xl border border-slate-600 bg-slate-800 text-white font-bold text-center hover:bg-slate-700">Verify SaneBox pricing →</a>
           </div>
-        </div>
-      </div>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/sanebox.html" class="hover:text-purple-300">Sanebox</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/aweber.html" class="hover:text-blue-300">AWeber</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Sanebox Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ AI email prioritization</div>
-<div>✓ Automated inbox organization</div>
-<div>✓ Spam and clutter reduction</div>
-<div>✓ Do Not Disturb feature</div>
+          <div class="rounded-2xl bg-[#0d1018] border border-[#25293b] p-5 space-y-4">
+            <div class="flex items-center justify-between gap-3">
+              <h3 class="text-xl font-black text-white">AWeber</h3>
+              <span class="text-xs font-bold text-emerald-300">Free option + paid tiers</span>
             </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">AWeber Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Email Campaign Creation</div>
-<div>✓ Automated Email Sequences</div>
-<div>✓ Landing Page Builder</div>
-<div>✓ Subscriber Management & Segmentation</div>
+            <div class="grid grid-cols-2 gap-2 text-center">
+              <div class="rounded-xl bg-[#151927] p-3"><div class="text-xs text-slate-400">Lite</div><div class="font-black text-emerald-400 mt-1">from $15/mo</div></div>
+              <div class="rounded-xl bg-[#151927] p-3"><div class="text-xs text-slate-400">Plus</div><div class="font-black text-emerald-400 mt-1">from $30/mo</div></div>
             </div>
+            <p class="text-xs text-slate-400 leading-relaxed">Official AWeber documentation lists Lite at $15 monthly or $150 annually and Plus at $30 monthly or $240 annually for up to 500 subscribers. AWeber also lists a Free plan and an Unlimited plan at $899 monthly.</p>
+            <a data-cta="affiliate" data-tool-id="aweber" data-cta-source="compare-pricing-aweber" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="block px-5 py-3 rounded-xl bg-blue-600 hover:bg-blue-500 text-white font-extrabold text-center">See AWeber through verified partner link →</a>
           </div>
         </div>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://sanebox.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Sanebox →</a>
-          <a href="https://www.aweber.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get AWeber →</a>
+      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-5">
+        <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Fast decision</div>
+        <h2 class="text-3xl font-black text-white">Do not buy based on the cheaper sticker price</h2>
+        <div class="grid md:grid-cols-2 gap-4 text-sm text-slate-300">
+          <div class="rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-5">
+            <div class="font-extrabold text-white mb-2">SaneBox is the cleaner choice if…</div>
+            <p class="leading-relaxed">You already receive too much email and want software to sort, postpone, screen and declutter that inbox. It does not replace an email marketing platform.</p>
+          </div>
+          <div class="rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-5">
+            <div class="font-extrabold text-white mb-2">AWeber is the cleaner choice if…</div>
+            <p class="leading-relaxed">You need subscriber capture, newsletters, automated campaigns, landing pages and audience segmentation. It does not organize your personal inbox like SaneBox.</p>
+          </div>
         </div>
-      </div>
+      </section>
+
+      <section class="rounded-3xl border border-blue-500/30 bg-blue-500/5 p-6 md:p-8 space-y-4 text-center">
+        <div class="text-xs uppercase tracking-widest text-blue-300 font-bold">Revenue-ready path</div>
+        <h2 class="text-3xl font-black text-white">Need email marketing rather than inbox cleanup?</h2>
+        <p class="text-sm text-slate-300 max-w-2xl mx-auto">Use COSHUMA's verified AWeber customer link. The destination remains the exact tracking URL already verified in COSHUMA's affiliate data rather than a generic homepage.</p>
+        <div class="flex flex-col sm:flex-row gap-3 justify-center">
+          <a data-cta="affiliate" data-tool-id="aweber" data-cta-source="compare-bottom-aweber" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="px-7 py-4 rounded-xl bg-blue-600 hover:bg-blue-500 text-white font-extrabold text-center">Start AWeber via verified link →</a>
+          <a href="/tool/aweber.html" class="px-7 py-4 rounded-xl border border-slate-600 bg-slate-800 text-white font-bold text-center hover:bg-slate-700">Read the AWeber buyer guide →</a>
+        </div>
+      </section>
+
+      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-4">
+        <h2 class="text-2xl font-black text-white">More useful comparisons</h2>
+        <div class="grid sm:grid-cols-3 gap-3 text-sm">
+          <a href="/tool/sanebox.html" class="rounded-xl border border-[#2a2e42] bg-[#0d1018] px-4 py-3 text-slate-200 hover:border-purple-500/40">SaneBox pricing & alternatives →</a>
+          <a href="/tool/aweber.html" class="rounded-xl border border-[#2a2e42] bg-[#0d1018] px-4 py-3 text-slate-200 hover:border-purple-500/40">AWeber pricing & features →</a>
+          <a href="/compare/aweber-vs-moosend.html" class="rounded-xl border border-[#2a2e42] bg-[#0d1018] px-4 py-3 text-slate-200 hover:border-purple-500/40">AWeber vs Moosend →</a>
+        </div>
+      </section>
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS buyer guidance.</div>
     </footer>
+    <script src="/affiliate-attribution.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Revenue-first, zero-cost cleanup of an existing comparison page linked from the search-visible SaneBox funnel.

Evidence rechecked Sep 7, 2026:
- COSHUMA's stored Search Console snapshot shows `sanebox` at 36 impressions / 0 clicks.
- SaneBox's official pricing page currently lists a 7-day free trial and biyearly rates of $4.54/mo Snack, $7.46/mo Lunch, and $22.04/mo Dinner.
- AWeber's official help/pricing pages currently list Free, Lite, Plus and Unlimited; Lite starts at $15 monthly or $150 annually for 500 subscribers, Plus at $30 monthly or $240 annually, and Unlimited at $899 monthly.
- COSHUMA repository data already verifies the exact customer-facing AWeber affiliate URL `https://www.aweber.com/easy-email.htm?id=561868`.

Changes:
- replace stale GlobalSaaSHub branding and placeholder `Not rated` copy with COSHUMA buyer guidance
- explain that SaneBox (inbox organization) and AWeber (email marketing) solve different jobs
- keep SaneBox as an official non-affiliate route
- add three source-tagged AWeber revenue CTAs using only the verified affiliate URL
- add current pricing/trial context, FAQ structured data, internal links and affiliate attribution script

No paid service, guessed tracking parameter, new subscription or unsupported commission claim is introduced.