### PR TITLE
Turn Jotform AI Agents partner path into a buyer-intent funnel

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/jotform.html
+++ b/projects/GlobalSaaSHub/public/tool/jotform.html
@@ -3,29 +3,54 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Jotform Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Jotform is a powerful online form builder that helps businesses create custom forms for data collection, payments, and workflow automation without any... Discover features, pricing (See official pricing), and official links for Jotform on GlobalSaaSHub." />
+    <title>Jotform Pricing 2026: Free, Bronze, Silver, Gold & AI Agents | COSHUMA</title>
+    <meta name="description" content="Jotform pricing and buyer guide for 2026: compare the free Starter plan, Bronze, Silver, Gold and Enterprise, plus a verified Jotform AI Agents partner path for customer-support automation." />
     <link rel="canonical" href="https://coshuma.com/tool/jotform.html" />
-    
-    <!-- Open Graph SEO Tags -->
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content="article" />
     <meta property="og:url" content="https://coshuma.com/tool/jotform.html" />
-    <meta property="og:title" content="Jotform Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Jotform is a powerful online form builder that helps businesses create custom forms for data collection, payments, and workflow automation without any... Check rating, pricing, and features." />
+    <meta property="og:title" content="Jotform Pricing 2026: Plans, Limits & AI Agents | COSHUMA" />
+    <meta property="og:description" content="Compare Jotform Starter, Bronze, Silver, Gold and Enterprise, then see when Jotform AI Agents is the better fit for 24/7 customer-support automation." />
 
-    <!-- JSON-LD Structured Data for Google Indexing -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Jotform",
       "operatingSystem": "Web",
-      "applicationCategory": "Coding & Dev Tools",
-      "description": "Jotform is a powerful online form builder that helps businesses create custom forms for data collection, payments, and workflow automation without any coding. Design surveys, applications, and order forms with ease."
+      "applicationCategory": "BusinessApplication",
+      "url": "https://www.jotform.com/",
+      "description": "Jotform is a no-code platform for forms, payments, e-signatures, workflows, apps and AI-powered customer interactions."
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "Does Jotform have a free plan?",
+          "acceptedAnswer": {"@type": "Answer", "text": "Yes. Jotform's Starter plan is free and currently includes 5 forms and 100 monthly submissions, with Jotform branding."}
+        },
+        {
+          "@type": "Question",
+          "name": "How much does Jotform cost?",
+          "acceptedAnswer": {"@type": "Answer", "text": "As of September 7, 2026, Jotform lists Bronze at $34 per month, Silver at $39 per month and Gold at $99 per month when billed annually. Enterprise uses custom pricing."}
+        },
+        {
+          "@type": "Question",
+          "name": "Does Jotform offer a paid-plan trial?",
+          "acceptedAnswer": {"@type": "Answer", "text": "Jotform says it does not offer a trial period for paid plans. The free Starter plan can be used to test standard features before upgrading."}
+        },
+        {
+          "@type": "Question",
+          "name": "What are Jotform AI Agents for?",
+          "acceptedAnswer": {"@type": "Answer", "text": "Jotform AI Agents are designed for automated customer interactions such as answering FAQs, collecting information and supporting users across web and other supported channels."}
+        }
+      ]
     }
     </script>
 
-    <!-- Tailwind & Fonts -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,133 +61,147 @@
     </style>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
-    <!-- Header Navigation -->
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+    <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-sm">C</div>
+          <span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
+        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Browse all tools</a>
       </div>
     </header>
 
