### PR TITLE
Optimize ElevenLabs CRO and COSHUMA branding

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/elevenlabs.html
+++ b/projects/GlobalSaaSHub/public/tool/elevenlabs.html
@@ -1,134 +1,152 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ElevenLabs Pricing, Free Plan & Voice AI Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="ElevenLabs pricing and buyer guide for 2026: Free $0, Starter $6, Creator $22, Pro $99, plus voice cloning, text-to-speech, commercial-use considerations and verified signup links." />
-    <link rel="canonical" href="https://coshuma.com/tool/elevenlabs.html" />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ElevenLabs Pricing 2026: Free, Starter, Creator & Pro | COSHUMA</title>
+  <meta name="description" content="ElevenLabs pricing and buyer guide for 2026: Free $0, Starter $6, Creator $22, Pro $99, plus voice cloning, commercial-use considerations and a verified partner signup link." />
+  <link rel="canonical" href="https://coshuma.com/tool/elevenlabs.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://coshuma.com/tool/elevenlabs.html" />
+  <meta property="og:title" content="ElevenLabs Pricing 2026: Plans, Free Tier & Voice AI Guide | COSHUMA" />
+  <meta property="og:description" content="Compare ElevenLabs Free, Starter, Creator and Pro, then choose the right voice AI tier for commercial use, cloning and higher-volume generation." />
 
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://coshuma.com/tool/elevenlabs.html" />
-    <meta property="og:title" content="ElevenLabs Pricing & Free Plan (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare ElevenLabs Free, Starter, Creator and Pro plans, then choose the right voice AI tier for commercial use, cloning and higher-volume generation." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"SoftwareApplication",
+    "name":"ElevenLabs",
+    "operatingSystem":"Web",
+    "applicationCategory":"MultimediaApplication",
+    "url":"https://elevenlabs.io/",
+    "description":"AI audio platform for text-to-speech, voice cloning, speech-to-text, dubbing, sound effects and music generation."
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"Does ElevenLabs have a free plan?","acceptedAnswer":{"@type":"Answer","text":"Yes. ElevenLabs currently offers a $0 free plan with monthly usage for testing text-to-speech and other core tools."}},
+      {"@type":"Question","name":"How much does ElevenLabs Starter cost?","acceptedAnswer":{"@type":"Answer","text":"ElevenLabs currently lists Starter at $6 per month."}},
+      {"@type":"Question","name":"Which ElevenLabs plan should a commercial creator compare first?","acceptedAnswer":{"@type":"Answer","text":"Starter is the first paid tier to compare when you need commercial-use rights and instant voice cloning. Creator adds more usage and professional voice cloning."}}
+    ]
+  }
+  </script>
 
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "ElevenLabs",
-      "operatingSystem": "Web",
-      "applicationCategory": "MultimediaApplication",
-      "description": "Voice AI platform for text-to-speech, speech-to-text, voice cloning, sound effects, music and audio production.",
-      "url": "https://elevenlabs.io/"
-    }
-    </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="/affiliate-attribution.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}
+    h1,h2,h3{font-family:'Outfit',sans-serif}
+  </style>
+</head>
+<body class="min-h-screen bg-[#0b0c10]">
+<header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50">
+  <div class="max-w-6xl mx-auto px-5 py-4 flex items-center justify-between">
+    <a href="/" class="flex items-center gap-3">
+      <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-black text-white">C</div>
+      <span class="font-black text-lg tracking-tight text-white">COSHUMA</span>
+    </a>
+    <a href="/best/index.html" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">Buyer Guides</a>
+  </div>
+</header>
 
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script defer src="/affiliate-attribution.js"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
-      </div>
-    </header>
-
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
-          <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=elevenlabs.io&sz=128" alt="ElevenLabs logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.style.display='none'" />
-            <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">Voice & Speech AI</div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">ElevenLabs Pricing & Free Plan</h1>
-              <p class="text-sm text-slate-400 mt-2">Pricing checked September 1, 2026 against ElevenLabs' official pricing pages.</p>
-            </div>
-          </div>
+<main class="max-w-5xl mx-auto px-5 py-12 space-y-8">
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-10 shadow-2xl">
+    <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-8">
+      <div class="max-w-2xl">
+        <div class="text-xs font-extrabold uppercase tracking-[0.18em] text-purple-300">Pricing checked Sep 7, 2026</div>
+        <h1 class="text-4xl md:text-5xl font-black tracking-tight mt-3">ElevenLabs pricing in 2026 — start free, then upgrade only when you need commercial rights or more usage</h1>
+        <p class="text-slate-300 mt-5 leading-relaxed">ElevenLabs combines text-to-speech, voice cloning, dubbing, speech-to-text, sound effects and music tools. The safest buying path is to test voice quality on Free first, then move to Starter or Creator only when the workflow justifies it.</p>
+        <div class="flex flex-col sm:flex-row gap-3 mt-7">
+          <a data-cta="affiliate" data-tool-id="elevenlabs" data-cta-source="elevenlabs_hero_free" href="https://try.elevenlabs.io/ldc2xmh2x2t5" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-extrabold text-center">Start ElevenLabs Free →</a>
+          <a data-cta="official" href="https://elevenlabs.io/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-slate-800 border border-slate-600 text-white font-extrabold text-center">Check official pricing</a>
         </div>
