### PR TITLE
Monetize Unbounce vs Jotform comparison

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/unbounce-vs-jotform.html
+++ b/projects/GlobalSaaSHub/public/compare/unbounce-vs-jotform.html
@@ -3,25 +3,25 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Unbounce vs Jotform Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Unbounce vs Jotform. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
-
+    <title>Unbounce vs Jotform: Landing Pages or Forms? (2026) | COSHUMA</title>
+    <meta name="description" content="Unbounce vs Jotform for 2026: compare landing-page optimization, forms, e-signatures, current public pricing, and the best fit for lead-generation workflows." />
     <link rel="canonical" href="https://coshuma.com/compare/unbounce-vs-jotform.html" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/compare/unbounce-vs-jotform.html" />
-    <meta property="og:title" content="Unbounce vs Jotform Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Unbounce and Jotform by pricing, features, and verified public information." />
+    <meta property="og:title" content="Unbounce vs Jotform: Landing Pages or Forms? (2026) | COSHUMA" />
+    <meta property="og:description" content="Choose Unbounce for conversion-focused landing pages and testing, or Jotform for forms, submissions, payments and e-signature workflows." />
 
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebPage",
-      "name": "Unbounce vs Jotform Comparison",
+      "name": "Unbounce vs Jotform: Landing Pages or Forms? (2026)",
       "url": "https://coshuma.com/compare/unbounce-vs-jotform.html",
-      "description": "Compare Unbounce and Jotform by pricing, features, and verified public information.",
+      "description": "A current buyer guide comparing Unbounce and Jotform by core workflow, public pricing and best fit.",
+      "dateModified": "2026-09-07",
       "isPartOf": {
         "@type": "WebSite",
-        "name": "GlobalSaaSHub",
+        "name": "COSHUMA",
         "url": "https://coshuma.com/"
       },
       "about": [
@@ -30,7 +30,30 @@
       ]
     }
     </script>
-    
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "Is Unbounce or Jotform better for landing pages?",
+          "acceptedAnswer": {"@type": "Answer", "text": "Unbounce is the stronger fit when the main job is building campaign landing pages and improving conversion rates with A/B testing and optimization features."}
+        },
+        {
+          "@type": "Question",
+          "name": "Is Unbounce or Jotform better for forms?",
+          "acceptedAnswer": {"@type": "Answer", "text": "Jotform is the stronger fit when the main job is collecting submissions, payments, signed documents, or building form-centric workflows."}
+        },
+        {
+          "@type": "Question",
+          "name": "Can I try either product before paying?",
+          "acceptedAnswer": {"@type": "Answer", "text": "Unbounce currently advertises a 14-day free trial with no credit card required. Jotform currently offers a free Starter plan with usage limits."}
+        }
+      ]
+    }
+    </script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -44,129 +67,113 @@
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div>
+          <span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Browse All Tools</a>
       </div>
     </header>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
+    <main class="max-w-5xl mx-auto px-4 py-12 w-full space-y-8">
+      <section class="text-center space-y-4">
+        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Buyer guide · Updated September 7, 2026</div>
         <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Unbounce vs Jotform</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Coding & Dev Tools tool.
