### PR TITLE
Improve Castmagic revenue attribution and COSHUMA conversion path

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/castmagic.html
+++ b/projects/GlobalSaaSHub/public/tool/castmagic.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Castmagic Pricing: Hobby vs Starter vs Team (2026) | GlobalSaaSHub</title>
+    <title>Castmagic Pricing: Hobby vs Starter vs Team (2026) | COSHUMA</title>
     <meta name="description" content="Compare Castmagic Hobby, Starter and Team pricing, transcription hours, storage, API access and content-repurposing workflows. Includes COSHUMA's verified Castmagic partner route." />
     <link rel="canonical" href="https://coshuma.com/tool/castmagic.html" />
 
@@ -37,11 +37,11 @@
   <body class="min-h-screen flex flex-col justify-between">
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">G</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">GlobalSaaSHub</span>
+        <a href="/index.html" class="flex items-center gap-3">
+          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div>
+          <span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span>
         </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
+        <a href="/index.html" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">← Back to All Tools</a>
       </div>
     </header>
 
@@ -82,10 +82,10 @@
         <p class="text-[11px] text-slate-500">*Castmagic's live pricing page currently shows these monthly equivalents on the annual-billing view and says annual billing saves 30%. It separately displays $239/yr, $579/yr and $1,669/yr. Confirm the final amount shown at checkout before paying.</p>
 
         <div class="flex flex-col sm:flex-row gap-3">
-          <a data-cta="affiliate" data-tool-id="castmagic" href="https://castmagic.io?fpr=sangkwon-an54" target="_blank" rel="sponsored noopener noreferrer" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Try Castmagic via COSHUMA →</a>
+          <a data-cta="affiliate" data-tool-id="castmagic" data-cta-source="castmagic-primary-hero" href="https://castmagic.io?fpr=sangkwon-an54" target="_blank" rel="sponsored noopener noreferrer" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Try Castmagic via COSHUMA →</a>
           <a href="/compare/castmagic-vs-tubebuddy.html" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-[#181a29] border border-[#30344c] text-white text-center hover:border-purple-500/50 transition-all">Castmagic vs TubeBuddy →</a>
         </div>
-        <p class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: the primary Castmagic button uses COSHUMA's verified partner URL. GlobalSaaSHub may earn a commission if you become a paying customer after using it, at no extra cost to you. Final prices, taxes, plan terms and eligibility are controlled by Castmagic.</p>
+        <p class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: the primary Castmagic button uses COSHUMA's verified partner URL. COSHUMA may earn a commission if you become a paying customer after using it, at no extra cost to you. Final prices, taxes, plan terms and eligibility are controlled by Castmagic.</p>
       </section>
 
       <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
@@ -103,6 +103,9 @@
             <h3 class="font-bold text-blue-300">Team for agencies and media teams</h3>
             <p class="text-slate-300 leading-relaxed">Team makes more sense when several people collaborate across brands or clients and the economics depend on a much larger media library, more spaces and priority support.</p>
           </div>
+        </div>
+        <div class="pt-1 text-center">
+          <a data-cta="affiliate" data-tool-id="castmagic" data-cta-source="castmagic-plan-mid" href="https://castmagic.io?fpr=sangkwon-an54" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-6 py-3.5 rounded-xl font-extrabold text-sm bg-purple-600 hover:bg-purple-500 text-white transition-all">See Castmagic plans via COSHUMA →</a>
         </div>
       </section>
 
@@ -142,7 +145,7 @@
       <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4 text-center">
         <h2 class="text-2xl font-black text-white">Best next step: test the workflow with a real recording</h2>
         <p class="text-sm text-slate-300 max-w-2xl mx-auto leading-relaxed">Use a podcast, webinar, interview or YouTube video you already own and judge whether the transcript plus downstream content outputs save enough editing and writing time to justify the plan you are considering.</p>
-        <a data-cta="affiliate" data-tool-id="castmagic" href="https://castmagic.io?fpr=sangkwon-an54" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Open Castmagic via COSHUMA →</a>
+        <a data-cta="affiliate" data-tool-id="castmagic" data-cta-source="castmagic-primary-bottom" href="https://castmagic.io?fpr=sangkwon-an54" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-7 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Open Castmagic via COSHUMA →</a>
         <p class="text-[10px] text-slate-500">Verified partner URL: castmagic.io?fpr=sangkwon-an54.</p>
       </section>
 
@@ -152,7 +155,7 @@
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Global AI SaaS Decision Platform. All rights reserved.</div>
+      <div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI SaaS decision platform. All rights reserved.</div>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
Revenue-focused, no-cost conversion improvement for the existing Castmagic buyer-intent page.

Verified evidence before change:
- Latest Castmagic affiliate welcome email (2026-08-24, FirstPromoter) provides the customer-facing referral URL `https://castmagic.io?fpr=sangkwon-an54`.
- The same latest email states 30% recurring commission and a 90-day cookie window.
- An older 2026-02-19 Castmagic affiliate email used a different Lemon Squeezy route and older terms, so this change deliberately preserves the newer FirstPromoter URL rather than reverting to stale evidence.

Changes:
- Keep the verified FirstPromoter partner URL unchanged.
- Add distinct CTA-source attribution for hero and bottom partner buttons.
- Add one new mid-page partner CTA immediately after plan-selection guidance, where purchase intent is strongest.
- Replace stale GlobalSaaSHub branding/disclosure/footer text with COSHUMA.
- Do not change pricing claims or invent conversion/revenue results.

No paid services or subscription changes are involved.