-
-        <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/20">
-          <p class="text-sm text-slate-300 leading-relaxed"><strong class="text-white">Affiliate disclosure:</strong> GlobalSaaSHub may earn a commission if you start with ElevenLabs through the verified partner link below and later become a qualifying paid subscriber. This does not increase the price you pay.</p>
-        </div>
-
-        <section class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Quick verdict</h2>
-          <p class="text-slate-300 leading-relaxed">ElevenLabs is a strong fit when you need realistic text-to-speech, voice cloning, sound effects or multilingual audio production in one platform. The free plan is enough to test core generation quality, while Starter is the first paid tier that adds a commercial license and instant voice cloning.</p>
-        </section>
-
-        <section class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Current ElevenLabs pricing</h2>
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
-              <div class="flex items-center justify-between gap-3"><h3 class="font-extrabold text-white">Free</h3><span class="text-emerald-400 font-black">$0/mo</span></div>
-              <p class="text-xs text-slate-400 mt-2">10,000 credits/month. Includes text-to-speech, speech-to-text, sound effects, Voice Design, music and 3 Studio projects.</p>
-            </div>
-            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
-              <div class="flex items-center justify-between gap-3"><h3 class="font-extrabold text-white">Starter</h3><span class="text-emerald-400 font-black">$6/mo</span></div>
-              <p class="text-xs text-slate-400 mt-2">30,000 credits/month. Adds a commercial license, instant voice cloning, 20 Studio projects and commercial music use.</p>
-            </div>
-            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
-              <div class="flex items-center justify-between gap-3"><h3 class="font-extrabold text-white">Creator</h3><span class="text-emerald-400 font-black">$22/mo</span></div>
-              <p class="text-xs text-slate-400 mt-2">121,000 credits/month. Official pricing currently shows the first month at $11 and adds professional voice cloning.</p>
-            </div>
-            <div class="p-5 rounded-2xl bg-[#181a29] border border-[#222538]">
-              <div class="flex items-center justify-between gap-3"><h3 class="font-extrabold text-white">Pro</h3><span class="text-emerald-400 font-black">$99/mo</span></div>
-              <p class="text-xs text-slate-400 mt-2">600,000 credits/month. Adds 44.1kHz PCM API output and 192kbps audio quality.</p>
-            </div>
-          </div>
-          <p class="text-xs text-slate-500">Higher tiers are also available: Scale $299/month, Business $990/month and Enterprise custom pricing. Taxes, billing options and promotional pricing can change; verify the final checkout before purchase.</p>
-        </section>
-
-        <section class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Which plan should you choose?</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">Testing voice quality:</strong><span class="text-slate-300"> start with Free before paying.</span></div>
-            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">Commercial creator work:</strong><span class="text-slate-300"> Starter is the first paid tier with a commercial license.</span></div>
-            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">Professional voice cloning:</strong><span class="text-slate-300"> Creator adds professional voice cloning and more monthly credits.</span></div>
-            <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><strong class="text-white">High-volume/API work:</strong><span class="text-slate-300"> compare Pro, Scale or Business based on output volume and team needs.</span></div>
-          </div>
-        </section>
-
-        <section class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white">Compare ElevenLabs alternatives</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <a href="/compare/elevenlabs-vs-murf-ai.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">ElevenLabs vs Murf AI</div><div class="text-xs text-slate-400 mt-1">Compare voice generation workflows and pricing context.</div></a>
-            <a href="/compare/elevenlabs-vs-lovo.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">ElevenLabs vs Lovo</div><div class="text-xs text-slate-400 mt-1">Compare two voice-generation options before choosing a paid plan.</div></a>
-          </div>
-        </section>
-
-        <section class="p-6 rounded-2xl bg-[#181a29] border border-purple-500/30 space-y-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Best low-risk next step</div>
-            <div class="text-2xl font-extrabold text-white mt-1">Start on the $0 Free plan</div>
-            <p class="text-sm text-slate-400 mt-2">Test the voices and workflow first. Upgrade only if you need commercial rights, cloning or more credits.</p>
-          </div>
-          <div class="flex flex-col sm:flex-row gap-3">
-            <a data-cta="affiliate" data-tool-id="elevenlabs" href="https://try.elevenlabs.io/ldc2xmh2x2t5" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all flex items-center justify-center gap-2"><span>Start ElevenLabs Free</span><span>→</span></a>
-            <a data-cta="official" href="https://elevenlabs.io/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all">Check Official Pricing</a>
-          </div>
-          <p class="text-[11px] text-slate-500">Verified partner destination: try.elevenlabs.io/ldc2xmh2x2t5. ElevenLabs states eligible Starter, Creator, Pro and Scale referrals can generate affiliate commission for 12 months; Business uses a lower rate and Enterprise purchases are excluded.</p>
-        </section>
-
-        <section class="p-5 rounded-2xl bg-[#0f1119] border border-[#222538] text-xs text-slate-400 leading-relaxed">
-          <strong class="text-slate-300">Sources checked:</strong> ElevenLabs official pricing pages and official affiliate-program terms/partner guide. Pricing and program terms can change, so the official checkout and current program terms control.
-        </section>
+        <p class="text-[11px] text-slate-500 mt-3">Affiliate disclosure: COSHUMA may earn a commission if you sign up through the verified ElevenLabs partner link and later become an eligible paid customer. This does not increase the price you pay.</p>
       </div>
