### PR TITLE
Turn verified Moosend traffic into direct affiliate revenue

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/moosend.html
+++ b/projects/GlobalSaaSHub/public/tool/moosend.html
@@ -1,168 +1,156 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Moosend Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="A powerful and user-friendly email marketing and marketing automation platform, perfect for businesses aiming to engage their audience effectively.... Discover features, pricing (See official pricing), and official links for Moosend on GlobalSaaSHub." />
-    <link rel="canonical" href="https://coshuma.com/tool/moosend.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://coshuma.com/tool/moosend.html" />
-    <meta property="og:title" content="Moosend Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="A powerful and user-friendly email marketing and marketing automation platform, perfect for businesses aiming to engage their audience effectively.... Check rating, pricing, and features." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Moosend Pricing 2026: 30-Day Trial, Plans & Review | COSHUMA</title>
+  <meta name="description" content="Moosend pricing and review for 2026: 30-day no-card trial, Pro, Moosend+ and Enterprise plans, email credits, automation features, and a verified COSHUMA affiliate link." />
+  <link rel="canonical" href="https://coshuma.com/tool/moosend.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://coshuma.com/tool/moosend.html" />
+  <meta property="og:title" content="Moosend Pricing 2026: 30-Day Trial, Plans & Review | COSHUMA" />
+  <meta property="og:description" content="Compare Moosend's current trial, subscription and credit options before choosing an email-marketing plan." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"SoftwareApplication",
+    "name":"Moosend",
+    "applicationCategory":"BusinessApplication",
+    "operatingSystem":"Web",
+    "url":"https://moosend.com/",
+    "description":"Email marketing and automation platform with campaigns, workflows, landing pages, forms, audience management, analytics and transactional email options."
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"Does Moosend offer a free trial?","acceptedAnswer":{"@type":"Answer","text":"Yes. Moosend's official pricing page currently advertises a 30-day free trial with no credit card required."}},
+      {"@type":"Question","name":"Is Moosend permanently free?","acceptedAnswer":{"@type":"Answer","text":"No permanent free plan is presented on the current pricing page. After the 30-day trial, customers can choose a subscription plan or purchase email credits."}},
+      {"@type":"Question","name":"How is Moosend subscription pricing calculated?","acceptedAnswer":{"@type":"Answer","text":"Subscription pricing scales with active subscriber count. Moosend currently offers monthly, biannual and annual billing, with the pricing page advertising 15% savings for biannual billing and 20% for annual billing."}},
+      {"@type":"Question","name":"What is Moosend+?","acceptedAnswer":{"@type":"Answer","text":"Moosend+ is a custom plan that includes Pro features plus selected enterprise add-ons such as transactional email, dedicated IPs, SSO/SAML, custom reports or additional team members."}}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen bg-[#0b0c10]">
+<header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50">
+  <div class="max-w-6xl mx-auto px-5 py-4 flex items-center justify-between">
+    <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white">C</div><span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span></a>
+    <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">← All AI & SaaS Tools</a>
+  </div>
+</header>
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "Moosend",
-      "operatingSystem": "Web",
-      "applicationCategory": "Email & Outreach",
-      "description": "A powerful and user-friendly email marketing and marketing automation platform, perfect for businesses aiming to engage their audience effectively."
-    }
-    </script>
-
-    <!-- Tailwind & Fonts -->
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+<main class="max-w-5xl mx-auto px-5 py-12 space-y-8">
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-10 shadow-2xl">
+    <div class="grid grid-cols-1 lg:grid-cols-[1.45fr_.75fr] gap-7 items-start">
+      <div>
+        <div class="text-xs font-extrabold uppercase tracking-[0.18em] text-purple-300">EMAIL MARKETING · AUTOMATION · VERIFIED SEP 7, 2026</div>
+        <h1 class="text-4xl md:text-5xl font-black tracking-tight mt-3">Moosend pricing & review: test the full workflow before paying</h1>
+        <p class="text-slate-300 mt-5 leading-relaxed">Moosend combines email campaigns, automation workflows, landing pages, subscription forms, audience management and reporting. Its current official pricing page offers a <strong class="text-white">30-day free trial with no credit card required</strong>, making the trial the lowest-risk first step before choosing a subscriber-based subscription.</p>
+        <div class="flex flex-col sm:flex-row gap-3 mt-7">
+          <a data-cta="affiliate" data-tool-id="moosend" data-cta-source="moosend-hero-trial" href="https://trymoo.moosend.com/6eappdpw04pw" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-extrabold text-center">Start Moosend via verified COSHUMA link →</a>
+          <a data-cta="official" href="https://moosend.com/pricing/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-slate-800 border border-slate-600 text-white font-extrabold text-center">Check official pricing →</a>
+        </div>
+        <p class="text-[11px] text-slate-500 mt-3">Affiliate disclosure: COSHUMA may earn a commission if you become a paying Moosend customer after using the verified partner link, at no extra cost to you.</p>
       </div>
