### PR TITLE
Activate newly approved Gamma affiliate revenue path

### DIFF
--- a/projects/GlobalSaaSHub/index.html
+++ b/projects/GlobalSaaSHub/index.html
@@ -104,6 +104,7 @@
           <a href="/tool/castmagic.html">Castmagic pricing & review</a> ·
           <a href="/tool/fliki.html">Fliki pricing & review</a><br />
           <strong>Recently verified partner buyer guides:</strong><br />
+          <a href="/tool/gamma.html">Gamma AI free plan & review</a> ·
           <a href="/tool/customgpt-ai.html">CustomGPT.ai pricing & trial</a> ·
           <a href="/tool/bookyourdata.html">Bookyourdata pricing & free leads</a> ·
           <a href="/tool/unbounce.html">Unbounce pricing & partner discount</a><br />

--- a/projects/GlobalSaaSHub/public/tool/gamma.html
+++ b/projects/GlobalSaaSHub/public/tool/gamma.html
@@ -1,168 +1,152 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Gamma Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="AI-powered presentation and document generator creating interactive web slides and pages.... Discover features, pricing (See official pricing), and official links for Gamma on GlobalSaaSHub." />
-    <link rel="canonical" href="https://coshuma.com/tool/gamma.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://coshuma.com/tool/gamma.html" />
-    <meta property="og:title" content="Gamma Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="AI-powered presentation and document generator creating interactive web slides and pages.... Check rating, pricing, and features." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gamma AI Review 2026: Free Plan, Plus, Pro & Ultra | COSHUMA</title>
+  <meta name="description" content="Gamma AI buyer guide for 2026. Compare the Free, Plus, Pro and Ultra plans, presentation features, exports, branding controls and the best plan fit before you subscribe." />
+  <link rel="canonical" href="https://coshuma.com/tool/gamma.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="COSHUMA" />
+  <meta property="og:url" content="https://coshuma.com/tool/gamma.html" />
+  <meta property="og:title" content="Gamma AI Review 2026: Free Plan, Plus, Pro & Ultra | COSHUMA" />
+  <meta property="og:description" content="A practical Gamma AI buyer guide covering the current Free, Plus, Pro and Ultra plan differences." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"SoftwareApplication",
+    "name":"Gamma",
+    "applicationCategory":"BusinessApplication",
+    "operatingSystem":"Web",
+    "url":"https://gamma.app/",
+    "description":"AI-powered workspace for creating presentations, documents, websites, social content and visual assets."
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"Can I try Gamma without a credit card?","acceptedAnswer":{"@type":"Answer","text":"Yes. Gamma's official pricing page currently says no credit card is required and offers a Free plan."}},
+      {"@type":"Question","name":"What can Gamma Free create?","acceptedAnswer":{"@type":"Answer","text":"Gamma's Free plan can create simple presentations, documents, websites, social content and images, with up to 10 slides per prompt. It can import PDF and PPTX and export to PDF, PPTX, PNG and Google Slides."}},
+      {"@type":"Question","name":"When does Gamma Pro make more sense than Plus?","acceptedAnswer":{"@type":"Answer","text":"Pro is the stronger fit when you need premium AI image models, custom branding and fonts, detailed analytics, advanced sharing, custom domains or API access."}}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="/affiliate-attribution.js" defer></script>
+  <style>body{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}</style>
+</head>
+<body class="bg-[#08090d] text-slate-100 antialiased">
+  <header class="border-b border-white/10 bg-[#0c0e14]">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-5 py-4">
+      <a href="/" class="text-xl font-black tracking-tight text-white">COSHUMA</a>
+      <a href="/" class="text-sm font-bold text-slate-400 hover:text-white">← All tools</a>
+    </div>
+  </header>
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "Gamma",
-      "operatingSystem": "Web",
-      "applicationCategory": "Creator Tools",
-      "description": "AI-powered presentation and document generator creating interactive web slides and pages."
-    }
-    </script>
+  <main class="mx-auto max-w-6xl px-5 py-12 sm:py-16">
+    <nav class="mb-7 text-sm text-slate-500"><a class="hover:text-white" href="/">Home</a> <span class="px-2">/</span> Gamma</nav>
 