-    </main>
+      <div class="min-w-[250px] p-5 rounded-2xl border border-emerald-500/20 bg-emerald-500/5">
+        <div class="text-xs uppercase tracking-wider font-bold text-emerald-300">Fast decision</div>
+        <p class="text-sm text-slate-300 mt-2"><strong class="text-white">Free:</strong> test voice quality and workflow before paying.</p>
+        <p class="text-sm text-slate-300 mt-3"><strong class="text-white">Starter:</strong> compare first for commercial creator work and instant voice cloning.</p>
+        <p class="text-sm text-slate-300 mt-3"><strong class="text-white">Creator:</strong> compare when you need more usage and professional voice cloning.</p>
+      </div>
+    </div>
+  </section>
 
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
-    </footer>
-  </body>
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-9">
+    <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-3">
+      <div>
+        <h2 class="text-2xl font-black">Current ElevenLabs plan snapshot</h2>
+        <p class="text-sm text-slate-400 mt-2">Official monthly pricing checked Sep 7, 2026. Taxes, billing options and promotions can change the final checkout total.</p>
+      </div>
+      <a href="https://elevenlabs.io/pricing" target="_blank" rel="noopener noreferrer" class="text-sm font-bold text-purple-300">Verify live pricing ↗</a>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-6">
+      <div class="rounded-2xl bg-[#181a29] border border-[#2a2d42] p-5">
+        <div class="text-xs font-bold text-slate-400">Free</div><div class="text-3xl font-black mt-2">$0</div><div class="text-xs text-slate-500">per month</div>
+        <p class="text-sm text-slate-300 mt-4">10k monthly credits for testing text-to-speech and other core creative tools.</p>
+      </div>
+      <div class="rounded-2xl bg-[#181a29] border border-purple-500/40 p-5">
+        <div class="text-xs font-bold text-purple-300">Starter</div><div class="text-3xl font-black mt-2">$6</div><div class="text-xs text-slate-500">per month</div>
+        <p class="text-sm text-slate-300 mt-4">30k credits/month. Adds a commercial license and instant voice cloning.</p>
+      </div>
+      <div class="rounded-2xl bg-[#181a29] border border-[#2a2d42] p-5">
+        <div class="text-xs font-bold text-slate-400">Creator</div><div class="text-3xl font-black mt-2">$22</div><div class="text-xs text-slate-500">per month · first month currently $11</div>
+        <p class="text-sm text-slate-300 mt-4">121k credits/month plus professional voice cloning and more usage headroom.</p>
+      </div>
+      <div class="rounded-2xl bg-[#181a29] border border-[#2a2d42] p-5">
+        <div class="text-xs font-bold text-slate-400">Pro</div><div class="text-3xl font-black mt-2">$99</div><div class="text-xs text-slate-500">per month</div>
+        <p class="text-sm text-slate-300 mt-4">600k credits/month for higher-volume generation and advanced output needs.</p>
+      </div>
+    </div>
+    <p class="text-xs text-slate-500 mt-5">Higher self-serve tiers are also listed: Scale $299/month and Business $990/month. Enterprise pricing is custom.</p>
+  </section>
+
+  <section class="grid grid-cols-1 lg:grid-cols-2 gap-5">
+    <div class="rounded-3xl border border-[#222538] bg-[#131520] p-7">
+      <h2 class="text-2xl font-black">Which plan should you test?</h2>
+      <div class="mt-5 space-y-4 text-sm text-slate-300">
+        <p><strong class="text-white">Testing voices:</strong> stay on Free until you know the output quality works for your content.</p>
+        <p><strong class="text-white">Commercial creator work:</strong> compare Starter first because it adds commercial-use rights and instant voice cloning.</p>
+        <p><strong class="text-white">Professional cloning:</strong> Creator adds professional voice cloning and a larger monthly allowance.</p>
+        <p><strong class="text-white">High-volume production/API use:</strong> compare Pro, Scale or Business based on the actual usage you expect.</p>
+      </div>
+    </div>
+    <div class="rounded-3xl border border-purple-500/35 bg-purple-500/5 p-7">
+      <div class="text-xs uppercase tracking-[0.16em] font-bold text-purple-300">Low-risk next step</div>
+      <h2 class="text-2xl font-black mt-2">Test the real workflow before buying credits</h2>
+      <p class="text-sm text-slate-300 mt-4 leading-relaxed">Generate the type of audio you actually plan to publish, then judge pronunciation, pacing, editing time and whether the output still needs manual cleanup. Upgrade only after that test passes.</p>
+      <a data-cta="affiliate" data-tool-id="elevenlabs" data-cta-source="elevenlabs_plan_fit_free" href="https://try.elevenlabs.io/ldc2xmh2x2t5" target="_blank" rel="sponsored noopener noreferrer" class="mt-6 block px-5 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-center font-extrabold">Start the free test via COSHUMA →</a>
+    </div>
+  </section>
+
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-9">
+    <h2 class="text-2xl font-black">Compare ElevenLabs alternatives</h2>
+    <p class="text-sm text-slate-400 mt-2">Use the comparison pages when voice workflow, editing style or platform fit matters more than the headline price.</p>
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-5">
+      <a href="/compare/elevenlabs-vs-murf-ai.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">ElevenLabs vs Murf AI</div><div class="text-xs text-slate-400 mt-1">Compare voice generation workflows and pricing context.</div></a>
+      <a href="/compare/elevenlabs-vs-lovo.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all"><div class="font-bold text-white">ElevenLabs vs Lovo</div><div class="text-xs text-slate-400 mt-1">Compare two voice-generation options before choosing a paid plan.</div></a>
+    </div>
+  </section>
+
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-9">
+    <h2 class="text-2xl font-black">Bottom line</h2>
+    <p class="text-slate-300 mt-4 leading-relaxed">ElevenLabs is a strong option when realistic voice generation, cloning and multilingual audio are core to the workflow. Do not pay just because a higher plan has more credits: start on Free, test your real content, and upgrade only when commercial rights, cloning or volume makes the paid tier necessary.</p>
+    <div class="flex flex-col sm:flex-row gap-3 mt-6">
+      <a data-cta="affiliate" data-tool-id="elevenlabs" data-cta-source="elevenlabs_bottom_free" href="https://try.elevenlabs.io/ldc2xmh2x2t5" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-purple-600 text-center font-extrabold">Start ElevenLabs Free →</a>
+      <a data-cta="official" href="https://elevenlabs.io/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-slate-800 border border-slate-600 text-center font-extrabold">Official ElevenLabs pricing</a>
+    </div>
+  </section>
+
+  <p class="text-xs text-slate-500 leading-relaxed">Source check: ElevenLabs official pricing and product pages, verified Sep 7, 2026. COSHUMA's customer-facing partner destination is the verified link stored in the repository: try.elevenlabs.io/ldc2xmh2x2t5. Pricing and program terms can change, so the official checkout and current program terms control.</p>
+</main>
+
+<footer class="border-t border-[#222538] mt-12 bg-[#07080c]">
+  <div class="max-w-5xl mx-auto px-5 py-8 text-center text-xs text-slate-500">&copy; 2026 COSHUMA. Global AI SaaS Decision Platform. All rights reserved.</div>
+</footer>
+</body>
 </html>


### PR DESCRIPTION
Refreshes the ElevenLabs buyer page with current official pricing checked Sep 7, 2026, removes remaining GlobalSaaSHub branding, keeps the verified ElevenLabs customer-facing partner URL unchanged, and adds CTA-source attribution at hero, plan-fit, and bottom conversion points. No paid services or new affiliate applications involved.