-        </p>
-      </div>
-
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
+        <p class="text-slate-300 text-base max-w-3xl mx-auto leading-relaxed">These products overlap around lead capture, but they solve different primary jobs. <strong class="text-white">Unbounce</strong> is built around conversion-focused landing pages and testing. <strong class="text-white">Jotform</strong> is built around forms, submissions, payments, signatures and workflow data collection.</p>
+        <div class="flex flex-col sm:flex-row gap-3 justify-center pt-2">
+          <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="compare-unbounce-jotform-hero" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="px-7 py-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-white transition-all">Start Unbounce free trial →</a>
+          <a data-cta="official" data-tool-id="jotform" data-cta-source="compare-unbounce-jotform-hero-jotform" href="https://www.jotform.com/pricing/" target="_blank" rel="noopener noreferrer" class="px-7 py-4 rounded-xl border border-blue-500/40 bg-blue-500/10 hover:bg-blue-500/20 font-extrabold text-blue-200 transition-all">See Jotform pricing →</a>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Unbounce if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
+        <p class="text-[11px] text-slate-500 max-w-2xl mx-auto">Affiliate disclosure: COSHUMA may earn a commission if an eligible Unbounce purchase is attributed through the partner link, at no extra cost to you.</p>
+      </section>
+
+      <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-5">
+        <h2 class="text-xl font-bold text-white">Quick decision</h2>
+        <div class="grid md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-3">
+            <h3 class="font-bold text-purple-300">Choose Unbounce when…</h3>
+            <ul class="space-y-2 text-sm text-slate-300">
+              <li>✓ Your priority is paid-campaign landing pages.</li>
+              <li>✓ You want built-in A/B testing and conversion optimization.</li>
+              <li>✓ You need popups, sticky bars, custom scripts or dynamic text on campaign pages.</li>
+            </ul>
           </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Jotform if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
+          <div class="p-5 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-3">
+            <h3 class="font-bold text-blue-300">Choose Jotform when…</h3>
+            <ul class="space-y-2 text-sm text-slate-300">
+              <li>✓ Your priority is forms and structured submissions.</li>
+              <li>✓ You need payment submissions or signed-document workflows.</li>
+              <li>✓ You want a free entry plan before upgrading to higher submission limits.</li>
+            </ul>
           </div>
         </div>
-      </div>
+      </section>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/unbounce.html" class="hover:text-purple-300">Unbounce</a>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
+        <div>
+          <h2 class="text-xl font-bold text-white">Current public pricing</h2>
+          <p class="mt-2 text-sm text-slate-400">Prices below were checked against each vendor's public pricing page on September 7, 2026. Vendors can change pricing or limits at any time.</p>
+        </div>
+        <div class="grid md:grid-cols-2 gap-5">
+          <div class="rounded-2xl bg-[#181a29] border border-purple-500/20 p-5 space-y-3">
+            <div class="flex items-center justify-between gap-3"><h3 class="font-extrabold text-white">Unbounce</h3><span class="text-xs text-emerald-300">14-day trial</span></div>
+            <ul class="text-sm text-slate-300 space-y-1.5">
+              <li>Starter: $29</li>
+              <li>Build: $99</li>
+              <li>Experiment: $149</li>
+              <li>Optimize: $249</li>
+              <li>Concierge / Agency: custom pricing</li>
+            </ul>
+            <p class="text-xs text-slate-500">Unbounce states the 14-day trial requires no credit card.</p>
+            <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="compare-unbounce-jotform-pricing" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="block text-center py-3 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white transition-all">Try Unbounce through COSHUMA →</a>
           </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/jotform.html" class="hover:text-blue-300">Jotform</a>
+          <div class="rounded-2xl bg-[#181a29] border border-blue-500/20 p-5 space-y-3">
+            <div class="flex items-center justify-between gap-3"><h3 class="font-extrabold text-white">Jotform</h3><span class="text-xs text-emerald-300">Free Starter</span></div>
+            <ul class="text-sm text-slate-300 space-y-1.5">
+              <li>Starter: free</li>
+              <li>Bronze: $34/month billed annually</li>
+              <li>Silver: $39/month billed annually</li>
+              <li>Gold: $99/month billed annually</li>
+              <li>Enterprise: custom pricing</li>
+            </ul>
+            <p class="text-xs text-slate-500">The free Starter plan currently includes 5 forms and 100 monthly submissions.</p>
+            <a data-cta="official" data-tool-id="jotform" data-cta-source="compare-unbounce-jotform-pricing-jotform" href="https://www.jotform.com/pricing/" target="_blank" rel="noopener noreferrer" class="block text-center py-3 px-4 rounded-xl border border-blue-500/40 bg-blue-500/10 hover:bg-blue-500/20 font-extrabold text-sm text-blue-200 transition-all">Check Jotform pricing →</a>
           </div>
         </div>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
