### PR TITLE
Turn Chatbase comparisons into verified revenue paths

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/chatbase-vs-privy.html
+++ b/projects/GlobalSaaSHub/public/compare/chatbase-vs-privy.html
@@ -1,172 +1,64 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Chatbase vs Privy Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Chatbase vs Privy. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chatbase vs Privy: AI Support or Ecommerce Marketing? (2026) | COSHUMA</title>
+  <meta name="description" content="Chatbase vs Privy is mostly a workflow choice: AI customer-support agents versus ecommerce email, SMS and pop-ups. Compare current pricing, free trials and the best fit." />
+  <link rel="canonical" href="https://coshuma.com/compare/chatbase-vs-privy.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/chatbase-vs-privy.html" />
+  <meta property="og:title" content="Chatbase vs Privy: AI Support or Ecommerce Marketing? (2026)" />
+  <meta property="og:description" content="Choose between AI customer-support agents and ecommerce email/SMS/pop-up marketing based on the job you need done." />
+  <script type="application/ld+json">{
+    "@context":"https://schema.org","@type":"WebPage","name":"Chatbase vs Privy","url":"https://coshuma.com/compare/chatbase-vs-privy.html","dateModified":"2026-09-07","isPartOf":{"@type":"WebSite","name":"COSHUMA","url":"https://coshuma.com/"},"about":[{"@type":"SoftwareApplication","name":"Chatbase","url":"https://coshuma.com/tool/chatbase.html"},{"@type":"SoftwareApplication","name":"Privy","url":"https://coshuma.com/tool/privy.html"}]}
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen bg-[#0b0c10]">
+<header class="border-b border-[#222538] bg-[#07080c]/90 sticky top-0 z-50"><div class="max-w-5xl mx-auto px-5 py-4 flex items-center justify-between"><a href="/" class="font-black text-xl text-white">COSHUMA</a><a href="/tool/chatbase.html" class="text-sm font-bold text-purple-300 hover:text-purple-200">Chatbase buyer guide →</a></div></header>
+<main class="max-w-5xl mx-auto px-5 py-12 space-y-8">
+  <section class="text-center space-y-4">
+    <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Buyer decision guide · Updated Sep 7, 2026</div>
+    <h1 class="text-4xl md:text-6xl font-black tracking-tight">Chatbase vs Privy</h1>
+    <p class="text-lg text-slate-300 max-w-3xl mx-auto">These tools solve different jobs. <strong class="text-white">Chatbase</strong> builds AI agents for customer support and customer-facing conversations. <strong class="text-white">Privy</strong> focuses on ecommerce email, SMS, pop-ups and conversion campaigns.</p>
+  </section>
 
-    <link rel="canonical" href="https://coshuma.com/compare/chatbase-vs-privy.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/chatbase-vs-privy.html" />
-    <meta property="og:title" content="Chatbase vs Privy Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Chatbase and Privy by pricing, features, and verified public information." />
+  <section class="grid md:grid-cols-2 gap-5">
+    <article class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
+      <div class="text-purple-300 font-extrabold">Choose Chatbase when…</div>
+      <h2 class="text-2xl font-black">Support questions are the bottleneck</h2>
+      <ul class="space-y-2 text-slate-300 text-sm"><li>✓ You want an AI agent trained on business knowledge.</li><li>✓ You need customer conversations across chat and other support channels.</li><li>✓ You want to automate repetitive support before adding more human handling.</li></ul>
+      <div class="rounded-2xl bg-black/20 p-4 text-sm"><strong class="text-white">Current entry point:</strong> Free at $0/month with 50 message credits/month. Hobby is $40/month and currently offers a 7-day trial.</div>
+      <a data-cta="affiliate" data-tool-id="chatbase" data-cta-source="compare-chatbase-vs-privy-hero" href="https://link.chatbase.co/sang-kwon-an" target="_blank" rel="sponsored noopener noreferrer" class="block text-center py-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-black text-white">Try Chatbase via partner link →</a>
+      <p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if you become a customer through this partner link, at no extra cost to you.</p>
+    </article>
 
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "Chatbase vs Privy Comparison",
-      "url": "https://coshuma.com/compare/chatbase-vs-privy.html",
-      "description": "Compare Chatbase and Privy by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "Chatbase", "url": "https://coshuma.com/tool/chatbase.html"},
-        {"@type": "SoftwareApplication", "name": "Privy", "url": "https://coshuma.com/tool/privy.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
-      </div>
-    </header>
+    <article class="p-6 rounded-3xl bg-[#131520] border border-blue-500/30 space-y-4">
+      <div class="text-blue-300 font-extrabold">Choose Privy when…</div>
+      <h2 class="text-2xl font-black">Store conversion and retention are the bottleneck</h2>
+      <ul class="space-y-2 text-slate-300 text-sm"><li>✓ You need ecommerce email and SMS campaigns.</li><li>✓ You want pop-ups, targeting and segmentation.</li><li>✓ You care more about capturing and converting shoppers than answering broad support questions.</li></ul>
+      <div class="rounded-2xl bg-black/20 p-4 text-sm"><strong class="text-white">Current entry point:</strong> Email starts at $30/month; Pop-ups & Displays starts at $24/month. Privy currently advertises a 15-day free trial with no credit card required.</div>
+      <a href="https://www.privy.com/pricing" target="_blank" rel="noopener noreferrer" class="block text-center py-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-black text-white">See Privy official pricing →</a>
+      <p class="text-[11px] text-slate-500">COSHUMA has not verified a Privy revenue link for this page, so this button goes to Privy's official pricing page.</p>
+    </article>
+  </section>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Chatbase vs Privy</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Sales & CRM tool.
-        </p>
-      </div>
+  <section class="p-6 md:p-8 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+    <h2 class="text-2xl font-black">Fast decision</h2>
+    <div class="overflow-x-auto"><table class="w-full text-sm text-left"><thead class="text-slate-400"><tr><th class="py-3 pr-4">Need</th><th class="py-3 pr-4">Better fit</th><th class="py-3">Why</th></tr></thead><tbody class="divide-y divide-[#222538]"><tr><td class="py-4 pr-4">AI customer support</td><td class="py-4 pr-4 font-bold text-purple-300">Chatbase</td><td class="py-4 text-slate-300">AI agents, integrations and support-oriented automation.</td></tr><tr><td class="py-4 pr-4">Email/SMS marketing</td><td class="py-4 pr-4 font-bold text-blue-300">Privy</td><td class="py-4 text-slate-300">Campaigns, segmentation and ecommerce messaging.</td></tr><tr><td class="py-4 pr-4">Pop-ups / list growth</td><td class="py-4 pr-4 font-bold text-blue-300">Privy</td><td class="py-4 text-slate-300">Dedicated pop-up and display tooling.</td></tr><tr><td class="py-4 pr-4">Knowledge-trained website agent</td><td class="py-4 pr-4 font-bold text-purple-300">Chatbase</td><td class="py-4 text-slate-300">Built around AI agents using your business knowledge.</td></tr></tbody></table></div>
+  </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Chatbase if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Privy if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
-      </div>
+  <section class="p-6 md:p-8 rounded-3xl bg-purple-500/10 border border-purple-500/30 space-y-4">
+    <h2 class="text-2xl font-black">Best low-risk test</h2>
+    <p class="text-slate-300">If support automation is the problem, start with Chatbase's free tier and test it on a narrow set of real questions before paying. If ecommerce campaigns are the problem, use Privy's 15-day trial and measure captured leads, email engagement and attributable sales. Do not buy both just because the feature lists overlap.</p>
+    <div class="flex flex-col sm:flex-row gap-3"><a data-cta="affiliate" data-tool-id="chatbase" data-cta-source="compare-chatbase-vs-privy-bottom" href="https://link.chatbase.co/sang-kwon-an" target="_blank" rel="sponsored noopener noreferrer" class="flex-1 text-center py-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-black">Start with Chatbase →</a><a href="/best/chatbase-pricing-free-trial.html" class="flex-1 text-center py-4 rounded-xl border border-purple-500/30 bg-black/20 font-bold">Read Chatbase pricing guide</a></div>
+  </section>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/chatbase.html" class="hover:text-purple-300">Chatbase</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/privy.html" class="hover:text-blue-300">Privy</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">Varies</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Chatbase Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Build AI agents without code</div>
-<div>✓ Automate customer support</div>
-<div>✓ Streamline sales processes</div>
-<div>✓ Integrate with e-commerce platforms</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Privy Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Pop-up & Exit-Intent Campaigns</div>
-<div>✓ Email Marketing Automation</div>
-<div>✓ Customizable Landing Pages</div>
-<div>✓ Integrations with E-commerce Platforms</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://www.chatbase.co/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Chatbase →</a>
-          <a href="https://www.privy.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Privy →</a>
-        </div>
-      </div>
-    </main>
-
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
-  </body>
-</html>
+  <section class="text-xs text-slate-500 leading-relaxed">Pricing and product facts were checked against the vendors' official public pricing pages on Sep 7, 2026. Prices and trial terms can change. Chatbase source: <a class="underline" href="https://www.chatbase.co/pricing" target="_blank" rel="noopener noreferrer">official pricing</a>. Privy source: <a class="underline" href="https://www.privy.com/pricing" target="_blank" rel="noopener noreferrer">official pricing</a>.</section>
+</main>
+<footer class="border-t border-[#222538] py-8 text-center text-xs text-slate-500">© 2026 COSHUMA · Independent SaaS buyer guides</footer>
+</body></html>

--- a/projects/GlobalSaaSHub/public/compare/chatbase-vs-reply-io.html
+++ b/projects/GlobalSaaSHub/public/compare/chatbase-vs-reply-io.html
@@ -1,172 +1,64 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Chatbase vs Reply.io Comparison, Pricing & Winner (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="In-depth side-by-side comparison of Chatbase vs Reply.io. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chatbase vs Reply.io: Support AI or Sales Outreach? (2026) | COSHUMA</title>
+  <meta name="description" content="Chatbase vs Reply.io is a support-vs-outbound-sales decision. Compare current pricing, trials, best-fit workflows and which tool to test first." />
+  <link rel="canonical" href="https://coshuma.com/compare/chatbase-vs-reply-io.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/chatbase-vs-reply-io.html" />
+  <meta property="og:title" content="Chatbase vs Reply.io: Support AI or Sales Outreach? (2026)" />
+  <meta property="og:description" content="Pick Chatbase for customer-facing AI agents or Reply.io for outbound sales sequences and multichannel outreach." />
+  <script type="application/ld+json">{
+    "@context":"https://schema.org","@type":"WebPage","name":"Chatbase vs Reply.io","url":"https://coshuma.com/compare/chatbase-vs-reply-io.html","dateModified":"2026-09-07","isPartOf":{"@type":"WebSite","name":"COSHUMA","url":"https://coshuma.com/"},"about":[{"@type":"SoftwareApplication","name":"Chatbase","url":"https://coshuma.com/tool/chatbase.html"},{"@type":"SoftwareApplication","name":"Reply.io","url":"https://coshuma.com/tool/reply-io.html"}]}
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen bg-[#0b0c10]">
+<header class="border-b border-[#222538] bg-[#07080c]/90 sticky top-0 z-50"><div class="max-w-5xl mx-auto px-5 py-4 flex items-center justify-between"><a href="/" class="font-black text-xl text-white">COSHUMA</a><a href="/tool/chatbase.html" class="text-sm font-bold text-purple-300 hover:text-purple-200">Chatbase buyer guide →</a></div></header>
+<main class="max-w-5xl mx-auto px-5 py-12 space-y-8">
+  <section class="text-center space-y-4">
+    <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Buyer decision guide · Updated Sep 7, 2026</div>
+    <h1 class="text-4xl md:text-6xl font-black tracking-tight">Chatbase vs Reply.io</h1>
+    <p class="text-lg text-slate-300 max-w-3xl mx-auto"><strong class="text-white">Chatbase</strong> is built for customer-facing AI agents and support automation. <strong class="text-white">Reply.io</strong> is built for outbound sales outreach across email and multiple channels. The right choice depends on which side of the customer journey you need to automate.</p>
+  </section>
 
-    <link rel="canonical" href="https://coshuma.com/compare/chatbase-vs-reply-io.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/chatbase-vs-reply-io.html" />
-    <meta property="og:title" content="Chatbase vs Reply.io Comparison (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Compare Chatbase and Reply.io by pricing, features, and verified public information." />
+  <section class="grid md:grid-cols-2 gap-5">
+    <article class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
+      <div class="text-purple-300 font-extrabold">Choose Chatbase when…</div>
+      <h2 class="text-2xl font-black">Inbound support is consuming time</h2>
+      <ul class="space-y-2 text-slate-300 text-sm"><li>✓ You want AI agents trained on your business knowledge.</li><li>✓ You need to answer customer questions before escalating to a person.</li><li>✓ You want support-oriented integrations, analytics and customer-facing automation.</li></ul>
+      <div class="rounded-2xl bg-black/20 p-4 text-sm"><strong class="text-white">Current entry point:</strong> Free at $0/month with 50 message credits/month. Hobby is $40/month and currently offers a 7-day trial.</div>
+      <a data-cta="affiliate" data-tool-id="chatbase" data-cta-source="compare-chatbase-vs-reply-hero" href="https://link.chatbase.co/sang-kwon-an" target="_blank" rel="sponsored noopener noreferrer" class="block text-center py-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-black text-white">Try Chatbase via partner link →</a>
+      <p class="text-[11px] text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if you become a customer through this partner link, at no extra cost to you.</p>
+    </article>
 
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "Chatbase vs Reply.io Comparison",
-      "url": "https://coshuma.com/compare/chatbase-vs-reply-io.html",
-      "description": "Compare Chatbase and Reply.io by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "GlobalSaaSHub",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "Chatbase", "url": "https://coshuma.com/tool/chatbase.html"},
-        {"@type": "SoftwareApplication", "name": "Reply.io", "url": "https://coshuma.com/tool/reply-io.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
-      </div>
-    </header>
+    <article class="p-6 rounded-3xl bg-[#131520] border border-blue-500/30 space-y-4">
+      <div class="text-blue-300 font-extrabold">Choose Reply.io when…</div>
+      <h2 class="text-2xl font-black">Outbound prospecting is the bottleneck</h2>
+      <ul class="space-y-2 text-slate-300 text-sm"><li>✓ You need cold-email and sales-sequence automation.</li><li>✓ You want multichannel outreach that can include LinkedIn, calls, SMS or WhatsApp workflows.</li><li>✓ You are optimizing prospecting volume, deliverability and meetings rather than support resolution.</li></ul>
+      <div class="rounded-2xl bg-black/20 p-4 text-sm"><strong class="text-white">Current entry point:</strong> Reply's Email Volume pricing currently starts at $49/user/month billed annually. Multichannel currently starts at $89/user/month billed annually and advertises a 14-day trial.</div>
+      <a href="https://reply.io/pricing/" target="_blank" rel="noopener noreferrer" class="block text-center py-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-black text-white">See Reply.io official pricing →</a>
+      <p class="text-[11px] text-slate-500">COSHUMA has not verified a Reply.io revenue link for this page, so this button goes to Reply.io's official pricing page.</p>
+    </article>
+  </section>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Chatbase vs Reply.io</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Sales & CRM tool.
-        </p>
-      </div>
+  <section class="p-6 md:p-8 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+    <h2 class="text-2xl font-black">Fast decision</h2>
+    <div class="overflow-x-auto"><table class="w-full text-sm text-left"><thead class="text-slate-400"><tr><th class="py-3 pr-4">Need</th><th class="py-3 pr-4">Better fit</th><th class="py-3">Why</th></tr></thead><tbody class="divide-y divide-[#222538]"><tr><td class="py-4 pr-4">Website / support AI agent</td><td class="py-4 pr-4 font-bold text-purple-300">Chatbase</td><td class="py-4 text-slate-300">Designed around customer-facing AI agents trained on your data.</td></tr><tr><td class="py-4 pr-4">Cold email automation</td><td class="py-4 pr-4 font-bold text-blue-300">Reply.io</td><td class="py-4 text-slate-300">Sales sequences, deliverability and outbound workflow controls.</td></tr><tr><td class="py-4 pr-4">Multichannel prospecting</td><td class="py-4 pr-4 font-bold text-blue-300">Reply.io</td><td class="py-4 text-slate-300">Email plus sales-channel automation in one outreach workflow.</td></tr><tr><td class="py-4 pr-4">Reduce repetitive support handling</td><td class="py-4 pr-4 font-bold text-purple-300">Chatbase</td><td class="py-4 text-slate-300">Support automation is the core job rather than outbound prospecting.</td></tr></tbody></table></div>
+  </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose Chatbase if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You prioritize Not rated, specialized feature set, and reliable industry workflow integration.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Reply.io if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              You want an alternative approach with See official pricing pricing structure and Not rated.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
-      </div>
+  <section class="p-6 md:p-8 rounded-3xl bg-purple-500/10 border border-purple-500/30 space-y-4">
+    <h2 class="text-2xl font-black">Best low-risk test</h2>
+    <p class="text-slate-300">For inbound support, start with Chatbase's free plan and train one narrow agent on a real FAQ or product knowledge set. For outbound selling, use Reply.io's trial and test one clearly defined prospect segment. Measure the workflow outcome you actually care about instead of comparing unrelated feature counts.</p>
+    <div class="flex flex-col sm:flex-row gap-3"><a data-cta="affiliate" data-tool-id="chatbase" data-cta-source="compare-chatbase-vs-reply-bottom" href="https://link.chatbase.co/sang-kwon-an" target="_blank" rel="sponsored noopener noreferrer" class="flex-1 text-center py-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-black">Start with Chatbase →</a><a href="/best/chatbase-pricing-free-trial.html" class="flex-1 text-center py-4 rounded-xl border border-purple-500/30 bg-black/20 font-bold">Read Chatbase pricing guide</a></div>
+  </section>
 
-
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/chatbase.html" class="hover:text-purple-300">Chatbase</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/reply-io.html" class="hover:text-blue-300">Reply.io</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">GlobalSaaSHub Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">Varies</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">Chatbase Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Build AI agents without code</div>
-<div>✓ Automate customer support</div>
-<div>✓ Streamline sales processes</div>
-<div>✓ Integrate with e-commerce platforms</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Reply.io Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Multi-Channel Sales Sequences</div>
-<div>✓ AI Email Assistant</div>
-<div>✓ CRM Integrations</div>
-<div>✓ Performance Tracking & Reporting</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://www.chatbase.co/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Chatbase →</a>
-          <a href="https://reply.io/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Reply.io →</a>
-        </div>
-      </div>
-    </main>
-
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 GlobalSaaSHub. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
-  </body>
-</html>
+  <section class="text-xs text-slate-500 leading-relaxed">Pricing and product facts were checked against the vendors' official public pricing pages on Sep 7, 2026. Prices and trial terms can change. Chatbase source: <a class="underline" href="https://www.chatbase.co/pricing" target="_blank" rel="noopener noreferrer">official pricing</a>. Reply.io source: <a class="underline" href="https://reply.io/pricing/" target="_blank" rel="noopener noreferrer">official pricing</a>.</section>
+</main>
+<footer class="border-t border-[#222538] py-8 text-center text-xs text-slate-500">© 2026 COSHUMA · Independent SaaS buyer guides</footer>
+</body></html>


### PR DESCRIPTION
Rewrites two stale programmatic comparison pages into buyer-intent guides using current official pricing checked Sep 7, 2026. Replaces generic Chatbase homepage buttons with the already verified Chatbase partner URL, adds distinct CTA attribution sources, COSHUMA branding and affiliate disclosure. Privy and Reply.io remain non-affiliate official pricing links because no verified COSHUMA revenue URL is established for them here.