### PR TITLE
Monetize Moosend comparison traffic with verified partner CTAs

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/aweber-vs-moosend.html
+++ b/projects/GlobalSaaSHub/public/compare/aweber-vs-moosend.html
@@ -1,170 +1,38 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AWeber vs Moosend Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of AWeber vs Moosend. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AWeber vs Moosend 2026: Pricing, Trial & Best Fit | COSHUMA</title>
+  <meta name="description" content="AWeber vs Moosend in 2026: compare current pricing, trials, subscriber limits, automation and the best email-marketing fit, with verified COSHUMA partner links." />
+  <link rel="canonical" href="https://coshuma.com/compare/aweber-vs-moosend.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/aweber-vs-moosend.html" />
+  <meta property="og:title" content="AWeber vs Moosend 2026: Pricing, Trial & Best Fit | COSHUMA" />
+  <meta property="og:description" content="Choose between AWeber and Moosend using current trial, pricing and workflow differences." />
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"AWeber vs Moosend 2026","url":"https://coshuma.com/compare/aweber-vs-moosend.html","isPartOf":{"@type":"WebSite","name":"COSHUMA","url":"https://coshuma.com/"},"about":[{"@type":"SoftwareApplication","name":"AWeber","url":"https://coshuma.com/tool/aweber.html"},{"@type":"SoftwareApplication","name":"Moosend","url":"https://coshuma.com/tool/moosend.html"}]}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Which has the longer free trial, AWeber or Moosend?","acceptedAnswer":{"@type":"Answer","text":"AWeber currently advertises a 14-day free trial, while Moosend currently advertises a 30-day free trial with no credit card required."}},{"@type":"Question","name":"Which is better for a small email list?","acceptedAnswer":{"@type":"Answer","text":"Both scale pricing with list size. AWeber publishes clear Lite and Plus subscriber tiers; Moosend uses a contact-count selector and also offers email credits for occasional sending. Compare the live price at your actual list size."}}]}</script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen bg-[#0b0c10]">
+<header class="border-b border-[#222538] bg-[#07080c]/90 sticky top-0 z-50"><div class="max-w-5xl mx-auto px-5 py-4 flex items-center justify-between"><a href="/" class="font-black text-white text-lg">COSHUMA</a><a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">← Buyer guides</a></div></header>
+<main class="max-w-5xl mx-auto px-5 py-12 space-y-8">
+  <section class="text-center space-y-4"><div class="text-xs font-bold tracking-[0.18em] text-purple-300">EMAIL MARKETING COMPARISON · VERIFIED SEP 7, 2026</div><h1 class="text-4xl md:text-5xl font-black">AWeber vs Moosend</h1><p class="text-slate-300 max-w-3xl mx-auto">Both cover campaigns, automations and landing pages, but their trial length, plan structure and list economics differ. This page uses separately verified partner links for both products and keeps pricing verification grounded in each vendor's current official material.</p></section>
 