-    <!-- Tool Detail Hero Section -->
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full">
-      <div class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-8">
-        
-        <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 border-b border-[#222538] pb-6">
+    <main class="max-w-5xl mx-auto px-4 py-12 w-full space-y-8">
+      <section class="p-7 md:p-9 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-7">
+        <div class="flex flex-col md:flex-row md:items-center justify-between gap-6">
           <div class="flex items-center gap-5">
-            <img src="https://www.google.com/s2/favicons?domain=jotform.com&sz=128" alt="Jotform logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" onError="this.onerror=null;this.src='data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>'" />
+            <img src="https://www.google.com/s2/favicons?domain=jotform.com&sz=128" alt="Jotform logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" />
             <div>
-              <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300 mb-2">
-                <span>Coding & Dev Tools</span>
-              </div>
-              <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Jotform</h1>
+              <div class="text-xs uppercase tracking-[0.18em] text-purple-300 font-bold mb-2">Forms, workflows & AI customer support</div>
+              <h1 class="text-4xl md:text-5xl font-black text-white tracking-tight">Jotform pricing & buyer guide</h1>
+              <p class="text-sm text-slate-400 mt-2">Updated September 7, 2026</p>
             </div>
           </div>
+        </div>
 
-          <div class="flex items-center gap-2 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-2 rounded-xl text-sm font-bold">
-            <span>Not yet editorially rated</span>
+        <p class="text-lg leading-relaxed text-slate-300 max-w-4xl">Jotform is strongest when you want one no-code stack for forms, payments, e-signatures and workflow capture. The free Starter plan is enough to validate a use case; paid plans mainly raise limits and remove branding. If your goal is automated customer service rather than form building alone, Jotform AI Agents is the more relevant path.</p>
+
+        <div class="grid md:grid-cols-3 gap-4">
+          <div class="p-5 rounded-2xl bg-[#0f1119] border border-[#222538]">
+            <div class="text-xs uppercase font-bold text-slate-500">Best low-risk start</div>
+            <div class="text-xl font-extrabold text-white mt-1">Starter — Free</div>
+            <p class="text-sm text-slate-400 mt-2">5 forms, 100 monthly submissions and Jotform branding.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#0f1119] border border-purple-500/30">
+            <div class="text-xs uppercase font-bold text-purple-300">Best value paid tier</div>
+            <div class="text-xl font-extrabold text-white mt-1">Silver — $39/mo</div>
+            <p class="text-sm text-slate-400 mt-2">Annual billing rate; 50 forms and 2,500 monthly submissions.</p>
+          </div>
+          <div class="p-5 rounded-2xl bg-[#0f1119] border border-[#222538]">
+            <div class="text-xs uppercase font-bold text-slate-500">Automation angle</div>
+            <div class="text-xl font-extrabold text-white mt-1">AI Agents</div>
+            <p class="text-sm text-slate-400 mt-2">24/7 FAQ handling, web embed, knowledge-base training and multi-channel interactions.</p>
           </div>
         </div>
 
-        <!-- Description -->
-        <div class="space-y-3">
-          <h2 class="text-xl font-bold text-white">Overview</h2>
-          <p class="text-slate-300 text-base leading-relaxed">Jotform is a powerful online form builder that helps businesses create custom forms for data collection, payments, and workflow automation without any coding. Design surveys, applications, and order forms with ease.</p>
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a data-cta="affiliate" data-cta-source="jotform-hero-ai-agents" href="https://link.jotform.com/17STYVOunG?username=AnSangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 hover:bg-purple-500 text-white text-center transition-all">Try Jotform AI Agents →</a>
+          <a data-cta="official" data-cta-source="jotform-hero-pricing" href="https://www.jotform.com/pricing/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 hover:bg-slate-700 text-white text-center border border-slate-600 transition-all">Check official Jotform pricing →</a>
         </div>
+        <p class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: the Jotform AI Agents button uses a customer-facing partner link supplied in COSHUMA's Jotform affiliate onboarding. COSHUMA may earn a commission from qualifying referrals. The pricing button is a non-affiliate official Jotform link.</p>
+      </section>
 
-        <!-- Key Features -->
-        <div class="space-y-4">
-          <h2 class="text-xl font-bold text-white">Key Features & Capabilities</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Drag-and-Drop Form Builder</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Payment Integrations</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> Workflow Automation</div>
-<div class="flex items-center gap-2.5 p-3 rounded-xl bg-[#131520] border border-[#222538] text-sm text-slate-200"><span class="text-purple-400 font-bold">✓</span> E-Signature Capabilities</div>
-          </div>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <div>
+          <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Current public pricing</div>
+          <h2 class="text-3xl font-black text-white mt-2">Which Jotform plan fits?</h2>
+          <p class="text-sm text-slate-400 mt-2">The amounts below are the annual-billing rates shown on Jotform's official pricing page on September 7, 2026. Local taxes and currency conversion may differ.</p>
         </div>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm min-w-[760px]">
+            <thead class="text-left text-slate-400 border-b border-[#222538]">
+              <tr><th class="py-3 pr-4">Plan</th><th class="py-3 pr-4">Price</th><th class="py-3 pr-4">Forms</th><th class="py-3 pr-4">Monthly submissions</th><th class="py-3">Best fit</th></tr>
+            </thead>
+            <tbody class="divide-y divide-[#222538] text-slate-300">
+              <tr><td class="py-4 pr-4 font-bold text-white">Starter</td><td class="py-4 pr-4 text-emerald-400 font-bold">Free</td><td class="py-4 pr-4">5</td><td class="py-4 pr-4">100</td><td class="py-4">Testing forms and small personal workflows</td></tr>
+              <tr><td class="py-4 pr-4 font-bold text-white">Bronze</td><td class="py-4 pr-4">$34/mo</td><td class="py-4 pr-4">25</td><td class="py-4 pr-4">1,000</td><td class="py-4">Freelancers and small teams outgrowing Starter</td></tr>
+              <tr><td class="py-4 pr-4 font-bold text-white">Silver</td><td class="py-4 pr-4">$39/mo</td><td class="py-4 pr-4">50</td><td class="py-4 pr-4">2,500</td><td class="py-4">Small-to-mid-sized businesses needing more capacity</td></tr>
+              <tr><td class="py-4 pr-4 font-bold text-white">Gold</td><td class="py-4 pr-4">$99/mo</td><td class="py-4 pr-4">100</td><td class="py-4 pr-4">10,000</td><td class="py-4">High-volume teams and optional HIPAA-enabled features</td></tr>
+              <tr><td class="py-4 pr-4 font-bold text-white">Enterprise</td><td class="py-4 pr-4">Custom</td><td class="py-4 pr-4">Unlimited</td><td class="py-4 pr-4">Unlimited</td><td class="py-4">Multiuser organizations requiring SSO, SLA or data residency</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="rounded-2xl border border-amber-500/20 bg-amber-500/5 p-5 text-sm text-slate-300">Jotform says there is no trial period for paid plans. The safer route is to validate the workflow on Starter first, then upgrade only when form, submission, storage or branding limits become restrictive.</div>
+      </section>
 
-        <!-- Pros & Cons Section -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-emerald-400 flex items-center gap-2">👍 Key Advantages (Pros)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Editorial review in progress</li>
-              <li>Flexible pricing structure (See official pricing)</li>
-              <li>Seamless workflow integration & API support</li>
+      <section class="p-7 rounded-3xl bg-purple-500/5 border border-purple-500/30 space-y-5">
+        <div>
+          <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Revenue-ready partner path</div>
+          <h2 class="text-3xl font-black text-white mt-2">Choose AI Agents when the problem is support, not just forms</h2>
+        </div>
+        <p class="text-slate-300 leading-relaxed">Jotform's AI Agents are a better fit when visitors need answers and actions in a conversation. Jotform's current documentation highlights 24/7 customer service, website embedding, training from websites/documents/FAQs, automatic website recrawling and support across channels including chat, phone, WhatsApp, Instagram, Gmail, Salesforce and SMS.</p>
+        <div class="grid md:grid-cols-2 gap-4">
+          <div class="p-5 rounded-2xl bg-[#11131d] border border-[#222538] space-y-2">
+            <h3 class="font-extrabold text-white">Good use cases</h3>
+            <ul class="text-sm text-slate-400 space-y-2 list-disc list-inside">
+              <li>Answer repetitive pre-sales or support questions 24/7</li>
+              <li>Collect structured information during a conversation</li>
+              <li>Train an agent from your website, FAQs or documents</li>
+              <li>Embed an agent on an existing site without building a support app from scratch</li>
             </ul>
           </div>
-
-          <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20 space-y-2">
-            <h3 class="text-sm font-bold text-rose-400 flex items-center gap-2">⚠️ Considerations (Cons)</h3>
-            <ul class="text-xs text-slate-300 space-y-1.5 list-disc list-inside">
-              <li>Requires active internet connection</li>
-              <li>Advanced features require premium tier subscription</li>
+          <div class="p-5 rounded-2xl bg-[#11131d] border border-[#222538] space-y-2">
+            <h3 class="font-extrabold text-white">Start with the normal Form Builder when</h3>
+            <ul class="text-sm text-slate-400 space-y-2 list-disc list-inside">
+              <li>You mainly need surveys, applications or payment forms</li>
+              <li>The workflow is deterministic and does not need conversation</li>
+              <li>You want to validate the process on the free Starter plan first</li>
+              <li>You need e-signatures or form limits more than chatbot automation</li>
             </ul>
           </div>
         </div>
-
-        <!-- Alternatives & Direct Competitors Section -->
-        <div class="space-y-4 pt-4 border-t border-[#222538]">
-          <h2 class="text-xl font-bold text-white flex items-center justify-between">
-            <span>Top Alternatives to Jotform</span>
-            <span class="text-xs font-semibold text-purple-400">Compare Alternatives</span>
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <a href="/tool/make-com.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=make.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Make.com</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/unbounce.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=unbounce.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Unbounce</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-<a href="/tool/webflow.html" class="p-3.5 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 transition-all flex items-center justify-between group"><div class="flex items-center gap-2.5"><img src="https://www.google.com/s2/favicons?domain=webflow.com&sz=128" class="h-6 w-6 rounded object-contain p-0.5 bg-slate-900 border border-[#222538]" onError="this.style.display='none'"/><span class="text-xs font-bold text-slate-200 group-hover:text-purple-300">Webflow</span></div><span class="text-[10px] font-extrabold text-emerald-400">See official pricing</span></a>
-          </div>
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a data-cta="affiliate" data-cta-source="jotform-ai-usecase" href="https://link.jotform.com/17STYVOunG?username=AnSangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white text-sm font-extrabold text-center">Build a Jotform AI Agent →</a>
+          <a href="https://www.jotform.com/ai/agents/pricing/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-slate-800 hover:bg-slate-700 border border-slate-600 text-white text-sm font-extrabold text-center">View official AI Agent limits →</a>
         </div>
+      </section>
 
-        <!-- Pricing & Action -->
-        <div class="p-6 rounded-2xl bg-[#181a29] border border-[#222538] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div>
-            <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
-            <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
-          </div>
-          <a data-cta="official" href="https://www.jotform.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official Jotform Site</span><span>→</span></a>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+        <h2 class="text-3xl font-black text-white">Decision shortcuts</h2>
+        <div class="grid md:grid-cols-3 gap-4">
+          <a href="/compare/make-com-vs-jotform.html" class="p-5 rounded-2xl bg-[#0f1119] border border-[#222538] hover:border-purple-500/40 transition-all">
+            <div class="font-extrabold text-white">Make.com vs Jotform</div><p class="text-sm text-slate-400 mt-2">Choose between workflow automation and form-first data capture.</p>
+          </a>
+          <a href="/compare/unbounce-vs-jotform.html" class="p-5 rounded-2xl bg-[#0f1119] border border-[#222538] hover:border-purple-500/40 transition-all">
+            <div class="font-extrabold text-white">Unbounce vs Jotform</div><p class="text-sm text-slate-400 mt-2">Compare landing-page conversion optimization with forms and workflows.</p>
+          </a>
+          <a href="/tool/chatbase.html" class="p-5 rounded-2xl bg-[#0f1119] border border-[#222538] hover:border-purple-500/40 transition-all">
+            <div class="font-extrabold text-white">Chatbase</div><p class="text-sm text-slate-400 mt-2">Compare a dedicated AI support-agent product with Jotform's broader suite.</p>
+          </a>
         </div>
+      </section>
 
-        <!-- Claim Profile & Official Founder Badge Section -->
-        <div class="p-6 rounded-2xl bg-[#181a29]/80 border border-purple-500/30 space-y-4">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2 text-purple-300 font-bold text-sm">
-              <span>🏆 Are you the founder of Jotform?</span>
-            </div>
-            <span class="text-[10px] uppercase tracking-wider font-extrabold bg-purple-500/20 text-purple-300 px-2.5 py-0.5 rounded-full border border-purple-500/30">Founder Verification</span>
-          </div>
-          <p class="text-xs text-slate-400 leading-relaxed">
-            Claim this official profile to update tool information, manage pricing details, and embed the verified rating badge on your website:
-          </p>
-          <div class="p-3 rounded-xl bg-[#0b0c10] border border-[#222538] text-[11px] text-slate-400 font-mono">
-            ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
-          </div>
-          <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim Jotform Profile ($49/yr)
-            </a>
-          </div>
-          <div class="relative pt-2">
-            <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
-            <textarea readonly class="w-full bg-[#0b0c10] border border-[#222538] text-[11px] font-mono text-slate-300 p-3 rounded-xl focus:outline-none resize-none h-16">&lt;a href="https://coshuma.com/tool/jotform.html" target="_blank" title="Featured on GlobalSaaSHub TOP AI"&gt;&lt;img src="https://coshuma.com/assets/verified-badge.svg" alt="Jotform Verified on GlobalSaaSHub" width="200" /&gt;&lt;/a&gt;</textarea>
-          </div>
+      <section class="p-7 rounded-3xl bg-[#131520] border border-[#222538] space-y-4">
+        <h2 class="text-2xl font-black text-white">Bottom line</h2>
+        <p class="text-slate-300 leading-relaxed">Start on Jotform Starter if forms are the core need. Move to Bronze, Silver or Gold when limits or branding become the bottleneck. If the actual job is conversational customer support, test Jotform AI Agents instead of paying for a larger form plan just to solve the wrong problem.</p>
+        <div class="flex flex-col sm:flex-row gap-3">
+          <a data-cta="affiliate" data-cta-source="jotform-bottom-ai-agents" href="https://link.jotform.com/17STYVOunG?username=AnSangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white text-sm font-extrabold text-center">Try Jotform AI Agents →</a>
+          <a href="https://www.jotform.com/pricing/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-slate-800 hover:bg-slate-700 border border-slate-600 text-white text-sm font-extrabold text-center">Compare official Jotform plans →</a>
         </div>
+      </section>
 
-
-      </div>
+      <section data-sponsorship-inquiry="tool" class="p-6 rounded-3xl bg-violet-500/5 border border-violet-500/20 space-y-3">
+        <div class="text-[10px] uppercase tracking-wider font-bold text-violet-300">Represent Jotform?</div>
+        <h2 class="text-xl font-extrabold text-white">Request a COSHUMA sponsored placement</h2>
+        <p class="text-xs text-slate-400 leading-relaxed">A one-time sponsored placement is USD 49. Sponsorship is reviewed separately from editorial coverage; payment does not guarantee acceptance, ranking or an editorial rating.</p>
+        <a data-cta="sponsorship-inquiry" data-cta-source="jotform-sponsorship" href="mailto:support@coshuma.com?subject=COSHUMA%20%2449%20sponsorship%20inquiry&amp;body=Product%20name%3A%20Jotform%0AWebsite%3A%20https%3A%2F%2Fwww.jotform.com%2F%0APlacement%20goal%3A%0A" class="inline-flex items-center justify-center px-5 py-3 rounded-xl bg-violet-600 hover:bg-violet-500 text-white text-xs font-extrabold transition-all">Email a sponsorship request →</a>
+        <p class="text-[10px] text-slate-500">This inquiry link does not create a charge.</p>
+      </section>
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.
-      </div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent SaaS buyer guides.</div>
     </footer>
+    <script src="/affiliate-attribution.js" defer></script>
   </body>
 </html>
-


### PR DESCRIPTION
Revenue-first CRO update for the existing Jotform page.

Evidence used:
- Jotform affiliate onboarding explicitly identifies `https://link.jotform.com/17STYVOunG?username=AnSangkwon` as the targeted Jotform AI Agents affiliate link and says custom links track back to the partner account.
- Jotform's current official pricing page lists Starter free, Bronze $34/mo, Silver $39/mo, Gold $99/mo when billed annually, Enterprise custom, and says paid plans do not have a trial period.
- Jotform's current AI Agents documentation describes 24/7 support, website embedding, knowledge training and multi-channel customer interactions.

Changes:
- Replace stale legacy template/review placeholders with current buyer-intent copy.
- Keep normal Jotform pricing links non-affiliate.
- Add three distinct, attributable CTAs using only the verified AI Agents partner URL.
- Add current plan comparison, AI Agents use-case qualification, FAQ schema and internal comparison links.
- Keep sponsorship as an inquiry-only path; no charge is created from the page.

No paid service, guessed tracking parameter or generic dashboard/onboarding URL is introduced.