### PR TITLE
Add CORA character-led Make Short and autonomous upload workflow

### DIFF
--- a/.github/workflows/coshuma-character-short-upload.yml
+++ b/.github/workflows/coshuma-character-short-upload.yml
@@ -1,0 +1,82 @@
+name: COSHUMA Character Short Upload
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/coshuma-character-short-upload.yml'
+      - 'projects/GlobalSaaSHub/data/youtube_character_upload_request.json'
+
+permissions:
+  contents: write
+
+jobs:
+  upload-character-short:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: projects/GlobalSaaSHub
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Install free dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y ffmpeg jq
+          pip install requests
+
+      - name: Download requested video
+        run: |
+          set -euo pipefail
+          VIDEO_URL=$(jq -r '.video_url' data/youtube_character_upload_request.json)
+          test -n "$VIDEO_URL"
+          curl -fL --retry 3 "$VIDEO_URL" -o /tmp/coshuma-character-short.mp4
+          ffprobe -v error -show_entries stream=width,height -show_entries format=duration,size -of json /tmp/coshuma-character-short.mp4
+
+      - name: Upload to YouTube
+        env:
+          YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
+          YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
+          YOUTUBE_REFRESH_TOKEN: ${{ secrets.YOUTUBE_REFRESH_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          from scripts.youtube_shorts.upload_youtube import upload
+
+          request = json.loads(Path('data/youtube_character_upload_request.json').read_text(encoding='utf-8'))
+          video_id = upload(
+              Path('/tmp/coshuma-character-short.mp4'),
+              request['title'],
+              request['description'],
+              request.get('privacy', 'unlisted'),
+          )
+          result = {
+              'campaign_slug': request['campaign_slug'],
+              'youtube_video_id': video_id,
+              'youtube_url': f'https://youtube.com/shorts/{video_id}',
+              'privacy': request.get('privacy', 'unlisted'),
+              'character_name': request.get('character_name'),
+              'source_video_url': request['video_url'],
+          }
+          Path('data/youtube_character_upload_result.json').write_text(
+              json.dumps(result, indent=2, ensure_ascii=False) + '\n', encoding='utf-8'
+          )
+          print(json.dumps(result, ensure_ascii=False))
+          PY
+
+      - name: Persist upload evidence
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add data/youtube_character_upload_result.json
+          git commit -m 'chore(youtube): record character short upload [skip ci]' || exit 0
+          git push origin HEAD:main

--- a/projects/GlobalSaaSHub/data/youtube_character_assets.json
+++ b/projects/GlobalSaaSHub/data/youtube_character_assets.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "characters": [
+    {
+      "name": "CORA-COSHUMA",
+      "role": "Recurring COSHUMA SaaS workflow guide",
+      "higgsfield_reference_element_id": "803f2f5e-2763-4492-8638-48a9d8d00b68",
+      "reference_media_url": "https://d2ol7oe51mr4n9.cloudfront.net/user_31CEl0VJ93W86g07a1gb5c1p4C0/c4235ce2-98fd-4c34-b9cf-c73d166bf629.png",
+      "visual_identity": "Purple-teal hair, dark blazer, white shirt, COSHUMA badge",
+      "usage_rule": "Reuse the same reference element across future Shorts. Change situation, pose and scene; do not redesign the character per tool.",
+      "created_at": "2026-09-07"
+    }
+  ]
+}

--- a/projects/GlobalSaaSHub/data/youtube_character_upload_request.json
+++ b/projects/GlobalSaaSHub/data/youtube_character_upload_request.json
@@ -1,0 +1,8 @@
+{
+  "campaign_slug": "make_cora_workflow",
+  "character_name": "CORA-COSHUMA",
+  "video_url": "https://d2ol7oe51mr4n9.cloudfront.net/user_31CEl0VJ93W86g07a1gb5c1p4C0/040893ef-dd47-4bc3-9e23-d8cda47c3984.mp4",
+  "title": "Stop Copying Leads by Hand: Build This Make Workflow | COSHUMA #Shorts",
+  "description": "CORA shows a simple Make workflow idea: Gmail → filter → Google Sheets → Slack. The goal is repeatable automation, not flashy AI or guaranteed income.\n\nFull COSHUMA Make guide: https://coshuma.com/tool/make-com.html?utm_source=youtube&utm_medium=shorts&utm_campaign=make_cora_workflow\n\nCOSHUMA may earn a commission from eligible partner links on the guide page.\n\n#Make #Automation #NoCode #SaaS #Shorts",
+  "privacy": "unlisted"
+}


### PR DESCRIPTION
Creates a reusable COSHUMA character asset (CORA), queues a character-led Make workflow Short, and adds a safe YouTube upload workflow using the existing OAuth secrets. The pilot is uploaded as **unlisted** to avoid publishing a first-pass creative publicly before quality review. No paid service or new subscription is used.