### PR TITLE
Record HelpDesk campaign-link revenue blocker from fresh Text support

### DIFF
--- a/projects/GlobalSaaSHub/data/browser_required_queue.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.json
@@ -104,6 +104,23 @@
     ]
   },
   {
+    "id": "text-helpdesk-campaign-affiliate-link",
+    "priority": "high",
+    "status": "browser_required",
+    "cost": "0",
+    "verified_at": "2026-09-07T12:15:27+09:00",
+    "gmail_thread_id": "1a056c2fa4964d52",
+    "gmail_message_id": "1a079dd172f5ca22",
+    "reason": "Text Support has now explicitly confirmed that Campaign affiliate links created in the authenticated Partner App are commission-bearing customer links, and that COSHUMA may create a HelpDesk-specific Campaign instead of using a generic URL. The exact generated HelpDesk customer-facing campaign URL has not yet been verified, so HelpDesk must remain non-monetized until that link is recovered.",
+    "next_action": "Reuse an already authenticated Text Partner App browser session and open https://partners.livechat.com/app/affiliate/campaigns. Prefer an existing active HelpDesk-specific campaign if one already exists; otherwise create a zero-cost HelpDesk-specific Campaign. Copy the exact generated customer-facing affiliate URL, verify that it routes to the intended HelpDesk signup/product destination and contains the account/campaign tracking assigned by Text, then update HelpDesk affiliate data and eligible COSHUMA HelpDesk CTAs.",
+    "do_not": [
+      "Do not treat https://partners.livechat.com/app/affiliate or /affiliate/campaigns as a revenue link; those are authenticated Partner App/dashboard locations.",
+      "Do not treat a generic helpdesk.com URL, Customer Portal URL, email tracking redirect, or https://share.text.com/CkwfynGH as the HelpDesk affiliate link unless the authenticated Campaign UI itself verifies it as the generated customer-facing campaign URL.",
+      "Do not guess or construct tracking parameters.",
+      "Do not submit another Text/HelpDesk affiliate application because the account is already enrolled."
+    ]
+  },
+  {
     "id": "coshuma-short-render-boldsign",
     "priority": "medium",
     "status": "browser_required",

--- a/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
+++ b/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
@@ -87,6 +87,17 @@ const statusOverrides = {
       'profile review expected in 3-5 business days',
     ],
   },
+  helpdesk: {
+    affiliate_verified: true,
+    affiliate_status: 'approved_account_campaign_link_pending',
+    affiliate_verified_at: '2026-09-07T12:15:27+09:00',
+    affiliate_evidence_markers: [
+      'Text Partner Program account enrolled',
+      'Text Support confirms Campaign affiliate links are commission-bearing customer links',
+      'Text Support permits creating a HelpDesk-specific Campaign instead of using a generic URL',
+      'Exact HelpDesk Campaign customer URL still requires authenticated Partner App verification',
+    ],
+  },
 };
 
 for (const file of ['data/tools.json', 'data/tools.next.json']) {


### PR DESCRIPTION
Revenue-first state correction using fresh primary account evidence from the connected Gmail thread with Text Support.

Verified new evidence (Sep 7, 2026):
- Text Support explicitly confirms that affiliate Campaign links created in the Partner App are commission-bearing customer links when the referred client creates an account through them.
- Support explicitly permits creating a HelpDesk-specific Campaign instead of using a generic URL.
- The exact generated customer-facing HelpDesk Campaign URL is still not verified, so this PR does **not** publish or guess a referral URL.

Changes:
- record HelpDesk as an approved affiliate-account state with `approved_account_campaign_link_pending`, while keeping `affiliate_url` unset
- add a high-priority `browser_required` queue item that tells the authenticated Work/browser session to recover and verify the exact HelpDesk-specific Campaign URL
- explicitly prohibit treating Partner App/dashboard URLs, generic HelpDesk links, portal links, or the support-provided share URL as a revenue URL without Campaign-UI verification
- record Gmail thread/message IDs as checkable provenance

No paid service, duplicate application, generic dashboard CTA, guessed tracking parameter, or unverified commission rate is introduced.