-    <!-- Tailwind & Fonts -->
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+    <section class="grid gap-8 lg:grid-cols-[1.35fr_.65fr] lg:items-start">
+      <div>
+        <div class="mb-5 inline-flex rounded-full border border-violet-400/20 bg-violet-400/10 px-3 py-1 text-xs font-bold text-violet-200">Current plan structure checked Sep 7, 2026</div>
+        <h1 class="text-4xl font-black tracking-[-0.04em] text-white sm:text-6xl">Gamma AI Review 2026</h1>
+        <p class="mt-5 max-w-3xl text-lg leading-8 text-slate-300">Gamma turns prompts and source material into presentations, documents, websites and visual content. The low-risk starting point is the Free plan; move up only when you need more slides per prompt, removed Gamma branding, premium AI models, analytics, custom domains or API access.</p>
+        <div class="mt-7 flex flex-col gap-3 sm:flex-row">
+          <a data-cta="affiliate" data-tool-id="gamma" data-cta-source="gamma_hero_free" href="https://try.gamma.app/pu20lusdpn1j" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-violet-600 px-6 py-4 text-center font-black text-white hover:bg-violet-500">Start Gamma Free →</a>
+          <a data-cta="official" href="https://gamma.app/pricing" target="_blank" rel="noopener noreferrer" class="rounded-xl border border-white/15 bg-white/[0.04] px-6 py-4 text-center font-bold text-slate-200 hover:bg-white/[0.08]">Check live Gamma pricing →</a>
+        </div>
+        <p class="mt-3 text-xs leading-5 text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if you sign up or purchase through the sponsored Gamma link, at no extra cost to you.</p>
       </div>
-    </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
-          <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=gamma.app&sz=128" alt="Gamma logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
-            <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Creator Tools</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Gamma</h1>
-            </div>
-          </div>
-
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
+      <aside class="rounded-3xl border border-white/10 bg-[#11131a] p-6">
+        <div class="flex items-center gap-4">
+          <img src="https://www.google.com/s2/favicons?domain=gamma.app&sz=128" alt="Gamma logo" class="h-14 w-14 rounded-2xl border border-white/10 bg-slate-900 p-2" />
+          <div><div class="text-xs font-black uppercase tracking-widest text-violet-300">Quick verdict</div><div class="mt-1 text-2xl font-black">Best for fast visual first drafts</div></div>
         </div>
+        <p class="mt-4 text-sm leading-6 text-slate-400">Use Gamma when speed, AI-assisted layout and shareable visual output matter more than building every slide manually. Test your real workflow on Free before paying.</p>
+      </aside>
+    </section>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">AI-powered presentation and document generator creating interactive web slides and pages.</p>
-        </div>
-
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> AI Presentation Generator</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Interactive Web Cards</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> One-Click Styling</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Export to PDF & PPTX</div>
-          </div>
-        </div>
-
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Gamma</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/krater.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=krater.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Krater</span></div><span class="text-[10px] font-extrabold text-emerald-400">Pro plan starting at $200/year (billed annually)</span></a>
-<a href="/tool/merlin-ai.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=merlin.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Merlin AI</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/babylovegrowth-ai.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=babylovegrowth.ai&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">BabyLoveGrowth.ai</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
-
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://gamma.app/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Gamma Site</span><span>→</span></a>
-        </div>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Gamma?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Gamma Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/gamma.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Gamma Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
+    <section class="mt-14">
+      <div class="text-xs font-bold uppercase tracking-[0.2em] text-violet-300">Plan fit</div>
+      <h2 class="mt-2 text-3xl font-black">Which Gamma plan should you start with?</h2>
+      <div class="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <article class="rounded-2xl border border-emerald-400/25 bg-emerald-400/[0.06] p-5">
+          <div class="text-xs font-black uppercase tracking-widest text-emerald-300">Start here</div><h3 class="mt-2 text-2xl font-black">Free</h3>
+          <p class="mt-3 text-sm leading-6 text-slate-300">Up to 10 slides per prompt, basic presentations/docs/websites/social/images, PDF & PPTX import, and PDF/PPTX/PNG/Google Slides export.</p>
+        </article>
+        <article class="rounded-2xl border border-white/10 bg-white/[0.035] p-5">
+          <div class="text-xs font-black uppercase tracking-widest text-slate-400">More output</div><h3 class="mt-2 text-2xl font-black">Plus</h3>
+          <p class="mt-3 text-sm leading-6 text-slate-300">Adds up to 100 slides per prompt, removal of Gamma branding and advanced AI image models.</p>
+        </article>
+        <article class="rounded-2xl border border-violet-400/25 bg-violet-400/[0.06] p-5">
+          <div class="text-xs font-black uppercase tracking-widest text-violet-300">Brand & workflow</div><h3 class="mt-2 text-2xl font-black">Pro</h3>
+          <p class="mt-3 text-sm leading-6 text-slate-300">Adds premium AI image models, custom branding/fonts, detailed analytics, advanced sharing, up to 10 custom domains and API access.</p>
+        </article>
+        <article class="rounded-2xl border border-cyan-400/25 bg-cyan-400/[0.06] p-5">
+          <div class="text-xs font-black uppercase tracking-widest text-cyan-300">Heavy AI use</div><h3 class="mt-2 text-2xl font-black">Ultra</h3>
+          <p class="mt-3 text-sm leading-6 text-slate-300">Adds 20× more AI usage, Gamma's most advanced text/image/video models, up to 100 custom domains and early feature access.</p>
+        </article>
       </div>