-    <link rel="canonical" href="https://coshuma.com/compare/aweber-vs-moosend.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/aweber-vs-moosend.html" />
-    <meta property="og:title" content="AWeber vs Moosend Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare AWeber and Moosend by pricing, features, and verified public information." />
+  <section class="grid grid-cols-1 md:grid-cols-2 gap-5">
+    <article class="rounded-3xl border border-purple-500/30 bg-[#131520] p-7 space-y-4"><div class="text-xs font-bold text-purple-300">AWeber</div><h2 class="text-2xl font-black">Clear tiered email-marketing plans</h2><p class="text-sm text-slate-300">AWeber currently lists Lite starting at $15/month or $150/year and Plus starting at $30/month or $240/year, with pricing increasing by subscriber tier. Its pricing page advertises a 14-day free trial.</p><ul class="text-sm text-slate-300 space-y-2"><li>✓ Lite: focused core email tools with quantity limits</li><li>✓ Plus: unlimited lists, landing pages and automations</li><li>✓ Detailed published subscriber/send tiers</li><li>✓ Strong fit when you want predictable feature tiers</li></ul><a data-cta="affiliate" data-tool-id="aweber" data-cta-source="aweber-vs-moosend-aweber-card" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="block px-5 py-3.5 rounded-xl bg-purple-600 text-center font-extrabold">Try AWeber via verified link →</a></article>
+    <article class="rounded-3xl border border-blue-500/30 bg-[#131520] p-7 space-y-4"><div class="text-xs font-bold text-blue-300">Moosend</div><h2 class="text-2xl font-black">Longer no-card trial + flexible billing</h2><p class="text-sm text-slate-300">Moosend currently offers a 30-day free trial with no credit card required. Its live pricing scales by active contacts across Pro, Moosend+ and Enterprise; Moosend's own current guidance describes paid plans as starting at $9/month.</p><ul class="text-sm text-slate-300 space-y-2"><li>✓ 30-day no-card trial</li><li>✓ Unlimited campaigns/sends shown for paid plan comparison</li><li>✓ 15% biannual and 20% annual savings currently advertised</li><li>✓ Email credits available for occasional senders</li></ul><a data-cta="affiliate" data-tool-id="moosend" data-cta-source="aweber-vs-moosend-moosend-card" href="https://trymoo.moosend.com/6eappdpw04pw" target="_blank" rel="sponsored noopener noreferrer" class="block px-5 py-3.5 rounded-xl bg-blue-600 text-center font-extrabold">Try Moosend via verified link →</a></article>
+  </section>
 
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "AWeber vs Moosend Comparison",
-      "url": "https://coshuma.com/compare/aweber-vs-moosend.html",
-      "description": "Compare AWeber and Moosend by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "AWeber", "url": "https://coshuma.com/tool/aweber.html"},
-        {"@type": "SoftwareApplication", "name": "Moosend", "url": "https://coshuma.com/tool/moosend.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
-      </div>
-    </header>
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-9 space-y-5"><h2 class="text-2xl font-black">Side-by-side decision table</h2><div class="overflow-x-auto"><table class="w-full text-sm text-left"><thead class="text-slate-400 border-b border-[#2a2d42]"><tr><th class="py-3 pr-4">Decision factor</th><th class="py-3 pr-4">AWeber</th><th class="py-3">Moosend</th></tr></thead><tbody class="text-slate-300 divide-y divide-[#202334]"><tr><td class="py-4 pr-4 font-bold text-white">Trial</td><td class="py-4 pr-4">14 days advertised</td><td class="py-4">30 days, no card advertised</td></tr><tr><td class="py-4 pr-4 font-bold text-white">Entry pricing</td><td class="py-4 pr-4">Lite $15 monthly / $150 annually at starting tier</td><td class="py-4">Vendor guidance says from $9/month; live total varies by contacts</td></tr><tr><td class="py-4 pr-4 font-bold text-white">Automation</td><td class="py-4 pr-4">Lite capped; Plus expands to unlimited automations</td><td class="py-4">Marketing automation included in current paid-plan comparison</td></tr><tr><td class="py-4 pr-4 font-bold text-white">Occasional sending</td><td class="py-4 pr-4">Subscription-focused</td><td class="py-4">Email-credit option available</td></tr><tr><td class="py-4 pr-4 font-bold text-white">Best first test</td><td class="py-4 pr-4">Check whether Lite caps cover your workflow</td><td class="py-4">Use the longer trial to validate a real campaign + automation</td></tr></tbody></table></div></section>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">AWeber vs Moosend</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Email & Outreach tool.
-        </p>
-      </div>
+  <section class="rounded-3xl border border-emerald-500/25 bg-emerald-500/5 p-7 space-y-4"><h2 class="text-2xl font-black">Which should you pick?</h2><p class="text-slate-300"><strong class="text-white">Choose AWeber</strong> if you prefer its published feature tiers and want a mature email-marketing platform with clear Lite/Plus limits. <strong class="text-white">Choose Moosend</strong> if the longer no-card trial, flexible billing cadence or occasional-send credits reduce your initial commitment. For either one, price your real subscriber count before paying.</p><div class="grid grid-cols-1 sm:grid-cols-2 gap-3"><a data-cta="affiliate" data-tool-id="aweber" data-cta-source="aweber-vs-moosend-bottom-aweber" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3.5 rounded-xl bg-purple-600 text-center font-extrabold">Start AWeber →</a><a data-cta="affiliate" data-tool-id="moosend" data-cta-source="aweber-vs-moosend-bottom-moosend" href="https://trymoo.moosend.com/6eappdpw04pw" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3.5 rounded-xl bg-blue-600 text-center font-extrabold">Start Moosend →</a></div><p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if you become a paying customer through either verified partner link, at no extra cost to you. This does not change the comparison criteria.</p></section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose AWeber if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Moosend if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/aweber.html" class="hover:text-purple-300">AWeber</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/moosend.html" class="hover:text-blue-300">Moosend</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">AWeber Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Email Campaign Creation</div>
-<div>✓ Automated Email Sequences</div>
-<div>✓ Landing Page Builder</div>
-<div>✓ Subscriber Management & Segmentation</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Moosend Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Email Campaign Designer</div>
-<div>✓ Marketing Automation Workflows</div>
-<div>✓ Landing Pages & Subscription Forms</div>
-<div>✓ Detailed Analytics & Reporting</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a data-cta="affiliate" data-tool-id="aweber" data-cta-source="compare_aweber_moosend" href="https://www.aweber.com/easy-email.htm?id=561868" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get AWeber →</a>
-          <a href="https://moosend.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Moosend →</a>
-        </div>
-        <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: COSHUMA may earn a commission when you purchase AWeber through the marked affiliate link, at no additional cost to you. Moosend remains linked to its official site here until a customer-facing tracking URL is independently verified.</p>
-      </div>
-    </main>
-
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
-    <script src="/affiliate-attribution.js" defer></script>
-  </body>
+  <p class="text-xs text-slate-500">Sources rechecked September 7, 2026: AWeber official pricing/documentation and Moosend official pricing/documentation. Prices and plan limits can change; verify live checkout before purchase.</p>
+</main>
+<footer class="border-t border-[#222538] mt-12 py-8 text-center text-xs text-slate-500">© 2026 COSHUMA. Independent AI & SaaS buyer guides.</footer>
+<script src="/affiliate-attribution.js" defer></script>
+</body>
 </html>

--- a/projects/GlobalSaaSHub/public/compare/convertkit-vs-moosend.html
+++ b/projects/GlobalSaaSHub/public/compare/convertkit-vs-moosend.html
@@ -1,172 +1,38 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Kit (formerly ConvertKit) vs Moosend Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Kit (formerly ConvertKit) vs Moosend. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kit vs Moosend 2026: Pricing, Free Plan & Trial | COSHUMA</title>
+  <meta name="description" content="Kit (formerly ConvertKit) vs Moosend in 2026: compare Kit's free creator plan with Moosend's 30-day trial, pricing model, automations and best-fit use cases." />
+  <link rel="canonical" href="https://coshuma.com/compare/convertkit-vs-moosend.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/convertkit-vs-moosend.html" />
+  <meta property="og:title" content="Kit vs Moosend 2026: Pricing, Free Plan & Trial | COSHUMA" />
+  <meta property="og:description" content="Choose Kit or Moosend based on creator monetization, automation, free-plan needs and real list economics." />
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Kit vs Moosend 2026","url":"https://coshuma.com/compare/convertkit-vs-moosend.html","isPartOf":{"@type":"WebSite","name":"COSHUMA","url":"https://coshuma.com/"},"about":[{"@type":"SoftwareApplication","name":"Kit","url":"https://coshuma.com/tool/convertkit.html"},{"@type":"SoftwareApplication","name":"Moosend","url":"https://coshuma.com/tool/moosend.html"}]}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Which has a permanent free plan, Kit or Moosend?","acceptedAnswer":{"@type":"Answer","text":"Kit currently offers a free plan for up to 10,000 subscribers. Moosend currently offers a 30-day free trial rather than a permanent free plan on its pricing page."}},{"@type":"Question","name":"Which is better for creators?","acceptedAnswer":{"@type":"Answer","text":"Kit is especially creator-focused with digital products, paid newsletters, recommendations and creator-network features. Moosend is a broader email-marketing and automation choice for businesses that want campaigns, workflows, forms and landing pages."}}]}</script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen bg-[#0b0c10]">
+<header class="border-b border-[#222538] bg-[#07080c]/90 sticky top-0 z-50"><div class="max-w-5xl mx-auto px-5 py-4 flex items-center justify-between"><a href="/" class="font-black text-white text-lg">COSHUMA</a><a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">← Buyer guides</a></div></header>
+<main class="max-w-5xl mx-auto px-5 py-12 space-y-8">
+  <section class="text-center space-y-4"><div class="text-xs font-bold tracking-[0.18em] text-purple-300">EMAIL MARKETING COMPARISON · VERIFIED SEP 7, 2026</div><h1 class="text-4xl md:text-5xl font-black">Kit (formerly ConvertKit) vs Moosend</h1><p class="text-slate-300 max-w-3xl mx-auto">The key difference is not just price: Kit is built around creator audience growth and monetization, while Moosend is positioned as an email-marketing and automation stack for broader business workflows.</p></section>
 
-    <link rel="canonical" href="https://coshuma.com/compare/convertkit-vs-moosend.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/convertkit-vs-moosend.html" />
-    <meta property="og:title" content="Kit (formerly ConvertKit) vs Moosend Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Kit (formerly ConvertKit) and Moosend by pricing, features, and verified public information." />
+  <section class="grid grid-cols-1 md:grid-cols-2 gap-5">
+    <article class="rounded-3xl border border-purple-500/30 bg-[#131520] p-7 space-y-4"><div class="text-xs font-bold text-purple-300">KIT</div><h2 class="text-2xl font-black">Best when a permanent free creator plan matters</h2><p class="text-sm text-slate-300">Kit currently offers Free at $0 for up to 10,000 subscribers. For 1,000 subscribers, its official pricing page currently shows Creator at $33/month on annual billing and Pro at $66/month on annual billing.</p><ul class="text-sm text-slate-300 space-y-2"><li>✓ Unlimited forms, landing pages and broadcasts on Free</li><li>✓ Digital products and paid subscriptions</li><li>✓ Creator Network and audience-growth features</li><li>✓ Paid tiers unlock visual automations and sequences</li></ul><a data-cta="official" href="https://kit.com/pricing" target="_blank" rel="noopener noreferrer" class="block px-5 py-3.5 rounded-xl bg-slate-800 border border-slate-600 text-center font-extrabold">Check Kit official pricing →</a></article>
+    <article class="rounded-3xl border border-blue-500/30 bg-[#131520] p-7 space-y-4"><div class="text-xs font-bold text-blue-300">MOOSEND</div><h2 class="text-2xl font-black">Best when you can use 30 days to test a business workflow</h2><p class="text-sm text-slate-300">Moosend currently offers a 30-day free trial with no credit card required. Its paid pricing scales by active contacts across Pro, Moosend+ and Enterprise, while current Moosend guidance describes paid plans as starting at $9/month.</p><ul class="text-sm text-slate-300 space-y-2"><li>✓ Campaigns and marketing automation</li><li>✓ Landing pages and subscription forms</li><li>✓ 15% biannual / 20% annual savings currently advertised</li><li>✓ Email credits available for occasional campaigns</li></ul><a data-cta="affiliate" data-tool-id="moosend" data-cta-source="kit-vs-moosend-moosend-card" href="https://trymoo.moosend.com/6eappdpw04pw" target="_blank" rel="sponsored noopener noreferrer" class="block px-5 py-3.5 rounded-xl bg-blue-600 text-center font-extrabold">Try Moosend via verified COSHUMA link →</a></article>
+  </section>
 
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "Kit (formerly ConvertKit) vs Moosend Comparison",
-      "url": "https://coshuma.com/compare/convertkit-vs-moosend.html",
-      "description": "Compare Kit (formerly ConvertKit) and Moosend by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "Kit (formerly ConvertKit)", "url": "https://coshuma.com/tool/convertkit.html"},
-        {"@type": "SoftwareApplication", "name": "Moosend", "url": "https://coshuma.com/tool/moosend.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
-      </div>
-    </header>
+  <section class="rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-9 space-y-5"><h2 class="text-2xl font-black">Side-by-side decision table</h2><div class="overflow-x-auto"><table class="w-full text-sm text-left"><thead class="text-slate-400 border-b border-[#2a2d42]"><tr><th class="py-3 pr-4">Decision factor</th><th class="py-3 pr-4">Kit</th><th class="py-3">Moosend</th></tr></thead><tbody class="text-slate-300 divide-y divide-[#202334]"><tr><td class="py-4 pr-4 font-bold text-white">Free access</td><td class="py-4 pr-4">Permanent Free plan up to 10,000 subscribers</td><td class="py-4">30-day free trial, no card required</td></tr><tr><td class="py-4 pr-4 font-bold text-white">Creator monetization</td><td class="py-4 pr-4">Strong: digital products, paid newsletters, subscriptions, recommendations</td><td class="py-4">More focused on email marketing, automation and business campaigns</td></tr><tr><td class="py-4 pr-4 font-bold text-white">Automation</td><td class="py-4 pr-4">Visual automations/sequences on paid tiers</td><td class="py-4">Marketing automation included in current paid-plan comparison</td></tr><tr><td class="py-4 pr-4 font-bold text-white">Pricing model</td><td class="py-4 pr-4">Subscriber-based; Creator $33 and Pro $66 monthly equivalent on annual billing at 1,000 subscribers</td><td class="py-4">Subscriber-based subscription or optional email credits</td></tr><tr><td class="py-4 pr-4 font-bold text-white">Best fit</td><td class="py-4 pr-4">Creators building and monetizing an audience</td><td class="py-4">Businesses testing campaign + automation workflows</td></tr></tbody></table></div></section>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Kit (formerly ConvertKit) vs Moosend</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Email & Outreach tool.
-        </p>
-      </div>
+  <section class="rounded-3xl border border-emerald-500/25 bg-emerald-500/5 p-7 space-y-4"><h2 class="text-2xl font-black">Bottom line</h2><p class="text-slate-300"><strong class="text-white">Start with Kit Free</strong> if your priority is growing a creator list without a subscription and its free-plan feature limits are enough. <strong class="text-white">Test Moosend</strong> if you want to evaluate a business email/automation stack and can use its longer 30-day trial to validate a real workflow before paying.</p><div class="grid grid-cols-1 sm:grid-cols-2 gap-3"><a data-cta="official" href="https://kit.com/pricing" target="_blank" rel="noopener noreferrer" class="px-5 py-3.5 rounded-xl bg-slate-800 border border-slate-600 text-center font-extrabold">Kit official pricing →</a><a data-cta="affiliate" data-tool-id="moosend" data-cta-source="kit-vs-moosend-bottom-moosend" href="https://trymoo.moosend.com/6eappdpw04pw" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3.5 rounded-xl bg-blue-600 text-center font-extrabold">Start Moosend →</a></div><p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if you become a paying Moosend customer through the verified link, at no extra cost to you. Kit links on this page are standard official links because COSHUMA is not claiming a verified Kit revenue URL here.</p></section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Kit (formerly ConvertKit) if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Moosend if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
-      </div>
-
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/convertkit.html" class="hover:text-purple-300">Kit (formerly ConvertKit)</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/moosend.html" class="hover:text-blue-300">Moosend</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">Free plan; Creator plan from $33/month for 1,000 subscribers</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Kit (formerly ConvertKit) Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Email marketing automation</div>
-<div>✓ Landing page builder</div>
-<div>✓ Audience segmentation</div>
-<div>✓ AI subject line generation</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Moosend Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Email Campaign Designer</div>
-<div>✓ Marketing Automation Workflows</div>
-<div>✓ Landing Pages & Subscription Forms</div>
-<div>✓ Detailed Analytics & Reporting</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://kit.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Kit (formerly ConvertKit) →</a>
-          <a href="https://moosend.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Moosend →</a>
-        </div>
-      </div>
-    </main>
-
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
-  </body>
+  <p class="text-xs text-slate-500">Sources rechecked September 7, 2026: Kit official pricing/help center and Moosend official pricing/documentation. Prices and limits can change; verify live checkout before purchase.</p>
+</main>
+<footer class="border-t border-[#222538] mt-12 py-8 text-center text-xs text-slate-500">© 2026 COSHUMA. Independent AI & SaaS buyer guides.</footer>
+<script src="/affiliate-attribution.js" defer></script>
+</body>
 </html>


### PR DESCRIPTION
Zero-cost revenue follow-up after the Moosend buyer-page refresh.

Repository audit found two existing comparison pages still sending Moosend buyers to the generic non-affiliate homepage even though COSHUMA has a verified Moosend customer referral URL.

This PR:
- replaces the generic Moosend CTA in AWeber vs Moosend with the exact verified Moosend referral URL and source-tagged attribution
- keeps the existing verified AWeber affiliate route, so both buyer choices are monetized without biasing the decision copy
- replaces the generic Moosend CTA in Kit vs Moosend with the exact verified Moosend referral URL while keeping Kit on an official non-affiliate pricing link
- removes stale GlobalSaaSHub / Not rated placeholder copy
- updates comparison facts using current official AWeber, Kit and Moosend pricing/help sources checked Sep 7, 2026
- keeps /affiliate-attribution.js and explicit affiliate disclosures

No guessed deep links, new applications, paid services or unsupported tracking parameters are introduced.