### PR TITLE
Turn stale Shopify comparisons into buyer-intent revenue paths

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/shopify-vs-privy.html
+++ b/projects/GlobalSaaSHub/public/compare/shopify-vs-privy.html
@@ -1,170 +1,102 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Shopify vs Privy Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Shopify vs Privy. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Shopify vs Privy (2026): Store Platform or Email & SMS Growth Tool? | COSHUMA</title>
+  <meta name="description" content="Shopify vs Privy in 2026: understand why they are complementary, compare current entry pricing and trials, and choose the right starting point for an ecommerce business." />
+  <link rel="canonical" href="https://coshuma.com/compare/shopify-vs-privy.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/shopify-vs-privy.html" />
+  <meta property="og:title" content="Shopify vs Privy: Store Platform or Growth Tool? (2026)" />
+  <meta property="og:description" content="Shopify runs the store; Privy adds email, SMS and onsite conversion tools. Compare the buying decision before you pay." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"WebPage",
+    "name":"Shopify vs Privy (2026)",
+    "url":"https://coshuma.com/compare/shopify-vs-privy.html",
+    "dateModified":"2026-09-07",
+    "isPartOf":{"@type":"WebSite","name":"COSHUMA","url":"https://coshuma.com/"},
+    "about":[
+      {"@type":"SoftwareApplication","name":"Shopify","url":"https://coshuma.com/tool/shopify.html"},
+      {"@type":"SoftwareApplication","name":"Privy","url":"https://coshuma.com/tool/privy.html"}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="/affiliate-attribution.js" defer></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}.glass{background:#131520;border:1px solid #222538}</style>
+</head>
+<body class="min-h-screen">
+  <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+    <div class="max-w-5xl mx-auto flex items-center justify-between gap-4">
+      <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-black">C</div><span class="font-extrabold text-lg">COSHUMA</span></a>
+      <a href="/best/shopify-pricing-free-trial.html" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">Shopify pricing guide</a>
+    </div>
+  </header>
 
-    <link rel="canonical" href="https://coshuma.com/compare/shopify-vs-privy.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/shopify-vs-privy.html" />
-    <meta property="og:title" content="Shopify vs Privy Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Shopify and Privy by pricing, features, and verified public information." />
+  <main class="max-w-5xl mx-auto px-4 py-10 space-y-8">
+    <section class="text-center space-y-4">
+      <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold bg-emerald-500/10 border border-emerald-500/20 text-emerald-300">BUYER GUIDE · CHECKED SEPTEMBER 7, 2026</div>
+      <h1 class="text-4xl md:text-6xl font-black tracking-tight">Shopify vs Privy</h1>
+      <p class="text-slate-300 max-w-3xl mx-auto leading-relaxed">This is not a normal either-or comparison. <strong>Shopify</strong> is the commerce platform that runs your storefront, catalog, checkout and operations. <strong>Privy</strong> is a growth layer for email, SMS, pop-ups and onsite conversion. A new store usually needs Shopify first; Privy becomes relevant after there is traffic and a list to grow.</p>
+    </section>
 
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "Shopify vs Privy Comparison",
-      "url": "https://coshuma.com/compare/shopify-vs-privy.html",
-      "description": "Compare Shopify and Privy by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "Shopify", "url": "https://coshuma.com/tool/shopify.html"},
-        {"@type": "SoftwareApplication", "name": "Privy", "url": "https://coshuma.com/tool/privy.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+    <section class="grid md:grid-cols-2 gap-5">
+      <article class="glass rounded-3xl p-6 space-y-5">
+        <div><div class="text-xs font-bold text-purple-300 mb-2">COMMERCE FOUNDATION</div><h2 class="text-2xl font-black">Choose Shopify when you need the store itself</h2></div>
+        <ul class="space-y-2 text-sm text-slate-300">
+          <li>✓ Hosted online storefront, products, checkout and inventory.</li>
+          <li>✓ Sell online, in person, on social and in supported AI shopping surfaces.</li>
+          <li>✓ Core plans scale from solo operators to larger teams and international operations.</li>
+          <li>✓ Best first purchase when you do not yet have a working commerce platform.</li>
+        </ul>
+        <div class="rounded-2xl bg-[#181a29] border border-purple-500/20 p-4 text-sm text-slate-300">
+          <div class="font-black text-white">Current US entry offer</div>
+          <div class="mt-2"><strong>3 days free, then $1/month for 3 months.</strong> Yearly pricing currently starts at <strong>$29/month for Basic</strong>.</div>
+        </div>
+        <a data-cta="affiliate" data-tool-id="shopify" data-cta-source="compare-shopify-privy-shopify" href="https://shopify.pxf.io/7670642-link?sharedid=7670642" target="_blank" rel="sponsored noopener noreferrer" class="block py-4 px-5 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center">Start Shopify via Verified Affiliate Link →</a>
+      </article>
+
+      <article class="glass rounded-3xl p-6 space-y-5">
+        <div><div class="text-xs font-bold text-blue-300 mb-2">RETENTION & CONVERSION LAYER</div><h2 class="text-2xl font-black">Choose Privy when the store exists and growth is the bottleneck</h2></div>
+        <ul class="space-y-2 text-sm text-slate-300">
+          <li>✓ Email and SMS campaigns plus automations.</li>
+          <li>✓ Pop-ups, displays, targeting and segmentation for list growth.</li>
+          <li>✓ Integrates with Shopify and other ecommerce platforms.</li>
+          <li>✓ Unlimited email sends are included on the current email plan.</li>
+        </ul>
+        <div class="rounded-2xl bg-[#181a29] border border-blue-500/20 p-4 text-sm text-slate-300">
+          <div class="font-black text-white">Current public entry pricing</div>
+          <div class="mt-2">Email starts at <strong>$30/month</strong>. Privy currently advertises a <strong>15-day free trial with no credit card required</strong>. Pop-ups & Displays only starts at $24/month.</div>
+        </div>
+        <a href="https://www.privy.com/pricing" target="_blank" rel="noopener noreferrer" class="block py-4 px-5 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center">View Privy Pricing →</a>
+      </article>
+    </section>
+
+    <section class="glass rounded-3xl p-6 md:p-8 space-y-5">
+      <h2 class="text-2xl font-black">Fast decision: what should you pay for first?</h2>
+      <div class="grid md:grid-cols-3 gap-4 text-sm">
+        <div class="rounded-2xl bg-[#181a29] border border-[#2a2d40] p-4"><div class="font-black text-purple-300 mb-2">No store yet</div><p class="text-slate-300">Start with <strong>Shopify</strong>. Privy does not replace the storefront, product catalog or checkout layer.</p></div>
+        <div class="rounded-2xl bg-[#181a29] border border-[#2a2d40] p-4"><div class="font-black text-blue-300 mb-2">Store works, traffic leaks</div><p class="text-slate-300">Test <strong>Privy</strong> when you need email capture, lifecycle campaigns, SMS or onsite conversion tools.</p></div>
+        <div class="rounded-2xl bg-[#181a29] border border-[#2a2d40] p-4"><div class="font-black text-emerald-300 mb-2">Growing ecommerce stack</div><p class="text-slate-300">Use them together only when Shopify is already operational and Privy's extra monthly cost is justified by measurable list or conversion growth.</p></div>
       </div>
-    </header>
+    </section>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Shopify vs Privy</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Sales & CRM tool.
-        </p>
-      </div>
+    <section class="rounded-3xl bg-gradient-to-r from-purple-500/10 to-emerald-500/10 border border-purple-500/25 p-7 text-center space-y-4">
+      <h2 class="text-2xl font-black">Building a new store? Validate Shopify before adding another paid tool</h2>
+      <p class="text-sm text-slate-300 max-w-2xl mx-auto">Publish a real product, configure checkout and test the buying flow first. Add retention software only after traffic makes the need visible.</p>
+      <a data-cta="affiliate" data-tool-id="shopify" data-cta-source="compare-shopify-privy-bottom" href="https://shopify.pxf.io/7670642-link?sharedid=7670642" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex justify-center px-7 py-4 rounded-xl bg-emerald-500 hover:bg-emerald-400 text-slate-950 font-black">Start Shopify through COSHUMA →</a>
+    </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Shopify if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Privy if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
-      </div>
+    <section class="rounded-3xl border border-amber-500/20 bg-amber-500/5 p-5 text-xs text-slate-400 leading-relaxed"><strong class="text-amber-300">Affiliate disclosure:</strong> COSHUMA is a Shopify Affiliate and may receive compensation for a qualifying Shopify referral at no extra cost to you. The Privy pricing link on this page is a standard official link and is not represented as an affiliate link.</section>
+    <section class="text-xs text-slate-500 leading-relaxed"><strong class="text-slate-300">Sources checked:</strong> Shopify official pricing and COSHUMA's account-specific Shopify Affiliate email; Privy official pricing. Pricing and trial terms were re-checked on September 7, 2026.</section>
+  </main>
 
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/shopify.html" class="hover:text-purple-300">Shopify</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/privy.html" class="hover:text-blue-300">Privy</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">Pricing details on website</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Shopify Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Intuitive Store Builder</div>
-<div>✓ Integrated Payment Gateway</div>
-<div>✓ Inventory Management</div>
-<div>✓ Marketing and Analytics Tools</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Privy Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Pop-up & Exit-Intent Campaigns</div>
-<div>✓ Email Marketing Automation</div>
-<div>✓ Customizable Landing Pages</div>
-<div>✓ Integrations with E-commerce Platforms</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a data-cta="affiliate" data-tool-id="shopify" href="https://shopify.pxf.io/7670642-link?sharedid=7670642" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Shopify →</a>
-          <a href="https://www.privy.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Privy →</a>
-        </div>
-        <p class="text-[10px] text-slate-500">COSHUMA is a Shopify Affiliate and may receive compensation if you sign up through the Shopify partner link.</p>
-      </div>
-    </main>
-
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
-    <script defer src="/affiliate-attribution.js"></script>
-  </body>
+  <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">© 2026 COSHUMA · Independent AI & SaaS buyer guides</footer>
+</body>
 </html>

--- a/projects/GlobalSaaSHub/public/compare/shopify-vs-reply-io.html
+++ b/projects/GlobalSaaSHub/public/compare/shopify-vs-reply-io.html
@@ -1,170 +1,96 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Shopify vs Reply.io Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Shopify vs Reply.io. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Shopify vs Reply.io (2026): Ecommerce Store or B2B Sales Outreach? | COSHUMA</title>
+  <meta name="description" content="Shopify vs Reply.io in 2026: compare ecommerce storefront needs with B2B outbound sales automation, current entry pricing, trials and the right buying path." />
+  <link rel="canonical" href="https://coshuma.com/compare/shopify-vs-reply-io.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/shopify-vs-reply-io.html" />
+  <meta property="og:title" content="Shopify vs Reply.io: Ecommerce Store or B2B Outreach? (2026)" />
+  <meta property="og:description" content="Shopify runs commerce; Reply.io automates outbound B2B prospecting and sales outreach. Choose based on the revenue motion you actually need." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"WebPage",
+    "name":"Shopify vs Reply.io (2026)",
+    "url":"https://coshuma.com/compare/shopify-vs-reply-io.html",
+    "dateModified":"2026-09-07",
+    "isPartOf":{"@type":"WebSite","name":"COSHUMA","url":"https://coshuma.com/"},
+    "about":[
+      {"@type":"SoftwareApplication","name":"Shopify","url":"https://coshuma.com/tool/shopify.html"},
+      {"@type":"SoftwareApplication","name":"Reply.io","url":"https://coshuma.com/tool/reply-io.html"}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="/affiliate-attribution.js" defer></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}.glass{background:#131520;border:1px solid #222538}</style>
+</head>
+<body class="min-h-screen">
+  <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+    <div class="max-w-5xl mx-auto flex items-center justify-between gap-4">
+      <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-black">C</div><span class="font-extrabold text-lg">COSHUMA</span></a>
+      <a href="/best/shopify-pricing-free-trial.html" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">Shopify pricing guide</a>
+    </div>
+  </header>
 
-    <link rel="canonical" href="https://coshuma.com/compare/shopify-vs-reply-io.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/shopify-vs-reply-io.html" />
-    <meta property="og:title" content="Shopify vs Reply.io Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Shopify and Reply.io by pricing, features, and verified public information." />
+  <main class="max-w-5xl mx-auto px-4 py-10 space-y-8">
+    <section class="text-center space-y-4">
+      <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold bg-emerald-500/10 border border-emerald-500/20 text-emerald-300">BUYER GUIDE · CHECKED SEPTEMBER 7, 2026</div>
+      <h1 class="text-4xl md:text-6xl font-black tracking-tight">Shopify vs Reply.io</h1>
+      <p class="text-slate-300 max-w-3xl mx-auto leading-relaxed">These products support different revenue motions. <strong>Shopify</strong> is for selling products through an ecommerce storefront and checkout. <strong>Reply.io</strong> is for prospecting and outbound B2B sales outreach across email and other channels. Pick the revenue engine you need before comparing price.</p>
+    </section>
 
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "Shopify vs Reply.io Comparison",
-      "url": "https://coshuma.com/compare/shopify-vs-reply-io.html",
-      "description": "Compare Shopify and Reply.io by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "Shopify", "url": "https://coshuma.com/tool/shopify.html"},
-        {"@type": "SoftwareApplication", "name": "Reply.io", "url": "https://coshuma.com/tool/reply-io.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+    <section class="grid md:grid-cols-2 gap-5">
+      <article class="glass rounded-3xl p-6 space-y-5">
+        <div><div class="text-xs font-bold text-purple-300 mb-2">ECOMMERCE REVENUE</div><h2 class="text-2xl font-black">Choose Shopify when customers should buy through a store</h2></div>
+        <ul class="space-y-2 text-sm text-slate-300">
+          <li>✓ Storefront, products, checkout, payments and inventory in one hosted platform.</li>
+          <li>✓ Suitable for direct-to-consumer, retail, social and marketplace commerce.</li>
+          <li>✓ Built around orders and checkout conversion rather than outbound prospecting sequences.</li>
+          <li>✓ Best first choice when you need a real ecommerce transaction layer.</li>
+        </ul>
+        <div class="rounded-2xl bg-[#181a29] border border-purple-500/20 p-4 text-sm text-slate-300"><div class="font-black text-white">Current US entry offer</div><div class="mt-2"><strong>3 days free, then $1/month for 3 months.</strong> Yearly Basic pricing currently starts at <strong>$29/month</strong>.</div></div>
+        <a data-cta="affiliate" data-tool-id="shopify" data-cta-source="compare-shopify-reply-shopify" href="https://shopify.pxf.io/7670642-link?sharedid=7670642" target="_blank" rel="sponsored noopener noreferrer" class="block py-4 px-5 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center">Start Shopify via Verified Affiliate Link →</a>
+      </article>
+
+      <article class="glass rounded-3xl p-6 space-y-5">
+        <div><div class="text-xs font-bold text-blue-300 mb-2">B2B OUTBOUND REVENUE</div><h2 class="text-2xl font-black">Choose Reply.io when your team needs to reach prospects</h2></div>
+        <ul class="space-y-2 text-sm text-slate-300">
+          <li>✓ Email outreach automation with warm-up and deliverability tools.</li>
+          <li>✓ Multichannel sequences can add LinkedIn, calls, SMS and other steps.</li>
+          <li>✓ Built-in live B2B data and AI-assisted outreach features.</li>
+          <li>✓ Better fit for lead generation and sales meetings than ecommerce checkout.</li>
+        </ul>
+        <div class="rounded-2xl bg-[#181a29] border border-blue-500/20 p-4 text-sm text-slate-300"><div class="font-black text-white">Current public entry pricing</div><div class="mt-2">Email Volume currently starts at <strong>$49/user/month billed annually</strong>. Multichannel starts at <strong>$89/user/month billed annually</strong> and currently advertises a <strong>14-day trial</strong>.</div></div>
+        <a href="https://reply.io/pricing/" target="_blank" rel="noopener noreferrer" class="block py-4 px-5 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center">View Reply.io Pricing →</a>
+      </article>
+    </section>
+
+    <section class="glass rounded-3xl p-6 md:p-8 space-y-5">
+      <h2 class="text-2xl font-black">Fast decision: which revenue model are you building?</h2>
+      <div class="grid md:grid-cols-3 gap-4 text-sm">
+        <div class="rounded-2xl bg-[#181a29] border border-[#2a2d40] p-4"><div class="font-black text-purple-300 mb-2">Visitors should place orders</div><p class="text-slate-300">Choose <strong>Shopify</strong> when the core action is adding products to cart and completing checkout.</p></div>
+        <div class="rounded-2xl bg-[#181a29] border border-[#2a2d40] p-4"><div class="font-black text-blue-300 mb-2">Sales reps should book meetings</div><p class="text-slate-300">Choose <strong>Reply.io</strong> when the core action is contacting prospects and moving them into a B2B sales conversation.</p></div>
+        <div class="rounded-2xl bg-[#181a29] border border-[#2a2d40] p-4"><div class="font-black text-emerald-300 mb-2">Hybrid business</div><p class="text-slate-300">A company can use both, but only if it runs both ecommerce and outbound sales motions. Do not buy both simply because both are labeled sales tools.</p></div>
       </div>
-    </header>
+    </section>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Shopify vs Reply.io</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Sales & CRM tool.
-        </p>
-      </div>
+    <section class="rounded-3xl bg-gradient-to-r from-purple-500/10 to-emerald-500/10 border border-purple-500/25 p-7 text-center space-y-4">
+      <h2 class="text-2xl font-black">Need an online store? Test checkout before adding more software</h2>
+      <p class="text-sm text-slate-300 max-w-2xl mx-auto">A working product page and checkout are the first proof points for ecommerce. Start with the current Shopify trial path and validate that flow before expanding the stack.</p>
+      <a data-cta="affiliate" data-tool-id="shopify" data-cta-source="compare-shopify-reply-bottom" href="https://shopify.pxf.io/7670642-link?sharedid=7670642" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex justify-center px-7 py-4 rounded-xl bg-emerald-500 hover:bg-emerald-400 text-slate-950 font-black">Start Shopify through COSHUMA →</a>
+    </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Shopify if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Reply.io if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
-      </div>
+    <section class="rounded-3xl border border-amber-500/20 bg-amber-500/5 p-5 text-xs text-slate-400 leading-relaxed"><strong class="text-amber-300">Affiliate disclosure:</strong> COSHUMA is a Shopify Affiliate and may receive compensation for a qualifying Shopify referral at no extra cost to you. The Reply.io pricing link on this page is a standard official link and is not represented as an affiliate link.</section>
+    <section class="text-xs text-slate-500 leading-relaxed"><strong class="text-slate-300">Sources checked:</strong> Shopify official pricing and COSHUMA's account-specific Shopify Affiliate email; Reply.io official pricing. Pricing and trial terms were re-checked on September 7, 2026.</section>
+  </main>
 
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/shopify.html" class="hover:text-purple-300">Shopify</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/reply-io.html" class="hover:text-blue-300">Reply.io</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">Pricing details on website</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Shopify Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Intuitive Store Builder</div>
-<div>✓ Integrated Payment Gateway</div>
-<div>✓ Inventory Management</div>
-<div>✓ Marketing and Analytics Tools</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Reply.io Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Multi-Channel Sales Sequences</div>
-<div>✓ AI Email Assistant</div>
-<div>✓ CRM Integrations</div>
-<div>✓ Performance Tracking & Reporting</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a data-cta="affiliate" data-tool-id="shopify" href="https://shopify.pxf.io/7670642-link?sharedid=7670642" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Shopify →</a>
-          <a href="https://reply.io/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Reply.io →</a>
-        </div>
-        <p class="text-[10px] text-slate-500">COSHUMA is a Shopify Affiliate and may receive compensation if you sign up through the Shopify partner link.</p>
-      </div>
-    </main>
-
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
-    <script defer src="/affiliate-attribution.js"></script>
-  </body>
+  <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">© 2026 COSHUMA · Independent AI & SaaS buyer guides</footer>
+</body>
 </html>


### PR DESCRIPTION
Rewrites two stale GlobalSaaSHub-era Shopify comparison pages into COSHUMA buyer guides. Uses the exact Shopify affiliate URL supplied by Shopify, keeps Privy/Reply.io as non-affiliate official links, adds source-specific attribution, updates current pricing/trial facts from official vendor pages, and removes misleading Not rated/template copy.