-    </header>
+      <aside class="rounded-2xl border border-emerald-500/25 bg-emerald-500/5 p-5 space-y-3">
+        <div class="text-xs uppercase tracking-wider font-bold text-emerald-300">Fast decision</div>
+        <p class="text-sm text-slate-300"><strong class="text-white">Good fit:</strong> teams that want campaigns, automation, landing pages and forms in one email-marketing stack.</p>
+        <p class="text-sm text-slate-300"><strong class="text-white">Test first:</strong> import a representative audience, build one real automation and send a sample campaign during the 30-day trial.</p>
+        <p class="text-sm text-slate-300"><strong class="text-white">Watch cost:</strong> subscription pricing increases with active subscriber count, so compare at your actual list size.</p>
+      </aside>
+    </div>
+  </section>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
-          <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=moosend.com&sz=128" alt="Moosend logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
-            <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Email & Outreach</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Moosend</h1>
-            </div>
-          </div>
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-9 space-y-6">
+    <div>
+      <h2 class="text-2xl font-black">Current Moosend plan structure</h2>
+      <p class="text-sm text-slate-400 mt-2">Checked against Moosend's official pricing page on September 7, 2026. Exact subscription price depends on contact count; verify the live selector before checkout.</p>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <article class="rounded-2xl bg-[#181a29] border border-purple-500/35 p-5 space-y-3">
+        <div class="text-xs font-bold uppercase text-purple-300">Pro</div>
+        <h3 class="text-xl font-black">Core email marketing</h3>
+        <ul class="text-sm text-slate-300 space-y-2"><li>✓ Unlimited email campaigns / sends</li><li>✓ Marketing automation</li><li>✓ Landing pages and subscription forms</li><li>✓ Reporting, A/B testing and API access</li><li>✓ Up to 5 team members shown in plan comparison</li></ul>
+      </article>
+      <article class="rounded-2xl bg-[#181a29] border border-blue-500/30 p-5 space-y-3">
+        <div class="text-xs font-bold uppercase text-blue-300">Moosend+</div>
+        <h3 class="text-xl font-black">Custom add-on mix</h3>
+        <p class="text-sm text-slate-300">Includes Pro features, then lets a business select enterprise add-ons such as transactional email, dedicated IPs, custom reports, hosted files, SSO/SAML or additional team members.</p>
+      </article>
+      <article class="rounded-2xl bg-[#181a29] border border-slate-600 p-5 space-y-3">
+        <div class="text-xs font-bold uppercase text-slate-400">Enterprise</div>
+        <h3 class="text-xl font-black">Advanced requirements</h3>
+        <p class="text-sm text-slate-300">Custom plan for organizations needing advanced support, account management, security, deliverability strategy and enterprise-level features.</p>
+      </article>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
+      <div class="rounded-xl bg-[#0f111a] border border-[#25283a] p-4"><strong class="text-white">Monthly</strong><div class="text-slate-400 mt-1">Flexible billing; pricing depends on list size.</div></div>
+      <div class="rounded-xl bg-[#0f111a] border border-[#25283a] p-4"><strong class="text-white">Biannual</strong><div class="text-slate-400 mt-1">Official page currently advertises 15% savings.</div></div>
+      <div class="rounded-xl bg-[#0f111a] border border-[#25283a] p-4"><strong class="text-white">Annual</strong><div class="text-slate-400 mt-1">Official page currently advertises 20% savings.</div></div>
+    </div>
+    <p class="text-xs text-slate-400 leading-relaxed">Moosend's own current marketing guidance also describes paid plans as starting at $9/month. Because the live subscription total is contact-count dependent, treat that as a starting-point reference rather than a guaranteed checkout price for every account.</p>
+  </section>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
-        </div>
+  <section class="grid grid-cols-1 lg:grid-cols-2 gap-5">
+    <div class="rounded-3xl border border-[#222538] bg-[#131520] p-7 space-y-4">
+      <h2 class="text-2xl font-black">What to validate during the free trial</h2>
+      <ul class="text-sm text-slate-300 space-y-3"><li>✓ Build the newsletter template you would actually send.</li><li>✓ Create one real automation workflow rather than only browsing features.</li><li>✓ Test landing-page or form capture if lead generation matters.</li><li>✓ Review reporting, segmentation and integration fit with your current stack.</li><li>✓ Estimate the paid tier using your real active-subscriber count.</li></ul>
+    </div>
+    <div class="rounded-3xl border border-purple-500/35 bg-purple-500/5 p-7 space-y-4">
+      <div class="text-xs uppercase tracking-[0.16em] font-bold text-purple-300">LOW-RISK CONVERSION PATH</div>
+      <h2 class="text-2xl font-black">Start with the no-card trial, then price your real list</h2>
+      <p class="text-sm text-slate-300 leading-relaxed">Moosend's affiliate team specifically recommends sending prospects to trial and pricing-oriented destinations instead of relying only on a generic homepage. COSHUMA therefore keeps the exact verified referral URL as the monetized route while linking separately to Moosend's official pricing page for independent price verification.</p>
+      <a data-cta="affiliate" data-tool-id="moosend" data-cta-source="moosend-plan-fit" href="https://trymoo.moosend.com/6eappdpw04pw" target="_blank" rel="sponsored noopener noreferrer" class="block px-5 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-center font-extrabold">Try Moosend via verified referral link →</a>
+    </div>
+  </section>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">A powerful and user-friendly email marketing and marketing automation platform, perfect for businesses aiming to engage their audience effectively.</p>
-        </div>
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-9 space-y-5">
+    <h2 class="text-2xl font-black">Subscription vs email credits</h2>
+    <div class="overflow-x-auto">
+      <table class="w-full text-sm text-left">
+        <thead class="text-slate-400 border-b border-[#2a2d42]"><tr><th class="py-3 pr-4">Option</th><th class="py-3 pr-4">How it works</th><th class="py-3">Best fit</th></tr></thead>
+        <tbody class="text-slate-300 divide-y divide-[#202334]"><tr><td class="py-4 pr-4 font-bold text-white">Subscription</td><td class="py-4 pr-4">Billed by active-subscriber tier; monthly, biannual or annual billing.</td><td class="py-4">Regular email programs and ongoing automation.</td></tr><tr><td class="py-4 pr-4 font-bold text-white">Email credits</td><td class="py-4 pr-4">One credit sends one email to one recipient; purchased credits do not expire according to current pricing documentation.</td><td class="py-4">Seasonal or occasional senders who do not want a recurring subscription.</td></tr></tbody>
+      </table>
+    </div>
+  </section>
 
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Email Campaign Designer</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Marketing Automation Workflows</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Landing Pages & Subscription Forms</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Detailed Analytics & Reporting</div>
-          </div>
-        </div>
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-9 space-y-5">
+    <h2 class="text-2xl font-black">Before you choose</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+      <div class="rounded-2xl bg-emerald-500/5 border border-emerald-500/20 p-5"><h3 class="font-black text-emerald-300">Moosend makes sense if…</h3><ul class="mt-3 space-y-2 text-slate-300"><li>• You need email campaigns plus automation in one product.</li><li>• Landing pages and forms are part of your list-growth workflow.</li><li>• You prefer testing without a card before committing.</li><li>• Subscriber-based pricing matches your growth model.</li></ul></div>
+      <div class="rounded-2xl bg-amber-500/5 border border-amber-500/20 p-5"><h3 class="font-black text-amber-300">Check alternatives if…</h3><ul class="mt-3 space-y-2 text-slate-300"><li>• You need a permanent free plan rather than a time-limited trial.</li><li>• Your main requirement is sales CRM rather than email marketing.</li><li>• Your list size makes subscriber-based pricing uneconomical.</li><li>• You need a specific integration that must be validated before migration.</li></ul></div>
+    </div>
+    <div class="flex flex-col sm:flex-row gap-3">
+      <a href="/tool/aweber.html" class="px-5 py-3 rounded-xl bg-[#181a29] border border-[#2a2d42] font-bold text-purple-300 text-center">Compare AWeber →</a>
+      <a href="/tool/convertkit.html" class="px-5 py-3 rounded-xl bg-[#181a29] border border-[#2a2d42] font-bold text-purple-300 text-center">Compare Kit →</a>
+    </div>
+  </section>
 
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
+  <section class="rounded-3xl bg-gradient-to-r from-purple-500/10 to-indigo-500/10 border border-purple-500/30 p-7 md:p-9 text-center space-y-4">
+    <h2 class="text-2xl md:text-3xl font-black">Use the 30 days to validate one real campaign workflow</h2>
+    <p class="text-sm text-slate-300 max-w-2xl mx-auto">The lowest-risk path is to test campaign creation, automation and list management first, then check the live price for your actual subscriber count before purchasing.</p>
+    <a data-cta="affiliate" data-tool-id="moosend" data-cta-source="moosend-bottom-trial" href="https://trymoo.moosend.com/6eappdpw04pw" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-extrabold">Start Moosend via verified COSHUMA link →</a>
+    <div class="text-[11px] text-slate-500">Exact referral URL verified from Moosend's affiliate welcome email to COSHUMA. Official pricing remains a separate non-affiliate verification destination.</div>
+  </section>
 
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
-        </div>
+  <section class="rounded-3xl bg-[#181a29]/80 border border-purple-500/30 p-6 space-y-4">
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3"><div><div class="text-sm font-black text-purple-300">Are you the founder or authorized representative of Moosend?</div><p class="text-xs text-slate-400 mt-1">Claim the COSHUMA profile to manage verified business information and badge details.</p></div><span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-1 rounded-full border border-purple-500/30">Founder Verification</span></div>
+    <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400">⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.</div>
+    <a href="/#submit" class="inline-flex px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs">⚡ Claim Moosend Profile ($49/yr)</a>
+  </section>
 
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Moosend</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/convertkit.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=kit.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Kit (formerly ConvertKit)</span></div><span class="text-[10px] font-extrabold text-emerald-400">Free plan; Creator plan from $33/month for 1,000 subscribers</span></a>
-<a href="/tool/aweber.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=aweber.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">AWeber</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/rytr.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=rytr.me&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Rytr</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
+  <p class="text-xs text-slate-500 leading-relaxed">Source check: Moosend official pricing page and current product documentation, verified September 7, 2026. Affiliate URL verification is based on Moosend's direct affiliate welcome email to COSHUMA. Product pricing and terms can change; verify the live vendor checkout before purchasing.</p>
+</main>
 
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://moosend.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Moosend Site</span><span>→</span></a>
-        </div>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Moosend?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Moosend Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/moosend.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Moosend Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
-      </div>
-    </main>
-
-    <!-- Footer -->
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
-    </footer>
-  </body>
+<footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Global AI & SaaS decision platform.</div></footer>
+<script src="/affiliate-attribution.js" defer></script>
+</body>
 </html>
