### PR TITLE
Turn verified Chatbase referral into a stronger primary buyer funnel

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/chatbase.html
+++ b/projects/GlobalSaaSHub/public/tool/chatbase.html
@@ -1,168 +1,183 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Chatbase Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Empower your business to build no-code AI agents for customer support, sales, and workflow automation, enhancing customer engagement across multiple c... Discover features, pricing (Varies), and official links for Chatbase on GlobalSaaSHub." />
-    <link rel="canonical" href="https://coshuma.com/tool/chatbase.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://coshuma.com/tool/chatbase.html" />
-    <meta property="og:title" content="Chatbase Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Empower your business to build no-code AI agents for customer support, sales, and workflow automation, enhancing customer engagement across multiple c... Check rating, pricing, and features." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chatbase Pricing 2026: Free, Hobby, Standard & Pro | COSHUMA</title>
+  <meta name="description" content="Chatbase pricing for 2026: Free $0, Hobby $40, Standard $150 and Pro $500 monthly, plus 7-day paid-plan trials, message-credit limits and buyer-fit guidance." />
+  <link rel="canonical" href="https://coshuma.com/tool/chatbase.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://coshuma.com/tool/chatbase.html" />
+  <meta property="og:title" content="Chatbase Pricing 2026: Free, Hobby, Standard & Pro | COSHUMA" />
+  <meta property="og:description" content="Compare Chatbase plans, current message-credit limits, 7-day trials and the best fit for AI support, sales and product-guidance agents." />
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "Chatbase",
-      "operatingSystem": "Web",
-      "applicationCategory": "Sales & CRM",
-      "description": "Empower your business to build no-code AI agents for customer support, sales, and workflow automation, enhancing customer engagement across multiple channels."
-    }
-    </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"SoftwareApplication",
+    "name":"Chatbase",
+    "operatingSystem":"Web",
+    "applicationCategory":"BusinessApplication",
+    "url":"https://www.chatbase.co/",
+    "description":"AI agent platform for customer experience across chat, email and voice, including support, sales and product-guidance workflows."
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {
+        "@type":"Question",
+        "name":"Does Chatbase have a free plan?",
+        "acceptedAnswer":{"@type":"Answer","text":"Yes. Chatbase currently lists a $0 Free plan with 50 message credits per month and one workspace member. Free-plan AI agents are deleted after 14 days of inactivity."}
+      },
+      {
+        "@type":"Question",
+        "name":"How much does Chatbase cost in 2026?",
+        "acceptedAnswer":{"@type":"Answer","text":"On monthly billing, Chatbase currently lists Hobby at $40 per month, Standard at $150 per month and Pro at $500 per month. Enterprise pricing is custom. Chatbase advertises 20% off yearly plans."}
+      },
+      {
+        "@type":"Question",
+        "name":"Does Chatbase offer a trial?",
+        "acceptedAnswer":{"@type":"Answer","text":"Chatbase currently shows a 7-day trial for Hobby, Standard and Pro on its official pricing page. Confirm the live checkout terms before subscribing."}
+      },
+      {
+        "@type":"Question",
+        "name":"Which Chatbase plan is the practical starting point?",
+        "acceptedAnswer":{"@type":"Answer","text":"Use Free to test answer quality and the basic agent workflow. Hobby is the first paid tier for lighter usage, while Standard is the first listed tier that includes Helpdesk, Voice, Telephony, outbound campaigns and API access."}
+      }
+    ]
+  }
+  </script>
 