-    </main>
-
-    <!-- Footer -->
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
+      <div class="mt-6 rounded-2xl border border-violet-400/20 bg-violet-400/[0.06] p-5 sm:flex sm:items-center sm:justify-between sm:gap-6">
+        <div><div class="font-black text-white">Not sure which tier fits?</div><p class="mt-1 text-sm text-slate-400">Gamma currently says no credit card is required. Build one real presentation on Free first, then upgrade only if a paid-only feature blocks your workflow.</p></div>
+        <a data-cta="affiliate" data-tool-id="gamma" data-cta-source="gamma_plan_fit_free" href="https://try.gamma.app/pu20lusdpn1j" target="_blank" rel="sponsored noopener noreferrer" class="mt-4 block shrink-0 rounded-xl bg-violet-600 px-5 py-3 text-center font-black text-white hover:bg-violet-500 sm:mt-0">Try Gamma Free →</a>
       </div>
-    </footer>
-  </body>
+    </section>
+
+    <section class="mt-14 grid gap-6 lg:grid-cols-2">
+      <article class="rounded-3xl border border-white/10 bg-[#11131a] p-6 sm:p-8">
+        <h2 class="text-2xl font-black">Gamma is a strong fit when…</h2>
+        <ul class="mt-5 space-y-3 text-sm leading-6 text-slate-300">
+          <li>✓ You want a presentation or visual document draft quickly from a prompt or existing material.</li>
+          <li>✓ You need PPTX/PDF imports and common export formats instead of a web-only result.</li>
+          <li>✓ Your team values consistent branding, analytics or custom domains on higher tiers.</li>
+          <li>✓ You want API access in the same product you use for visual content creation.</li>
+        </ul>
+      </article>
+      <article class="rounded-3xl border border-white/10 bg-[#11131a] p-6 sm:p-8">
+        <h2 class="text-2xl font-black">Check alternatives when…</h2>
+        <ul class="mt-5 space-y-3 text-sm leading-6 text-slate-300">
+          <li>• Your workflow requires pixel-level manual slide control from the beginning.</li>
+          <li>• You need a specialized presentation product rather than Gamma's broader docs/sites/social format mix.</li>
+          <li>• Your organization requires a different collaboration, template or export workflow.</li>
+        </ul>
+        <a href="/tool/decktopus.html" class="mt-5 inline-flex font-bold text-violet-300 hover:text-violet-200">Compare another AI presentation option: Decktopus →</a>
+      </article>
+    </section>
+
+    <section class="mt-14 rounded-3xl border border-white/10 bg-white/[0.035] p-6 sm:p-8">
+      <h2 class="text-2xl font-black">What to verify before paying</h2>
+      <p class="mt-3 max-w-4xl text-sm leading-7 text-slate-300">Gamma's pricing page can change by billing cycle, workspace type or future product updates. COSHUMA therefore does not hard-code a paid price here when the current public page does not reliably expose a single price in its static response. Check Gamma's live pricing page immediately before purchase, then decide based on the feature that actually forces the upgrade.</p>
+      <a data-cta="official" href="https://gamma.app/pricing" target="_blank" rel="noopener noreferrer" class="mt-5 inline-flex rounded-xl border border-white/15 px-5 py-3 font-bold text-white hover:bg-white/[0.06]">Open official pricing →</a>
+    </section>
+
+    <section class="mt-14">
+      <h2 class="text-3xl font-black">Gamma FAQ</h2>
+      <div class="mt-6 space-y-4">
+        <details class="rounded-2xl border border-white/10 bg-[#11131a] p-5"><summary class="cursor-pointer font-black">Can I use Gamma without a credit card?</summary><p class="mt-3 text-sm leading-6 text-slate-400">Yes. Gamma's current official pricing page states that no credit card is required and offers a Free plan.</p></details>
+        <details class="rounded-2xl border border-white/10 bg-[#11131a] p-5"><summary class="cursor-pointer font-black">Can Gamma export to PowerPoint?</summary><p class="mt-3 text-sm leading-6 text-slate-400">Gamma lists PPTX among its export formats on the Free plan. It also lists PDF, PNG and Google Slides exports.</p></details>
+        <details class="rounded-2xl border border-white/10 bg-[#11131a] p-5"><summary class="cursor-pointer font-black">What is the practical difference between Plus and Pro?</summary><p class="mt-3 text-sm leading-6 text-slate-400">Plus mainly expands generation and removes Gamma branding. Pro adds premium image models plus business-oriented controls such as custom branding/fonts, detailed analytics, advanced sharing, custom domains and API access.</p></details>
+      </div>
+    </section>
+
+    <section class="mt-14 rounded-3xl border border-violet-400/25 bg-gradient-to-br from-violet-500/15 to-cyan-500/5 p-7 sm:p-9">
+      <div class="max-w-3xl"><div class="text-xs font-black uppercase tracking-widest text-violet-300">Low-risk next step</div><h2 class="mt-2 text-3xl font-black">Test Gamma on a real presentation before you subscribe</h2><p class="mt-3 leading-7 text-slate-300">The best conversion test is also the safest buyer test: use the Free plan for one actual project, check output quality and editing friction, then pay only if Plus, Pro or Ultra solves a specific limitation.</p></div>
+      <div class="mt-6 flex flex-col gap-3 sm:flex-row">
+        <a data-cta="affiliate" data-tool-id="gamma" data-cta-source="gamma_bottom_free" href="https://try.gamma.app/pu20lusdpn1j" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-violet-600 px-6 py-4 text-center font-black text-white hover:bg-violet-500">Start Gamma Free →</a>
+        <a href="https://gamma.app/pricing" target="_blank" rel="noopener noreferrer" class="rounded-xl border border-white/15 px-6 py-4 text-center font-bold text-slate-200 hover:bg-white/[0.06]">Verify pricing first →</a>
+      </div>
+    </section>
+
+    <section class="mt-10 rounded-2xl border border-purple-500/20 bg-[#11131a] p-6">
+      <div class="font-black text-purple-200">Are you the founder or team behind Gamma?</div>
+      <p class="mt-2 text-sm leading-6 text-slate-400">Claim the COSHUMA profile to manage verified company information and profile details. Sponsorship or profile purchases never guarantee editorial ratings or ranking positions.</p>
+      <a href="/#submit" class="mt-4 inline-flex rounded-xl bg-purple-600 px-4 py-2.5 text-xs font-black text-white hover:bg-purple-500">Claim Gamma Profile ($49/yr) →</a>
+    </section>
+  </main>
+
+  <footer class="mt-14 border-t border-white/10 bg-[#07080c] py-8 text-center text-xs text-slate-500">© 2026 COSHUMA. Independent AI & SaaS buyer guides.</footer>
+</body>
 </html>