-


### PR DESCRIPTION
Revenue-first, zero-cost refresh of an existing approved partner page.

Evidence rechecked Sep 7, 2026:
- Moosend's affiliate welcome email to COSHUMA explicitly supplies the customer-facing referral URL `https://trymoo.moosend.com/6eappdpw04pw`.
- Moosend's follow-up affiliate guidance recommends trial/pricing-oriented destinations over relying only on a generic homepage.
- Moosend's current official pricing page advertises a 30-day free trial with no credit card required; current plans are Pro, Moosend+ and Enterprise, with 15% biannual and 20% annual savings shown.
- The existing COSHUMA Moosend page was still stale GlobalSaaSHub content and linked only to the non-affiliate homepage, despite the verified referral URL already being stored in production sync.

Changes:
- replace stale GlobalSaaSHub branding and placeholder review copy with a current COSHUMA buyer guide
- add three position-tagged monetized CTAs using only the exact verified Moosend referral URL
- keep official pricing as a clearly separate non-affiliate verification link
- add current trial, plan, billing, credit and buyer-fit guidance plus FAQ structured data
- add affiliate attribution script
- preserve the existing $49/year profile-claim direct-revenue route and editorial-independence disclosure

No paid service, new subscription, guessed deep link, unsupported tracking parameter or duplicate affiliate application is introduced.