-    <!-- Tailwind & Fonts -->
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
-      </div>
-    </header>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700;800;900&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <style>
+    body { font-family:'Inter',sans-serif; background:#0b0c10; color:#f1f5f9; }
+    h1,h2,h3 { font-family:'Outfit',sans-serif; }
+  </style>
+  <script defer src="/affiliate-attribution.js"></script>
+</head>
+<body class="min-h-screen bg-[#0b0c10] text-slate-100">
+  <header class="sticky top-0 z-50 border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md">
+    <div class="max-w-5xl mx-auto px-5 py-4 flex items-center justify-between gap-4">
+      <a href="/" class="flex items-center gap-3">
+        <div class="h-9 w-9 rounded-xl bg-purple-600 flex items-center justify-center font-black text-white">C</div>
+        <span class="font-extrabold tracking-tight text-white">COSHUMA</span>
+      </a>
+      <a href="/best/chatbase-pricing-free-trial.html" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 text-purple-200 hover:bg-purple-500/10">Full Chatbase pricing guide →</a>
+    </div>
+  </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
-          <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=chatbase.co&sz=128" alt="Chatbase logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
-            <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Sales & CRM</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Chatbase</h1>
-            </div>
-          </div>
-
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
-          </div>
-        </div>
-
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">Empower your business to build no-code AI agents for customer support, sales, and workflow automation, enhancing customer engagement across multiple channels.</p>
-        </div>
-
-        <!-- Key Features -->
+  <main class="max-w-5xl mx-auto px-5 py-10 md:py-14 space-y-8">
+    <section class="rounded-3xl border border-purple-500/30 bg-[#121520] p-6 md:p-10 shadow-2xl space-y-7">
+      <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold border border-emerald-500/25 bg-emerald-500/10 text-emerald-300">AI customer experience · Pricing checked September 7, 2026</div>
+      <div class="grid lg:grid-cols-[1.4fr_.8fr] gap-7 items-start">
         <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Build AI agents without code</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Automate customer support</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Streamline sales processes</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Integrate with e-commerce platforms</div>
+          <h1 class="text-4xl md:text-6xl font-black tracking-tight text-white">Chatbase pricing: test the agent before paying for scale</h1>
+          <p class="text-lg text-slate-300 leading-relaxed">Chatbase builds conversational AI agents for customer experience across chat, email and voice. Its current product positioning covers support, sales and product guidance, so the important buying question is not only model quality—it is whether your real monthly message volume and channel needs justify a paid tier.</p>
+          <div class="flex flex-col sm:flex-row gap-3 pt-1">
+            <a data-cta="affiliate" data-tool-id="chatbase" data-cta-source="chatbase-hero" href="https://link.chatbase.co/sang-kwon-an" target="_blank" rel="sponsored noopener noreferrer" class="px-7 py-4 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center font-extrabold hover:brightness-110 shadow-lg shadow-purple-950/40">Start with Chatbase via verified partner link →</a>
+            <a data-cta="official" data-tool-id="chatbase" data-cta-source="chatbase-official-pricing" href="https://www.chatbase.co/pricing" target="_blank" rel="noopener noreferrer" class="px-7 py-4 rounded-xl border border-slate-600 bg-slate-800 text-white text-center font-bold hover:bg-slate-700">Verify official pricing →</a>
           </div>
+          <p class="text-[11px] text-slate-500 leading-relaxed">Affiliate disclosure: Chatbase support directly confirmed COSHUMA's customer-facing referral URL. COSHUMA may earn a commission if an eligible purchase is attributed through that link, at no extra cost to you. Pricing and limits below come from Chatbase's public pricing page and can change.</p>
         </div>
-
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (Varies)</li>
-              <li>Seamless workflow integration & API support</li>
-            </ul>
-          </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
-            </ul>
-          </div>
+        <div class="rounded-2xl border border-emerald-500/25 bg-emerald-500/5 p-5 space-y-3">
+          <div class="text-[11px] uppercase tracking-wider font-extrabold text-emerald-300">Lowest-risk test</div>
+          <div class="text-3xl font-black text-white">Free · $0/mo</div>
+          <div class="text-sm text-slate-300 leading-relaxed">50 message credits per month and one member. Use it to test knowledge quality and deployment fit before choosing a paid tier.</div>
+          <div class="text-xs text-amber-200 border-t border-emerald-500/15 pt-3">Free-plan agents are currently deleted after 14 days of inactivity, so do not treat the free workspace as permanent storage.</div>
         </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Chatbase</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/privy.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=privy.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Privy</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/reply-io.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=reply.io&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Reply.io</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/omnisend.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=omnisend.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Omnisend</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
-        </div>
-
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">Varies</div>
-          </div>
-          <a data-cta="official" href="https://www.chatbase.co/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Chatbase Site</span><span>→</span></a>
-        </div>
-
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Chatbase?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Chatbase Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/chatbase.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Chatbase Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
-        </div>
-
-
       </div>
-    </main>
+    </section>
 
-    <!-- Footer -->
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
+    <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-6">
+      <div>
+        <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Current monthly pricing</div>
+        <h2 class="text-3xl font-black text-white mt-1">Choose by message volume and channel requirements</h2>
+        <p class="text-sm text-slate-400 mt-2">Chatbase currently advertises 20% off yearly plans. The figures below are its monthly-billing prices, which make plan jumps easier to compare without mixing billing periods.</p>
       </div>
-    </footer>
-  </body>
+      <div class="grid md:grid-cols-2 gap-4">
+        <article class="rounded-2xl border border-emerald-500/20 bg-[#0d1018] p-5 space-y-3">
+          <div class="flex items-center justify-between gap-3"><h3 class="text-xl font-black text-white">Free</h3><span class="text-emerald-300 font-extrabold">$0/mo</span></div>
+          <ul class="text-sm text-slate-300 space-y-2"><li>✓ 50 message credits/month</li><li>✓ 1 member</li><li>✓ Limited model access</li><li>• Best for testing the core workflow</li></ul>
+        </article>
+        <article class="rounded-2xl border border-blue-500/20 bg-[#0d1018] p-5 space-y-3">
+          <div class="flex items-center justify-between gap-3"><h3 class="text-xl font-black text-white">Hobby</h3><span class="text-blue-300 font-extrabold">$40/mo</span></div>
+          <ul class="text-sm text-slate-300 space-y-2"><li>✓ 7-day trial listed</li><li>✓ 700 message credits/month</li><li>✓ 2 members</li><li>✓ Advanced models, integrations, basic analytics and attachments</li></ul>
+        </article>
+        <article class="rounded-2xl border border-purple-500/30 bg-purple-500/5 p-5 space-y-3">
+          <div class="flex items-center justify-between gap-3"><h3 class="text-xl font-black text-white">Standard</h3><span class="text-purple-300 font-extrabold">$150/mo</span></div>
+          <ul class="text-sm text-slate-300 space-y-2"><li>✓ 7-day trial listed</li><li>✓ 4,000 message credits/month</li><li>✓ 3 members</li><li>✓ Helpdesk, Voice, Telephony, outbound campaigns and API access</li><li>✓ Personalization, auto retraining and advanced integrations</li></ul>
+        </article>
+        <article class="rounded-2xl border border-indigo-500/25 bg-[#0d1018] p-5 space-y-3">
+          <div class="flex items-center justify-between gap-3"><h3 class="text-xl font-black text-white">Pro</h3><span class="text-indigo-300 font-extrabold">$500/mo</span></div>
+          <ul class="text-sm text-slate-300 space-y-2"><li>✓ 7-day trial listed</li><li>✓ 15,000 message credits/month</li><li>✓ 5 members</li><li>✓ Advanced analytics</li><li>✓ Source suggestions and tickets as a training source</li></ul>
+        </article>
+      </div>
+      <div class="rounded-2xl border border-amber-500/20 bg-amber-500/5 p-4 text-sm text-amber-100 leading-relaxed"><strong>Cost check:</strong> Chatbase also lists paid add-ons, including auto-recharge message credits, extra agents and branding removal. Estimate peak-month usage rather than choosing a plan only from the headline subscription price.</div>
+      <div class="flex flex-col sm:flex-row items-center justify-between gap-4 rounded-2xl border border-purple-500/25 bg-purple-500/5 p-5">
+        <div><div class="font-extrabold text-white">Ready to test a real support workload?</div><div class="text-xs text-slate-400 mt-1">Start small, track credit consumption and upgrade only if the agent earns its place in the workflow.</div></div>
+        <a data-cta="affiliate" data-tool-id="chatbase" data-cta-source="chatbase-pricing" href="https://link.chatbase.co/sang-kwon-an" target="_blank" rel="sponsored noopener noreferrer" class="shrink-0 px-6 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-extrabold text-sm">Open Chatbase via partner link →</a>
+      </div>
+    </section>
+
+    <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-5">
+      <div>
+        <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">What you are buying</div>
+        <h2 class="text-3xl font-black text-white mt-1">One agent lifecycle across customer channels</h2>
+      </div>
+      <div class="grid md:grid-cols-2 gap-4">
+        <div class="rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-5"><h3 class="text-lg font-extrabold text-white">Build from business data</h3><p class="text-sm text-slate-300 mt-2 leading-relaxed">Connect data sources, define the agent's role and set guardrails. Chatbase's current homepage positions setup as no-code.</p></div>
+        <div class="rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-5"><h3 class="text-lg font-extrabold text-white">Test before deployment</h3><p class="text-sm text-slate-300 mt-2 leading-relaxed">Run real customer scenarios to check accuracy, brand consistency and edge cases before exposing the agent to live traffic.</p></div>
+        <div class="rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-5"><h3 class="text-lg font-extrabold text-white">Deploy across channels</h3><p class="text-sm text-slate-300 mt-2 leading-relaxed">Chatbase currently promotes deployment across chat, email, voice, WhatsApp, Slack and other connected channels, depending on plan and integration.</p></div>
+        <div class="rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-5"><h3 class="text-lg font-extrabold text-white">Optimize with real conversations</h3><p class="text-sm text-slate-300 mt-2 leading-relaxed">Review resolutions and escalations, then refine instructions rather than assuming the first agent configuration is production-ready.</p></div>
+      </div>
+    </section>
+
+    <section class="grid md:grid-cols-2 gap-4">
+      <div class="rounded-3xl border border-emerald-500/20 bg-emerald-500/5 p-6 space-y-3">
+        <h2 class="text-xl font-black text-white">Chatbase is a stronger fit when...</h2>
+        <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>You want an AI agent trained on your own support or product knowledge.</li><li>You need customer interactions across more than a basic website chat box.</li><li>You can measure monthly conversation volume and map it to message credits.</li><li>You want Helpdesk, Voice or Telephony and can justify Standard or above.</li></ul>
+      </div>
+      <div class="rounded-3xl border border-amber-500/20 bg-amber-500/5 p-6 space-y-3">
+        <h2 class="text-xl font-black text-white">Be cautious when...</h2>
+        <ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>Your expected traffic is too high or unpredictable to estimate credit cost.</li><li>You only need a simple static FAQ and do not need AI actions or multichannel support.</li><li>Your workflow requires enterprise controls such as SSO, audit logs or special data handling; verify Enterprise terms first.</li><li>You have not yet tested answer accuracy on representative customer questions.</li></ul>
+      </div>
+    </section>
+
+    <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-4">
+      <h2 class="text-2xl font-black text-white">Quick answers before you start</h2>
+      <div class="space-y-3 text-sm">
+        <details class="rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-4"><summary class="font-bold text-white cursor-pointer">Is there a permanent free tier?</summary><p class="text-slate-300 mt-3 leading-relaxed">There is a $0 Free plan, but Chatbase currently says free-plan AI agents are deleted after 14 days of inactivity. Treat it as a testing environment, not permanent storage.</p></details>
+        <details class="rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-4"><summary class="font-bold text-white cursor-pointer">Where do Helpdesk and Voice begin?</summary><p class="text-slate-300 mt-3 leading-relaxed">On the current pricing page, Standard is the first listed tier that includes Helpdesk, Voice, Telephony, outbound campaigns and API access.</p></details>
+        <details class="rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-4"><summary class="font-bold text-white cursor-pointer">Should I choose annual billing immediately?</summary><p class="text-slate-300 mt-3 leading-relaxed">Chatbase advertises 20% off yearly plans, but the safer sequence is to validate answer quality and message-credit consumption first. A lower annual rate does not help if the workflow is a poor fit.</p></details>
+      </div>
+      <a href="/best/chatbase-pricing-free-trial.html" class="inline-flex text-sm font-bold text-purple-300 hover:text-purple-200">Read the deeper Chatbase pricing & trial guide →</a>
+    </section>
+
+    <section class="rounded-3xl border border-purple-500/30 bg-purple-500/5 p-6 md:p-8 text-center space-y-4">
+      <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Decision path</div>
+      <h2 class="text-3xl font-black text-white">Test one real customer workflow, then decide</h2>
+      <p class="text-sm text-slate-300 max-w-2xl mx-auto">Load representative source material, ask the questions your customers actually ask, watch message-credit usage, and only then choose the paid tier that matches your channels and volume.</p>
+      <a data-cta="affiliate" data-tool-id="chatbase" data-cta-source="chatbase-bottom" href="https://link.chatbase.co/sang-kwon-an" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-4 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-extrabold">Start Chatbase via verified COSHUMA partner link →</a>
+      <div class="text-[11px] text-slate-500">Referral URL verified directly by Chatbase support after reviewing the COSHUMA partner account.</div>
+    </section>
+
+    <section data-sponsorship-inquiry="tool" class="rounded-3xl border border-violet-500/20 bg-violet-500/5 p-6 space-y-3">
+      <div class="text-[10px] uppercase tracking-wider font-bold text-violet-300">Represent Chatbase?</div>
+      <h2 class="text-lg font-extrabold text-white">Request a COSHUMA sponsored placement</h2>
+      <p class="text-xs text-slate-400 leading-relaxed">A one-time sponsored placement is USD 49. Sponsorship is reviewed separately from editorial coverage; payment does not guarantee acceptance, ranking or an editorial rating.</p>
+      <a data-cta="sponsorship-inquiry" data-cta-source="chatbase-sponsorship" href="mailto:support@coshuma.com?subject=COSHUMA%20%2449%20sponsorship%20inquiry&amp;body=Product%20name%3A%20Chatbase%0AWebsite%3A%0APlacement%20goal%3A%0A" class="inline-flex items-center justify-center px-5 py-3 rounded-xl bg-violet-600 hover:bg-violet-500 text-white text-xs font-extrabold">Email a sponsorship request →</a>
+      <p class="text-[10px] text-slate-500">This inquiry link does not create a charge.</p>
+    </section>
+  </main>
+
+  <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
+    <div class="max-w-5xl mx-auto px-5">&copy; 2026 COSHUMA. Independent AI & SaaS buyer guides.</div>
+  </footer>
+</body>
 </html>
-


### PR DESCRIPTION
Revenue-first, zero-cost CRO refresh for an approved partner route that is already verified but weak on the primary tool page.

Evidence rechecked Sep 7, 2026:
- Chatbase support directly reviewed the COSHUMA partner account and supplied the exact customer-facing referral URL `https://link.chatbase.co/sang-kwon-an`.
- The current Chatbase pricing page lists Free $0, Hobby $40/mo, Standard $150/mo, Pro $500/mo, Enterprise custom, 7-day trials on the self-serve paid plans, and 20% off yearly plans.
- The existing production tool page was still generic: pricing `Varies`, review placeholders, and only one auto-injected affiliate CTA despite the verified referral route.

Changes:
- rebuild the primary Chatbase page as a current COSHUMA buyer guide
- add Free/Hobby/Standard/Pro pricing and message-credit guidance from the official pricing page
- add three position-specific affiliate CTAs using only the exact support-verified referral URL
- keep official pricing as a separate non-affiliate verification link
- add FAQ structured data, buyer-fit guidance and the existing deeper Chatbase pricing guide internal link
- preserve the $49 COSHUMA sponsored-placement inquiry route and editorial separation
- retain `/affiliate-attribution.js` for click attribution

No paid service, new subscription, duplicate application, guessed tracking parameter or generic dashboard URL is introduced.