### PR TITLE
Remove hardcoded SMTP credential from public test script

### DIFF
--- a/test_email.py
+++ b/test_email.py
@@ -1,27 +1,32 @@
-# Test email sending with proper encoding
+# Test email sending with credentials supplied through environment variables
 import os
-os.environ['SMTP_HOST'] = 'smtp.gmail.com'
-os.environ['SMTP_PORT'] = '587'
-os.environ['SMTP_USER'] = 'qmfforfhem@gmail.com'
-os.environ['SMTP_PASSWORD'] = 'wzcglgsulhcgscuo'
-os.environ['FROM_EMAIL'] = 'qmfforfhem@gmail.com'
+
+os.environ.setdefault('SMTP_HOST', 'smtp.gmail.com')
+os.environ.setdefault('SMTP_PORT', '587')
+
+smtp_user = os.getenv('SMTP_USER')
+smtp_password = os.getenv('SMTP_PASSWORD')
+if not smtp_user or not smtp_password:
+    raise RuntimeError('Set SMTP_USER and SMTP_PASSWORD in the environment before running this test.')
+
+os.environ.setdefault('FROM_EMAIL', smtp_user)
+test_recipient = os.getenv('TEST_EMAIL_TO', smtp_user)
 
 import email_manager
 
-print("Testing email system...")
+print('Testing email system...')
 
-# Simple test email
 result = email_manager.send_email(
-    to_email='qmfforfhem@gmail.com',
+    to_email=test_recipient,
     subject='Test from Cauchemar AI',
     body_html='<h1>Hello!</h1><p>Email system is working!</p>',
     body_text='Hello! Email system is working!'
 )
 
-print(f"Email sent: {result}")
+print(f'Email sent: {result}')
 
 if result:
-    print("\n✅ SUCCESS: Email sent successfully!")
-    print("Check your inbox at qmfforfhem@gmail.com")
+    print('\n✅ SUCCESS: Email sent successfully!')
+    print(f'Check the inbox at {test_recipient}')
 else:
-    print("\n❌ FAILED: Could not send email")
+    print('\n❌ FAILED: Could not send email')


### PR DESCRIPTION
Security cleanup discovered during the COSHUMA repository verification. The public test script contained an SMTP credential in source. This change removes the embedded credential and requires SMTP_USER / SMTP_PASSWORD to be supplied through environment variables instead. No production revenue URLs, checkout settings, or paid services are changed.

Note: removing the credential from the current branch does not revoke a credential that may already have been exposed in Git history; account-side rotation should be treated separately.