### PR TITLE
Turn n8n buyer traffic into a verified Make revenue path

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/n8n.html
+++ b/projects/GlobalSaaSHub/public/tool/n8n.html
@@ -3,166 +3,192 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>n8n Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="n8n is a flexible low-code automation platform designed for building sophisticated workflows, creating AI agents, and integrating with over 500 applic... Discover features, pricing (Open-source: free, Enterprise: custom pricing), and official links for n8n on GlobalSaaSHub." />
+    <title>n8n Pricing 2026: Cloud, Self-Hosting & Make Alternative | COSHUMA</title>
+    <meta name="description" content="n8n pricing and buyer guide for 2026: Starter and Pro Cloud plans, free Community Edition, execution-based billing, self-hosting, trial limits, and when Make.com may be easier." />
     <link rel="canonical" href="https://coshuma.com/tool/n8n.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/tool/n8n.html" />
-    <meta property="og:title" content="n8n Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="n8n is a flexible low-code automation platform designed for building sophisticated workflows, creating AI agents, and integrating with over 500 applic... Check rating, pricing, and features." />
-
-    <!-- JSON-LD Structured Data for Google Indexing -->
+    <meta property="og:title" content="n8n Pricing 2026: Cloud, Self-Hosting & Make Alternative" />
+    <meta property="og:description" content="Compare n8n Cloud, self-hosting, execution-based billing and a verified Make.com alternative before choosing an automation platform." />
     <script type="application/ld+json">
     {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "n8n",
-      "operatingSystem": "Web",
-      "applicationCategory": "Coding & Dev Tools",
-      "description": "n8n is a flexible low-code automation platform designed for building sophisticated workflows, creating AI agents, and integrating with over 500 applications seamlessly."
+      "@context":"https://schema.org",
+      "@type":"SoftwareApplication",
+      "name":"n8n",
+      "operatingSystem":"Web, Self-hosted",
+      "applicationCategory":"BusinessApplication",
+      "url":"https://n8n.io/",
+      "description":"Workflow automation platform with hosted Cloud plans and a free self-hosted Community Edition."
     }
     </script>
-
-    <!-- Tailwind & Fonts -->
+    <script type="application/ld+json">
+    {
+      "@context":"https://schema.org",
+      "@type":"FAQPage",
+      "mainEntity":[
+        {
+          "@type":"Question",
+          "name":"How much does n8n cost in 2026?",
+          "acceptedAnswer":{"@type":"Answer","text":"As checked September 7, 2026, n8n lists Starter at €20 per month billed annually for 2,500 workflow executions and Pro at €50 per month billed annually for 10,000 executions. Business is a self-hosted paid tier and Enterprise uses custom pricing. Live prices can change, so verify the official pricing page before purchase."}
+        },
+        {
+          "@type":"Question",
+          "name":"Can I use n8n for free?",
+          "acceptedAnswer":{"@type":"Answer","text":"Yes. n8n offers a free self-hosted Community Edition. n8n Cloud also offers a trial; the current Cloud trial does not require a credit card."}
+        },
+        {
+          "@type":"Question",
+          "name":"How does n8n billing work?",
+          "acceptedAnswer":{"@type":"Answer","text":"n8n prices its current plans around workflow executions. One execution is a run of the entire workflow, regardless of how many steps it contains, which differs from platforms that consume usage for individual module actions."}
+        },
+        {
+          "@type":"Question",
+          "name":"When should I consider Make.com instead of n8n?",
+          "acceptedAnswer":{"@type":"Answer","text":"Consider Make.com when you prefer a highly visual hosted automation experience, a permanent free tier for light usage, and less infrastructure responsibility. Consider n8n when self-hosting, deeper workflow control or execution-based billing better fits your use case."}
+        }
+      ]
+    }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <script defer src="/affiliate-attribution.js"></script>
     <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