-

--- a/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
+++ b/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
@@ -20,6 +20,7 @@ const verified = {
   moosend: 'https://trymoo.moosend.com/6eappdpw04pw',
   chatbase: 'https://link.chatbase.co/sang-kwon-an',
   taskade: 'https://www.taskade.com/?via=7zzjo7',
+  gamma: 'https://try.gamma.app/pu20lusdpn1j',
 };
 
 const verifiedAt = {
@@ -27,6 +28,7 @@ const verifiedAt = {
   moosend: '2026-09-01T04:48:36+09:00',
   chatbase: '2026-09-06T01:50:28+09:00',
   taskade: '2026-09-06T00:00:00+09:00',
+  gamma: '2026-09-07T05:19:08+09:00',
 };
 
 // Current official product data that must remain correct in the production build


### PR DESCRIPTION
Revenue-first, zero-cost activation of a newly approved affiliate program.

Evidence checked Sep 7, 2026:
- Gamma affiliate approval email sent to support@coshuma.com confirms approval and the exact unique customer-facing affiliate link `https://try.gamma.app/pu20lusdpn1j`.
- The same approval email states a 25% commission for the first year for referred customers.
- Gamma's official pricing page currently lists Free, Plus, Pro and Ultra, says no credit card is required, and documents the current plan feature differences.

Changes:
- add the exact verified Gamma affiliate URL to the production affiliate sync
- replace the stale GlobalSaaSHub Gamma page with a COSHUMA buyer-intent landing page
- add three position-tagged affiliate CTAs plus explicit disclosure and attribution
- keep official pricing separate from the sponsored referral link
- avoid hard-coding paid prices because Gamma's current public static pricing response does not expose one reliable monetary figure
- surface Gamma in the homepage crawler fallback as a newly verified partner guide
- preserve the existing COSHUMA $49/year profile-claim direct-revenue path

No paid service, new subscription, guessed tracking parameter or generic dashboard URL is introduced.