+      <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-xl font-bold text-white">Feature comparison that actually matters</h2>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead><tr class="border-b border-[#2b2e43] text-left"><th class="py-3 pr-4 text-slate-400">Decision factor</th><th class="py-3 pr-4 text-purple-300">Unbounce</th><th class="py-3 text-blue-300">Jotform</th></tr></thead>
+            <tbody class="text-slate-300">
+              <tr class="border-b border-[#222538]"><td class="py-3 pr-4">Primary job</td><td class="py-3 pr-4">Landing pages + CRO</td><td class="py-3">Forms + submissions</td></tr>
+              <tr class="border-b border-[#222538]"><td class="py-3 pr-4">A/B testing</td><td class="py-3 pr-4">Core paid-plan capability</td><td class="py-3">Not the primary product focus</td></tr>
+              <tr class="border-b border-[#222538]"><td class="py-3 pr-4">Payments / signed docs</td><td class="py-3 pr-4">Not the primary product focus</td><td class="py-3">Supported with plan limits</td></tr>
+              <tr><td class="py-3 pr-4">Best first step</td><td class="py-3 pr-4">Use the 14-day trial</td><td class="py-3">Use the free Starter plan</td></tr>
+            </tbody>
+          </table>
         </div>
+      </section>
 
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
+      <section class="p-6 rounded-3xl bg-gradient-to-br from-purple-500/15 to-blue-500/10 border border-purple-500/30 space-y-4">
+        <h2 class="text-xl font-bold text-white">Bottom line</h2>
+        <p class="text-sm text-slate-300 leading-relaxed">Pick <strong class="text-white">Unbounce</strong> if the page itself is the conversion problem you are trying to solve. Pick <strong class="text-white">Jotform</strong> if the form, submission process, payment collection or signature workflow is the core problem. For marketers buying traffic to dedicated campaign pages, Unbounce is the more direct match.</p>
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="compare-unbounce-jotform-bottom" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="flex-1 text-center py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white transition-all">Start Unbounce free trial →</a>
+          <a href="/best/unbounce-discount.html" class="flex-1 text-center py-3.5 px-4 rounded-xl border border-slate-600 hover:border-purple-500/60 font-bold text-sm text-slate-200 transition-all">See COSHUMA's Unbounce offer guide →</a>
         </div>
+      </section>
 
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Unbounce Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Drag-and-Drop Page Builder</div>
-<div>✓ A/B Testing & Optimization</div>
-<div>✓ AI-Powered Copy Generation</div>
-<div>✓ Conversion Rate Smart Features</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Jotform Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Drag-and-Drop Form Builder</div>
-<div>✓ Payment Integrations</div>
-<div>✓ Workflow Automation</div>
-<div>✓ E-Signature Capabilities</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://unbounce.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Unbounce →</a>
-          <a href="https://www.jotform.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Jotform →</a>
-        </div>
-      </div>
+      <section class="grid sm:grid-cols-2 gap-4 text-sm">
+        <a href="/tool/unbounce.html" class="p-4 rounded-2xl border border-[#222538] bg-[#131520] hover:border-purple-500/40 transition-all"><span class="font-bold text-white">Unbounce pricing guide</span><span class="block mt-1 text-slate-400">Plans, trial terms and buyer fit →</span></a>
+        <a href="/tool/jotform.html" class="p-4 rounded-2xl border border-[#222538] bg-[#131520] hover:border-blue-500/40 transition-all"><span class="font-bold text-white">Jotform overview</span><span class="block mt-1 text-slate-400">Features and product context →</span></a>
+      </section>
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent SaaS buyer guides.</div>
     </footer>
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
Refreshes the stale Unbounce vs Jotform comparison with COSHUMA branding, current public pricing checked on 2026-09-07, buyer-intent copy, FAQ schema, internal links, and the already-verified Unbounce partner URL with position-specific attribution. Jotform remains an official non-affiliate link because no verified customer referral URL is recorded. No paid services added.