+      body{font-family:Inter,system-ui,sans-serif;background:#0b0c10;color:#f1f5f9}
+      h1,h2,h3{font-family:Inter,system-ui,sans-serif}
     </style>
   </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
+  <body class="min-h-screen bg-[#0b0c10] text-slate-100">
+    <header class="sticky top-0 z-50 border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md">
+      <div class="max-w-5xl mx-auto px-5 py-4 flex items-center justify-between gap-4">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-9 w-9 rounded-xl bg-purple-600 flex items-center justify-center font-black text-white">C</div>
+          <span class="font-extrabold tracking-tight text-white">COSHUMA</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 text-purple-200 hover:bg-purple-500/10">Browse AI & SaaS tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
-          <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=n8n.io&sz=128" alt="n8n logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
-            <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Coding & Dev Tools</span>
+    <main class="max-w-5xl mx-auto px-5 py-10 md:py-14 space-y-8">
+      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-10 shadow-2xl">
+        <div class="grid md:grid-cols-[1fr_auto] gap-8 items-start">
+          <div class="space-y-5">
+            <div class="flex items-center gap-4">
+              <img src="https://www.google.com/s2/favicons?domain=n8n.io&sz=128" alt="n8n logo" class="h-14 w-14 rounded-2xl border border-[#2a2e42] bg-slate-900 p-2" />
+              <div>
+                <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Workflow automation · AI · self-hosting</div>
+                <h1 class="text-4xl md:text-5xl font-black text-white mt-1">n8n Pricing & Review 2026</h1>
               </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">n8n</h1>
             </div>
-          </div>
-
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
-        </div>
-
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">n8n is a flexible low-code automation platform designed for building sophisticated workflows, creating AI agents, and integrating with over 500 applications seamlessly.</p>
-        </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Low-code workflow building</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI agent development</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> 500+ app integrations</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Customizable automation logic</div>
-          </div>
-        </div>
-
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (Open-source: free, Enterprise: custom pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to n8n</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/make-com.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=make.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Make.com</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/unbounce.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=unbounce.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Unbounce</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/jotform.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=jotform.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Jotform</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
-
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">Open-source: free, Enterprise: custom pricing</div>
-          </div>
-          <a data-cta="official" href="https://n8n.io/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official n8n Site</span><span>→</span></a>
-        </div>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of n8n?</span>
+            <p class="text-lg text-slate-300 leading-relaxed max-w-3xl">n8n is strongest when you want visual automation without giving up developer-level control. It offers hosted Cloud plans plus a free self-hosted Community Edition, and current paid plans are priced around full workflow executions rather than individual workflow steps.</p>
+            <div class="flex flex-wrap gap-2 text-xs font-bold">
+              <span class="px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/25 text-emerald-300">Cloud trial: no card</span>
+              <span class="px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/25 text-emerald-300">Free Community Edition</span>
+              <span class="px-3 py-1.5 rounded-full bg-purple-500/10 border border-purple-500/25 text-purple-200">Unlimited workflow steps</span>
             </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
+            <div class="flex flex-col sm:flex-row gap-3 pt-1">
+              <a data-cta="official" href="https://n8n.io/pricing/" target="_blank" rel="noopener noreferrer" class="px-6 py-4 rounded-xl bg-slate-800 border border-slate-600 text-white font-extrabold text-center hover:bg-slate-700">Check n8n pricing →</a>
+              <a data-cta="affiliate" data-tool-id="make-com" data-cta-source="n8n-hero-make-alternative" href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white font-extrabold text-center hover:brightness-110">Prefer easier hosted automation? Try Make free →</a>
+            </div>
+            <p class="text-[11px] text-slate-500 leading-relaxed">The n8n button above is an official non-affiliate link. COSHUMA may earn a commission from an eligible Make.com purchase through the separately labeled verified partner link, at no extra cost to you.</p>
           </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim n8n Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/n8n.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="n8n Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
+          <aside class="w-full md:w-72 rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-5 space-y-4">
+            <div>
+              <div class="text-xs uppercase tracking-wider text-slate-500 font-bold">Best for</div>
+              <div class="mt-2 text-sm text-slate-200 leading-relaxed">Technical teams, AI automations, API-heavy workflows and buyers who value self-hosting or deeper control.</div>
+            </div>
+            <div class="border-t border-[#222538] pt-4">
+              <div class="text-xs uppercase tracking-wider text-slate-500 font-bold">Main trade-off</div>
+              <div class="mt-2 text-sm text-slate-300 leading-relaxed">Self-hosting adds infrastructure work, while complex workflows can have a steeper learning curve than simpler hosted automation tools.</div>
+            </div>
+          </aside>
         </div>
+      </section>
 
+      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-5">
+        <div>
+          <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Current buyer snapshot</div>
+          <h2 class="text-2xl md:text-3xl font-black text-white mt-1">n8n plans checked September 7, 2026</h2>
+          <p class="text-sm text-slate-400 mt-2">Figures below were rechecked against n8n's official pricing material. Prices exclude applicable tax and can change.</p>
+        </div>
+        <div class="overflow-x-auto rounded-2xl border border-[#2a2e42]">
+          <table class="w-full min-w-[760px] text-left text-sm">
+            <thead class="bg-[#0d1018] text-slate-300">
+              <tr><th class="p-4">Plan</th><th class="p-4">Current annual-view price</th><th class="p-4">Execution allowance</th><th class="p-4">Deployment / fit</th></tr>
+            </thead>
+            <tbody class="divide-y divide-[#25293b] text-slate-300">
+              <tr><td class="p-4 font-bold text-white">Community Edition</td><td class="p-4">Free</td><td class="p-4">Self-managed</td><td class="p-4">Self-hosted; best when you can run and maintain your own instance</td></tr>
+              <tr><td class="p-4 font-bold text-white">Starter</td><td class="p-4">€20/mo billed annually</td><td class="p-4">2,500 / month</td><td class="p-4">n8n Cloud · 1 shared project · 5 concurrent executions · 2,300 AI credits/mo</td></tr>
+              <tr><td class="p-4 font-bold text-white">Pro</td><td class="p-4">€50/mo billed annually</td><td class="p-4">10,000 / month</td><td class="p-4">n8n Cloud · 3 shared projects · 20 concurrent executions · higher AI allowance</td></tr>
+              <tr><td class="p-4 font-bold text-white">Business</td><td class="p-4">€667/mo billed annually</td><td class="p-4">40,000 / month</td><td class="p-4">Self-hosted · collaboration, SSO, environments and Git version control</td></tr>
+              <tr><td class="p-4 font-bold text-white">Enterprise</td><td class="p-4">Custom</td><td class="p-4">Custom</td><td class="p-4">Governance, compliance and enterprise-scale requirements</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <a href="https://n8n.io/pricing/" target="_blank" rel="noopener noreferrer" class="inline-flex justify-center px-5 py-3.5 rounded-xl border border-slate-600 text-slate-200 font-bold hover:bg-slate-800">Verify latest n8n pricing and limits →</a>
+      </section>
 
-      </div>
+      <section class="rounded-3xl border border-cyan-500/20 bg-cyan-500/5 p-6 md:p-8 space-y-5">
+        <div class="text-xs uppercase tracking-widest text-cyan-300 font-bold">Billing difference that matters</div>
+        <h2 class="text-2xl md:text-3xl font-black text-white">n8n bills around full workflow executions</h2>
+        <p class="text-sm md:text-base text-slate-300 leading-relaxed">n8n defines one execution as a run of the entire workflow, regardless of how many steps it contains. That can make usage easier to estimate for long multi-step workflows. Make uses credits, and standard module activity generally consumes credits as scenarios run. The cheaper platform therefore depends on workflow design, run frequency and feature usage—not just the sticker price.</p>
+        <div class="grid md:grid-cols-2 gap-4">
+          <div class="rounded-2xl border border-cyan-500/15 bg-[#0d1018] p-5"><h3 class="font-black text-white">n8n may fit better when</h3><ul class="mt-3 space-y-2 text-sm text-slate-300"><li>✓ You build long or API-heavy workflows</li><li>✓ Self-hosting is a real advantage</li><li>✓ You want deeper code and infrastructure control</li><li>✓ AI-agent workflows need custom logic</li></ul></div>
+          <div class="rounded-2xl border border-purple-500/20 bg-[#0d1018] p-5"><h3 class="font-black text-white">Make may fit better when</h3><ul class="mt-3 space-y-2 text-sm text-slate-300"><li>✓ You want a highly visual hosted experience</li><li>✓ You want to start on a permanent free tier</li><li>✓ Your priority is quick deployment with less infrastructure work</li><li>✓ Your team prefers a large no-code integration ecosystem</li></ul></div>
+        </div>
+      </section>
+
+      <section class="rounded-3xl border border-purple-500/25 bg-purple-500/5 p-6 md:p-8 space-y-5">
+        <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Lower-friction alternative</div>
+        <h2 class="text-2xl md:text-3xl font-black text-white">If self-hosting is not the goal, compare n8n with Make before paying</h2>
+        <p class="text-slate-300 leading-relaxed">Make currently offers a permanent Free plan with 1,000 credits per month. For buyers who mainly want visual cloud automation and do not need to manage infrastructure, that makes it a sensible side-by-side test before committing to a paid automation stack.</p>
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a href="/compare/n8n-vs-make-com.html" class="px-5 py-3.5 rounded-xl border border-purple-400/30 text-purple-200 font-bold text-center hover:bg-purple-500/10">Read n8n vs Make.com →</a>
+          <a data-cta="affiliate" data-tool-id="make-com" data-cta-source="n8n-mid-make-alternative" href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-extrabold text-center">Start Make.com Free via verified partner link →</a>
+        </div>
+        <p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if an eligible paid Make subscription is attributed through this verified link. The n8n links on this page are not affiliate links.</p>
+      </section>
+
+      <section class="grid md:grid-cols-2 gap-5">
+        <div class="rounded-3xl border border-emerald-500/20 bg-emerald-500/5 p-6">
+          <h2 class="text-xl font-black text-white">Choose n8n if…</h2>
+          <ul class="mt-4 space-y-3 text-sm text-slate-300">
+            <li>✓ You want a free self-hosted route and can maintain it.</li>
+            <li>✓ Workflow-level execution billing matches your usage better.</li>
+            <li>✓ You need advanced API logic, code or AI-agent orchestration.</li>
+            <li>✓ Hosting location and infrastructure control matter.</li>
+          </ul>
+        </div>
+        <div class="rounded-3xl border border-amber-500/20 bg-amber-500/5 p-6">
+          <h2 class="text-xl font-black text-white">Compare Make first if…</h2>
+          <ul class="mt-4 space-y-3 text-sm text-slate-300">
+            <li>• You do not want to operate a self-hosted instance.</li>
+            <li>• You want to prototype light workflows for free in a hosted product.</li>
+            <li>• Nontechnical collaborators will build most automations.</li>
+            <li>• Faster onboarding matters more than maximum control.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-4">
+        <h2 class="text-2xl font-black text-white">n8n free trial: what is currently included?</h2>
+        <p class="text-slate-300 leading-relaxed">The current n8n Cloud trial includes Pro-level functionality with limits including 1,000 executions and 5 concurrent executions. n8n says no credit card is required for the Cloud trial. The separate Business trial is self-hosted and does require a card, so check which trial you are starting.</p>
+      </section>
+
+      <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-4">
+        <h2 class="text-2xl font-black text-white">Bottom line</h2>
+        <p class="text-slate-300 leading-relaxed">n8n is a strong choice when control, self-hosting and complex workflows justify a little more setup. If your main goal is simply to get cloud automations running quickly, compare Make at the same time rather than choosing on feature count alone.</p>
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a data-cta="official" href="https://n8n.io/pricing/" target="_blank" rel="noopener noreferrer" class="px-6 py-4 rounded-xl border border-slate-600 bg-slate-800 text-white font-bold text-center hover:bg-slate-700">Check n8n official pricing →</a>
+          <a data-cta="affiliate" data-tool-id="make-com" data-cta-source="n8n-bottom-make-alternative" href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white font-extrabold text-center hover:brightness-110">Try Make.com Free via COSHUMA →</a>
+        </div>
+        <div class="pt-2 text-xs text-slate-500">Also see: <a href="/tool/make-com.html" class="text-purple-300 hover:underline">Make.com pricing & review</a> · <a href="/compare/n8n-vs-make-com.html" class="text-purple-300 hover:underline">n8n vs Make.com comparison</a></div>
+      </section>
     </main>
 
-    <!-- Footer -->
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
+    <footer class="border-t border-[#222538] bg-[#07080c]">
+      <div class="max-w-5xl mx-auto px-5 py-8 text-xs text-slate-500 flex flex-col sm:flex-row gap-3 justify-between">
+        <div>© 2026 COSHUMA. Independent AI & SaaS buyer guides.</div>
+        <div><a href="/privacy.html" class="hover:text-slate-300">Privacy</a> · <a href="/terms.html" class="hover:text-slate-300">Terms</a> · <a href="/sponsorship.html" class="hover:text-slate-300">Sponsorship policy</a></div>
       </div>
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
Revenue-first, zero-cost refresh of the stale n8n buyer page.

Evidence rechecked September 7, 2026:
- n8n's official pricing pages currently list Starter at €20/mo billed annually for 2.5K executions, Pro at €50/mo for 10K executions, Business at €667/mo self-hosted for 40K executions, and Enterprise custom.
- n8n Cloud trial currently requires no credit card; the free self-hosted Community Edition remains available.
- n8n now states that billing is based on full workflow executions rather than individual workflow steps.
- COSHUMA already has a verified customer-facing Make.com partner URL: `https://www.make.com/?pc=coshuma`.
- n8n's own affiliate program is live again, but COSHUMA does not have a verified n8n customer referral URL, so n8n CTAs remain official non-affiliate links.

Changes:
- replace remaining GlobalSaaSHub branding on the n8n tool page with COSHUMA
- refresh current n8n pricing, trial and Community Edition guidance
- add FAQ structured data and buyer-fit guidance
- add three position-tagged Make.com alternative CTAs using only the existing verified partner URL
- clearly separate official n8n links from sponsored Make links
- link into the existing n8n-vs-Make comparison and Make buyer page

No paid service, new subscription, guessed tracking parameter, or unsupported n8n affiliate URL is introduced.