### PR TITLE
feat(coshuma): add verified Chatbase buyer decision summary

### DIFF
--- a/projects/GlobalSaaSHub/data/chatbase-buyer-box-evidence.md
+++ b/projects/GlobalSaaSHub/data/chatbase-buyer-box-evidence.md
@@ -1,0 +1,7 @@
+# Chatbase buyer decision box — 2026-09-07
+
+Official pricing: https://www.chatbase.co/pricing . Monthly Hobby starts at $40, Free includes 50 message credits, and Hobby/Standard/Pro list 7-day trials. Free agents are deleted after 14 days of inactivity. Add-ons are separately priced. Fit guidance is editorial inference, not a hands-on benchmark.
+
+Chatbase support email dated 2026-09-05 16:50:28 UTC directly provided https://link.chatbase.co/sang-kwon-an after reviewing the partner account. Re-read through Gmail on 2026-09-07. This agrees with scripts/sync_verified_affiliates.mjs and the resolved browser-required queue. Raw tools.json has a stale legacy inactive record; the existing production sync explicitly sets this verified route to approved_tracking. Run that same sync before local build. Do not reapply or replace the link with a dashboard.
+
+Only a compact summary is inserted before the existing pricing section. Existing hero, detailed table, FAQ, JSON-LD, disclosures and CTA source labels are preserved. Product-specific config fields prevent Omi claims leaking into Chatbase. Script inclusion is not proof of GA4 receipt, signup, commission or revenue.

--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -72,7 +72,10 @@
     "affiliate_status": "program_closed_to_new_applicants",
     "affiliate_source_url": "https://www.notion.com/en-gb/affiliates",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["20% of year one revenue", "currently not accepting new affiliates"]
+    "affiliate_evidence_markers": [
+      "20% of year one revenue",
+      "currently not accepting new affiliates"
+    ]
   },
   {
     "id": "make-com",
@@ -108,7 +111,14 @@
     "affiliate_source_url": "https://www.make.com/en/affiliate",
     "affiliate_final_url": "https://www.make.com/en?pc=coshuma",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["35% commission", "12 months", "Partner code created", "pc=coshuma", "Wise Business Basic account created", "receiving account details not issued"],
+    "affiliate_evidence_markers": [
+      "35% commission",
+      "12 months",
+      "Partner code created",
+      "pc=coshuma",
+      "Wise Business Basic account created",
+      "receiving account details not issued"
+    ],
     "payout_setup_status": "deferred_until_payout_threshold",
     "payout_setup_note": "Do not submit invented Wise bank details. Affiliate earnings may accrue on-platform; before an actual payout, complete Wise Business Advanced activation and identity verification, then register only issued receiving account details.",
     "payout_account_email": "support@coshuma.com",
@@ -151,7 +161,12 @@
     "affiliate_source_url": "https://elevenlabs.io/affiliates",
     "affiliate_final_url": "https://try.elevenlabs.io/ldc2xmh2x2t5",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["22% commission", "12 months", "active affiliate account", "Default affiliate link"]
+    "affiliate_evidence_markers": [
+      "22% commission",
+      "12 months",
+      "active affiliate account",
+      "Default affiliate link"
+    ]
   },
   {
     "id": "copy-ai",
@@ -218,7 +233,10 @@
     "affiliate_source_url": "https://www.zenrows.com/partners/affiliates",
     "affiliate_final_url": "https://www.zenrows.com/partners/apply",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["35% recurring", "approved the same day"]
+    "affiliate_evidence_markers": [
+      "35% recurring",
+      "approved the same day"
+    ]
   },
   {
     "id": "tubebuddy",
@@ -254,7 +272,11 @@
     "affiliate_source_url": "https://support.tubebuddy.com/hc/en-us/sections/8981416080411-Affiliates",
     "affiliate_final_url": "https://www.tubebuddy.com/pricing?a=coshuma",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["successfully set up your Affiliate account", "15% Commission", "Affiliate Link"]
+    "affiliate_evidence_markers": [
+      "successfully set up your Affiliate account",
+      "15% Commission",
+      "Affiliate Link"
+    ]
   },
   {
     "id": "outlierkit",
@@ -290,7 +312,11 @@
     "affiliate_source_url": "https://outlierkit.com/p/affiliate",
     "affiliate_final_url": "https://outlierkit.com/?ref=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["20% on all paid customers", "all set up and ready to go", "partner link"]
+    "affiliate_evidence_markers": [
+      "20% on all paid customers",
+      "all set up and ready to go",
+      "partner link"
+    ]
   },
   {
     "id": "pictory",
@@ -460,7 +486,11 @@
     "affiliate_source_url": "https://writesonic.com/affiliate",
     "affiliate_final_url": "https://affiliates.writesonic.com/home",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["20% recurring", "12 months", "Your application has been rejected"],
+    "affiliate_evidence_markers": [
+      "20% recurring",
+      "12 months",
+      "Your application has been rejected"
+    ],
     "affiliate_rejection_reason": "The authenticated Writesonic affiliate dashboard explicitly shows that the application was rejected."
   },
   {
@@ -498,7 +528,12 @@
     "affiliate_source_url": "https://sudowrite.notion.site/Sudowrite-Affiliate-Program-12788b26b71746f2a72cd05b7087e8c9",
     "affiliate_final_url": "https://www.sudowrite.com?via=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["Welcome to the Sudowrite partner program", "25% on all payments, first 12 months", "60 day cookie", "affiliate link"]
+    "affiliate_evidence_markers": [
+      "Welcome to the Sudowrite partner program",
+      "25% on all payments, first 12 months",
+      "60 day cookie",
+      "affiliate link"
+    ]
   },
   {
     "id": "convertkit",
@@ -541,7 +576,11 @@
     "affiliate_source_url": "https://kit.com/affiliate",
     "affiliate_final_url": "https://dash.partnerstack.com/application?company=kit&group=kitaffiliates",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["50% commission for 12 months", "PartnerStack Network marketplace access limited", "application page rendered blank"]
+    "affiliate_evidence_markers": [
+      "50% commission for 12 months",
+      "PartnerStack Network marketplace access limited",
+      "application page rendered blank"
+    ]
   },
   {
     "id": "quillbot",
@@ -576,7 +615,11 @@
     "affiliate_status": "blocked_partnerstack_marketplace_limited",
     "affiliate_source_url": "https://quillbot.com/affiliates",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["10% - 20% commission", "30-day cookie", "PartnerStack Network marketplace access limited"]
+    "affiliate_evidence_markers": [
+      "10% - 20% commission",
+      "30-day cookie",
+      "PartnerStack Network marketplace access limited"
+    ]
   },
   {
     "id": "text-cortex",
@@ -612,7 +655,10 @@
     "affiliate_source_url": "https://affiliate.textcortex.com/signup",
     "affiliate_final_url": "https://affiliate.textcortex.com/signup",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["campaign has been deactivated by the owner", "affiliate program is no longer active"]
+    "affiliate_evidence_markers": [
+      "campaign has been deactivated by the owner",
+      "affiliate program is no longer active"
+    ]
   },
   {
     "id": "vidiq",
@@ -681,7 +727,11 @@
     "affiliate_source_url": "https://www.bolddesk.com/affiliate-program/signup",
     "affiliate_final_url": "https://www.bolddesk.com/?via=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["30% of active subscription for first year", "password creation required", "payment only via Business PayPal account"]
+    "affiliate_evidence_markers": [
+      "30% of active subscription for first year",
+      "password creation required",
+      "payment only via Business PayPal account"
+    ]
   },
   {
     "id": "brand24",
@@ -715,7 +765,10 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-08-31T22:59:47Z",
-    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Brand24 review"]
+    "affiliate_evidence_markers": [
+      "PartnerStack application received",
+      "submitted for Brand24 review"
+    ]
   },
   {
     "id": "socialchamp-io",
@@ -786,7 +839,10 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-08-31T23:01:13Z",
-    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Triple Whale review"]
+    "affiliate_evidence_markers": [
+      "PartnerStack application received",
+      "submitted for Triple Whale review"
+    ]
   },
   {
     "id": "boldsign",
@@ -822,7 +878,10 @@
     "affiliate_source_url": "https://boldsign.com/affiliate-program/signup/",
     "affiliate_final_url": "https://boldsign.com?via=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["30% of active subscription for first year", "password creation required"]
+    "affiliate_evidence_markers": [
+      "30% of active subscription for first year",
+      "password creation required"
+    ]
   },
   {
     "id": "privy",
@@ -919,7 +978,10 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Unbounce review"]
+    "affiliate_evidence_markers": [
+      "PartnerStack application received",
+      "submitted for Unbounce review"
+    ]
   },
   {
     "id": "moosend",
@@ -1080,7 +1142,10 @@
     "affiliate_verified": true,
     "affiliate_status": "rejected",
     "affiliate_verified_at": "2026-09-01T08:45:37Z",
-    "affiliate_evidence_markers": ["Impact email", "Semrush Contract Terms Declined"]
+    "affiliate_evidence_markers": [
+      "Impact email",
+      "Semrush Contract Terms Declined"
+    ]
   },
   {
     "id": "hubspot",
@@ -1144,7 +1209,10 @@
     "affiliate_verified": true,
     "affiliate_status": "rejected",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["Kinsta Affiliate Program application status", "profile is not suitable for the program at this time"]
+    "affiliate_evidence_markers": [
+      "Kinsta Affiliate Program application status",
+      "profile is not suitable for the program at this time"
+    ]
   },
   {
     "id": "shopify",
@@ -1248,7 +1316,11 @@
     "affiliate_status": "approved_account",
     "affiliate_source_url": "https://www.jotform.com/partnership/affiliate/",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["Welcome to the Jotform Affiliate Program", "30% recurring commission", "Partner Dashboard"]
+    "affiliate_evidence_markers": [
+      "Welcome to the Jotform Affiliate Program",
+      "30% recurring commission",
+      "Partner Dashboard"
+    ]
   },
   {
     "id": "webflow",
@@ -1345,7 +1417,11 @@
     "affiliate_source_url": "https://synthesia.getrewardful.com/",
     "affiliate_final_url": "https://www.synthesia.io?via=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["Logged in successfully.", "Joined August 26, 2026", "https://www.synthesia.io?via=sangkwon"]
+    "affiliate_evidence_markers": [
+      "Logged in successfully.",
+      "Joined August 26, 2026",
+      "https://www.synthesia.io?via=sangkwon"
+    ]
   },
   {
     "id": "octo-browser",
@@ -1595,7 +1671,10 @@
     "affiliate_verified": true,
     "affiliate_status": "approved_tracking",
     "affiliate_verified_at": "2026-08-31T22:02:27Z",
-    "affiliate_evidence_markers": ["Vista Social approval email", "unique referral link in email body"]
+    "affiliate_evidence_markers": [
+      "Vista Social approval email",
+      "unique referral link in email body"
+    ]
   },
   {
     "id": "gravity-forms",
@@ -1836,7 +1915,7 @@
     "category": "dev_coding",
     "category_display": "Coding & Dev Tools",
     "description": "Dorik is a no-code AI website builder that enables quick creation of professional websites without any coding knowledge. Build stunning, responsive sites effortlessly, perfect for businesses, portfolios, and personal brands.",
-    "affiliate_url": null,
+    "affiliate_url": "https://dorik.com/?ref=coshuma",
     "pricing": "See official pricing",
     "key_features": [
       "No-code website building",
@@ -1859,7 +1938,6 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://dorik.com/",
-    "affiliate_url": "https://dorik.com/?ref=coshuma",
     "affiliate_verified": true,
     "affiliate_status": "approved_tracking",
     "affiliate_source_url": "https://partners.dorik.com/success-hub",
@@ -2443,7 +2521,10 @@
     "affiliate_verified": true,
     "affiliate_status": "rejected",
     "affiliate_verified_at": "2026-09-01T09:14:55Z",
-    "affiliate_evidence_markers": ["PartnerStack decision email", "GetResponse application declined"]
+    "affiliate_evidence_markers": [
+      "PartnerStack decision email",
+      "GetResponse application declined"
+    ]
   },
   {
     "id": "kit",
@@ -2573,7 +2654,10 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["Impact application received", "application will be reviewed"]
+    "affiliate_evidence_markers": [
+      "Impact application received",
+      "application will be reviewed"
+    ]
   },
   {
     "id": "koala-ai",
@@ -3582,7 +3666,10 @@
     "affiliate_verified": true,
     "affiliate_status": "approved_tracking",
     "affiliate_verified_at": "2026-09-01T10:04:07Z",
-    "affiliate_evidence_markers": ["Text Partner Program dashboard", "Share your default signup link without campaign customization"]
+    "affiliate_evidence_markers": [
+      "Text Partner Program dashboard",
+      "Share your default signup link without campaign customization"
+    ]
   },
   {
     "id": "typedesk",
@@ -3719,7 +3806,10 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for BidX review"]
+    "affiliate_evidence_markers": [
+      "PartnerStack application received",
+      "submitted for BidX review"
+    ]
   },
   {
     "id": "tidio",
@@ -3819,7 +3909,10 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Bookyourdata review"]
+    "affiliate_evidence_markers": [
+      "PartnerStack application received",
+      "submitted for Bookyourdata review"
+    ]
   },
   {
     "id": "mindstudio",
@@ -4217,7 +4310,11 @@
     "affiliate_verified": true,
     "affiliate_status": "application_not_submitted",
     "affiliate_verified_at": "2026-08-31T16:05:00Z",
-    "affiliate_evidence_markers": ["Claap affiliate manager email", "application did not go through", "correct PartnerStack link provided"]
+    "affiliate_evidence_markers": [
+      "Claap affiliate manager email",
+      "application did not go through",
+      "correct PartnerStack link provided"
+    ]
   },
   {
     "id": "cloudtalk",
@@ -4420,7 +4517,7 @@
     "category": "sales_crm",
     "category_display": "Sales & CRM",
     "description": "Empower your business to build no-code AI agents for customer support, sales, and workflow automation, enhancing customer engagement across multiple channels.",
-    "affiliate_url": null,
+    "affiliate_url": "https://link.chatbase.co/sang-kwon-an",
     "pricing": "Varies",
     "key_features": [
       "Build AI agents without code",
@@ -4443,9 +4540,11 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://www.chatbase.co/",
-    "affiliate_status": "legacy_program_inactive_new_experts_program_available",
-    "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
-    "affiliate_status_evidence_url": "https://affiliates.chatbase.co/"
+    "affiliate_status": "approved_tracking",
+    "affiliate_status_checked_at": "2026-09-07T00:00:00+09:00",
+    "affiliate_status_evidence_url": "https://link.chatbase.co/sang-kwon-an",
+    "affiliate_verified": true,
+    "affiliate_verified_at": "2026-09-06T01:50:28+09:00"
   },
   {
     "id": "krater",
@@ -4628,7 +4727,10 @@
     "affiliate_status": "referral_link_requested",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
     "affiliate_status_evidence_url": "https://agent-works.ai/contact",
-    "affiliate_evidence_markers": ["Message sent", "Thanks for reaching out. We typically respond within 1 business day."]
+    "affiliate_evidence_markers": [
+      "Message sent",
+      "Thanks for reaching out. We typically respond within 1 business day."
+    ]
   },
   {
     "id": "airia",
@@ -4711,7 +4813,12 @@
     "affiliate_status": "approved_tracking",
     "affiliate_status_checked_at": "2026-09-07T06:16:08Z",
     "affiliate_status_evidence_url": "https://affiliate.omi.me/overview",
-    "affiliate_evidence_markers": ["Email verified", "Welcome back, Sangkwon", "Your Referral Link", "https://www.omi.me/?ref=SANGKWONAN"]
+    "affiliate_evidence_markers": [
+      "Email verified",
+      "Welcome back, Sangkwon",
+      "Your Referral Link",
+      "https://www.omi.me/?ref=SANGKWONAN"
+    ]
   },
   {
     "id": "fireflies-ai",
@@ -4786,7 +4893,10 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Gamma review"]
+    "affiliate_evidence_markers": [
+      "PartnerStack application received",
+      "submitted for Gamma review"
+    ]
   },
   {
     "id": "gobii",
@@ -4824,7 +4934,10 @@
     "affiliate_status": "program_unavailable_company_winding_down",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
     "affiliate_status_evidence_url": "https://gobii.ai/",
-    "affiliate_evidence_markers": ["Gobii is winding down", "final day of operations will be September 1, 2026"]
+    "affiliate_evidence_markers": [
+      "Gobii is winding down",
+      "final day of operations will be September 1, 2026"
+    ]
   },
   {
     "id": "voibe",
@@ -4857,13 +4970,15 @@
     "affiliate_source_url": "https://www.getvoibe.com/",
     "affiliate_final_url": "https://www.getvoibe.com/",
     "affiliate_http_status": 200,
-    "affiliate_evidence_markers": [],
+    "affiliate_evidence_markers": [
+      "Affiliate application has been submitted and is awaiting approval",
+      "This may take up to 48 hours"
+    ],
     "affiliate_verified_at": null,
     "affiliate_rejection_reason": "HTTP 200 but no strong affiliate evidence found. Required at least one compound pattern (e.g. 'affiliate program', 'commission rate', 'cookie duration'). Single-word matches in footer/privacy/blog are not accepted.",
     "affiliate_status": "affiliate_profile_pending",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
     "affiliate_status_evidence_url": "https://affiliates.lemonsqueezy.com/programs/voibe",
-    "affiliate_evidence_markers": ["Affiliate application has been submitted and is awaiting approval", "This may take up to 48 hours"],
     "primary_category": "voice_cloning",
     "comparison_group": "voice_generation",
     "official_verification_status": "verified",

--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -72,10 +72,7 @@
     "affiliate_status": "program_closed_to_new_applicants",
     "affiliate_source_url": "https://www.notion.com/en-gb/affiliates",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "20% of year one revenue",
-      "currently not accepting new affiliates"
-    ]
+    "affiliate_evidence_markers": ["20% of year one revenue", "currently not accepting new affiliates"]
   },
   {
     "id": "make-com",
@@ -111,14 +108,7 @@
     "affiliate_source_url": "https://www.make.com/en/affiliate",
     "affiliate_final_url": "https://www.make.com/en?pc=coshuma",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "35% commission",
-      "12 months",
-      "Partner code created",
-      "pc=coshuma",
-      "Wise Business Basic account created",
-      "receiving account details not issued"
-    ],
+    "affiliate_evidence_markers": ["35% commission", "12 months", "Partner code created", "pc=coshuma", "Wise Business Basic account created", "receiving account details not issued"],
     "payout_setup_status": "deferred_until_payout_threshold",
     "payout_setup_note": "Do not submit invented Wise bank details. Affiliate earnings may accrue on-platform; before an actual payout, complete Wise Business Advanced activation and identity verification, then register only issued receiving account details.",
     "payout_account_email": "support@coshuma.com",
@@ -161,12 +151,7 @@
     "affiliate_source_url": "https://elevenlabs.io/affiliates",
     "affiliate_final_url": "https://try.elevenlabs.io/ldc2xmh2x2t5",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "22% commission",
-      "12 months",
-      "active affiliate account",
-      "Default affiliate link"
-    ]
+    "affiliate_evidence_markers": ["22% commission", "12 months", "active affiliate account", "Default affiliate link"]
   },
   {
     "id": "copy-ai",
@@ -233,10 +218,7 @@
     "affiliate_source_url": "https://www.zenrows.com/partners/affiliates",
     "affiliate_final_url": "https://www.zenrows.com/partners/apply",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "35% recurring",
-      "approved the same day"
-    ]
+    "affiliate_evidence_markers": ["35% recurring", "approved the same day"]
   },
   {
     "id": "tubebuddy",
@@ -272,11 +254,7 @@
     "affiliate_source_url": "https://support.tubebuddy.com/hc/en-us/sections/8981416080411-Affiliates",
     "affiliate_final_url": "https://www.tubebuddy.com/pricing?a=coshuma",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "successfully set up your Affiliate account",
-      "15% Commission",
-      "Affiliate Link"
-    ]
+    "affiliate_evidence_markers": ["successfully set up your Affiliate account", "15% Commission", "Affiliate Link"]
   },
   {
     "id": "outlierkit",
@@ -312,11 +290,7 @@
     "affiliate_source_url": "https://outlierkit.com/p/affiliate",
     "affiliate_final_url": "https://outlierkit.com/?ref=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "20% on all paid customers",
-      "all set up and ready to go",
-      "partner link"
-    ]
+    "affiliate_evidence_markers": ["20% on all paid customers", "all set up and ready to go", "partner link"]
   },
   {
     "id": "pictory",
@@ -486,11 +460,7 @@
     "affiliate_source_url": "https://writesonic.com/affiliate",
     "affiliate_final_url": "https://affiliates.writesonic.com/home",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "20% recurring",
-      "12 months",
-      "Your application has been rejected"
-    ],
+    "affiliate_evidence_markers": ["20% recurring", "12 months", "Your application has been rejected"],
     "affiliate_rejection_reason": "The authenticated Writesonic affiliate dashboard explicitly shows that the application was rejected."
   },
   {
@@ -528,12 +498,7 @@
     "affiliate_source_url": "https://sudowrite.notion.site/Sudowrite-Affiliate-Program-12788b26b71746f2a72cd05b7087e8c9",
     "affiliate_final_url": "https://www.sudowrite.com?via=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "Welcome to the Sudowrite partner program",
-      "25% on all payments, first 12 months",
-      "60 day cookie",
-      "affiliate link"
-    ]
+    "affiliate_evidence_markers": ["Welcome to the Sudowrite partner program", "25% on all payments, first 12 months", "60 day cookie", "affiliate link"]
   },
   {
     "id": "convertkit",
@@ -576,11 +541,7 @@
     "affiliate_source_url": "https://kit.com/affiliate",
     "affiliate_final_url": "https://dash.partnerstack.com/application?company=kit&group=kitaffiliates",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "50% commission for 12 months",
-      "PartnerStack Network marketplace access limited",
-      "application page rendered blank"
-    ]
+    "affiliate_evidence_markers": ["50% commission for 12 months", "PartnerStack Network marketplace access limited", "application page rendered blank"]
   },
   {
     "id": "quillbot",
@@ -615,11 +576,7 @@
     "affiliate_status": "blocked_partnerstack_marketplace_limited",
     "affiliate_source_url": "https://quillbot.com/affiliates",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "10% - 20% commission",
-      "30-day cookie",
-      "PartnerStack Network marketplace access limited"
-    ]
+    "affiliate_evidence_markers": ["10% - 20% commission", "30-day cookie", "PartnerStack Network marketplace access limited"]
   },
   {
     "id": "text-cortex",
@@ -655,10 +612,7 @@
     "affiliate_source_url": "https://affiliate.textcortex.com/signup",
     "affiliate_final_url": "https://affiliate.textcortex.com/signup",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "campaign has been deactivated by the owner",
-      "affiliate program is no longer active"
-    ]
+    "affiliate_evidence_markers": ["campaign has been deactivated by the owner", "affiliate program is no longer active"]
   },
   {
     "id": "vidiq",
@@ -727,11 +681,7 @@
     "affiliate_source_url": "https://www.bolddesk.com/affiliate-program/signup",
     "affiliate_final_url": "https://www.bolddesk.com/?via=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "30% of active subscription for first year",
-      "password creation required",
-      "payment only via Business PayPal account"
-    ]
+    "affiliate_evidence_markers": ["30% of active subscription for first year", "password creation required", "payment only via Business PayPal account"]
   },
   {
     "id": "brand24",
@@ -765,10 +715,7 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-08-31T22:59:47Z",
-    "affiliate_evidence_markers": [
-      "PartnerStack application received",
-      "submitted for Brand24 review"
-    ]
+    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Brand24 review"]
   },
   {
     "id": "socialchamp-io",
@@ -839,10 +786,7 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-08-31T23:01:13Z",
-    "affiliate_evidence_markers": [
-      "PartnerStack application received",
-      "submitted for Triple Whale review"
-    ]
+    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Triple Whale review"]
   },
   {
     "id": "boldsign",
@@ -878,10 +822,7 @@
     "affiliate_source_url": "https://boldsign.com/affiliate-program/signup/",
     "affiliate_final_url": "https://boldsign.com?via=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "30% of active subscription for first year",
-      "password creation required"
-    ]
+    "affiliate_evidence_markers": ["30% of active subscription for first year", "password creation required"]
   },
   {
     "id": "privy",
@@ -978,10 +919,7 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "PartnerStack application received",
-      "submitted for Unbounce review"
-    ]
+    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Unbounce review"]
   },
   {
     "id": "moosend",
@@ -1142,10 +1080,7 @@
     "affiliate_verified": true,
     "affiliate_status": "rejected",
     "affiliate_verified_at": "2026-09-01T08:45:37Z",
-    "affiliate_evidence_markers": [
-      "Impact email",
-      "Semrush Contract Terms Declined"
-    ]
+    "affiliate_evidence_markers": ["Impact email", "Semrush Contract Terms Declined"]
   },
   {
     "id": "hubspot",
@@ -1209,10 +1144,7 @@
     "affiliate_verified": true,
     "affiliate_status": "rejected",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "Kinsta Affiliate Program application status",
-      "profile is not suitable for the program at this time"
-    ]
+    "affiliate_evidence_markers": ["Kinsta Affiliate Program application status", "profile is not suitable for the program at this time"]
   },
   {
     "id": "shopify",
@@ -1316,11 +1248,7 @@
     "affiliate_status": "approved_account",
     "affiliate_source_url": "https://www.jotform.com/partnership/affiliate/",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "Welcome to the Jotform Affiliate Program",
-      "30% recurring commission",
-      "Partner Dashboard"
-    ]
+    "affiliate_evidence_markers": ["Welcome to the Jotform Affiliate Program", "30% recurring commission", "Partner Dashboard"]
   },
   {
     "id": "webflow",
@@ -1417,11 +1345,7 @@
     "affiliate_source_url": "https://synthesia.getrewardful.com/",
     "affiliate_final_url": "https://www.synthesia.io?via=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "Logged in successfully.",
-      "Joined August 26, 2026",
-      "https://www.synthesia.io?via=sangkwon"
-    ]
+    "affiliate_evidence_markers": ["Logged in successfully.", "Joined August 26, 2026", "https://www.synthesia.io?via=sangkwon"]
   },
   {
     "id": "octo-browser",
@@ -1671,10 +1595,7 @@
     "affiliate_verified": true,
     "affiliate_status": "approved_tracking",
     "affiliate_verified_at": "2026-08-31T22:02:27Z",
-    "affiliate_evidence_markers": [
-      "Vista Social approval email",
-      "unique referral link in email body"
-    ]
+    "affiliate_evidence_markers": ["Vista Social approval email", "unique referral link in email body"]
   },
   {
     "id": "gravity-forms",
@@ -1915,7 +1836,7 @@
     "category": "dev_coding",
     "category_display": "Coding & Dev Tools",
     "description": "Dorik is a no-code AI website builder that enables quick creation of professional websites without any coding knowledge. Build stunning, responsive sites effortlessly, perfect for businesses, portfolios, and personal brands.",
-    "affiliate_url": "https://dorik.com/?ref=coshuma",
+    "affiliate_url": null,
     "pricing": "See official pricing",
     "key_features": [
       "No-code website building",
@@ -1938,6 +1859,7 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://dorik.com/",
+    "affiliate_url": "https://dorik.com/?ref=coshuma",
     "affiliate_verified": true,
     "affiliate_status": "approved_tracking",
     "affiliate_source_url": "https://partners.dorik.com/success-hub",
@@ -2521,10 +2443,7 @@
     "affiliate_verified": true,
     "affiliate_status": "rejected",
     "affiliate_verified_at": "2026-09-01T09:14:55Z",
-    "affiliate_evidence_markers": [
-      "PartnerStack decision email",
-      "GetResponse application declined"
-    ]
+    "affiliate_evidence_markers": ["PartnerStack decision email", "GetResponse application declined"]
   },
   {
     "id": "kit",
@@ -2654,10 +2573,7 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "Impact application received",
-      "application will be reviewed"
-    ]
+    "affiliate_evidence_markers": ["Impact application received", "application will be reviewed"]
   },
   {
     "id": "koala-ai",
@@ -3666,10 +3582,7 @@
     "affiliate_verified": true,
     "affiliate_status": "approved_tracking",
     "affiliate_verified_at": "2026-09-01T10:04:07Z",
-    "affiliate_evidence_markers": [
-      "Text Partner Program dashboard",
-      "Share your default signup link without campaign customization"
-    ]
+    "affiliate_evidence_markers": ["Text Partner Program dashboard", "Share your default signup link without campaign customization"]
   },
   {
     "id": "typedesk",
@@ -3806,10 +3719,7 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "PartnerStack application received",
-      "submitted for BidX review"
-    ]
+    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for BidX review"]
   },
   {
     "id": "tidio",
@@ -3909,10 +3819,7 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "PartnerStack application received",
-      "submitted for Bookyourdata review"
-    ]
+    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Bookyourdata review"]
   },
   {
     "id": "mindstudio",
@@ -4310,11 +4217,7 @@
     "affiliate_verified": true,
     "affiliate_status": "application_not_submitted",
     "affiliate_verified_at": "2026-08-31T16:05:00Z",
-    "affiliate_evidence_markers": [
-      "Claap affiliate manager email",
-      "application did not go through",
-      "correct PartnerStack link provided"
-    ]
+    "affiliate_evidence_markers": ["Claap affiliate manager email", "application did not go through", "correct PartnerStack link provided"]
   },
   {
     "id": "cloudtalk",
@@ -4727,10 +4630,7 @@
     "affiliate_status": "referral_link_requested",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
     "affiliate_status_evidence_url": "https://agent-works.ai/contact",
-    "affiliate_evidence_markers": [
-      "Message sent",
-      "Thanks for reaching out. We typically respond within 1 business day."
-    ]
+    "affiliate_evidence_markers": ["Message sent", "Thanks for reaching out. We typically respond within 1 business day."]
   },
   {
     "id": "airia",
@@ -4813,12 +4713,7 @@
     "affiliate_status": "approved_tracking",
     "affiliate_status_checked_at": "2026-09-07T06:16:08Z",
     "affiliate_status_evidence_url": "https://affiliate.omi.me/overview",
-    "affiliate_evidence_markers": [
-      "Email verified",
-      "Welcome back, Sangkwon",
-      "Your Referral Link",
-      "https://www.omi.me/?ref=SANGKWONAN"
-    ]
+    "affiliate_evidence_markers": ["Email verified", "Welcome back, Sangkwon", "Your Referral Link", "https://www.omi.me/?ref=SANGKWONAN"]
   },
   {
     "id": "fireflies-ai",
@@ -4893,10 +4788,7 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "PartnerStack application received",
-      "submitted for Gamma review"
-    ]
+    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Gamma review"]
   },
   {
     "id": "gobii",
@@ -4934,10 +4826,7 @@
     "affiliate_status": "program_unavailable_company_winding_down",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
     "affiliate_status_evidence_url": "https://gobii.ai/",
-    "affiliate_evidence_markers": [
-      "Gobii is winding down",
-      "final day of operations will be September 1, 2026"
-    ]
+    "affiliate_evidence_markers": ["Gobii is winding down", "final day of operations will be September 1, 2026"]
   },
   {
     "id": "voibe",
@@ -4970,15 +4859,13 @@
     "affiliate_source_url": "https://www.getvoibe.com/",
     "affiliate_final_url": "https://www.getvoibe.com/",
     "affiliate_http_status": 200,
-    "affiliate_evidence_markers": [
-      "Affiliate application has been submitted and is awaiting approval",
-      "This may take up to 48 hours"
-    ],
+    "affiliate_evidence_markers": [],
     "affiliate_verified_at": null,
     "affiliate_rejection_reason": "HTTP 200 but no strong affiliate evidence found. Required at least one compound pattern (e.g. 'affiliate program', 'commission rate', 'cookie duration'). Single-word matches in footer/privacy/blog are not accepted.",
     "affiliate_status": "affiliate_profile_pending",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
     "affiliate_status_evidence_url": "https://affiliates.lemonsqueezy.com/programs/voibe",
+    "affiliate_evidence_markers": ["Affiliate application has been submitted and is awaiting approval", "This may take up to 48 hours"],
     "primary_category": "voice_cloning",
     "comparison_group": "voice_generation",
     "official_verification_status": "verified",

--- a/projects/GlobalSaaSHub/data/tools.next.json
+++ b/projects/GlobalSaaSHub/data/tools.next.json
@@ -82,7 +82,7 @@
     "name": "Make.com",
     "category": "dev_coding",
     "category_display": "Coding & Dev Tools",
-    "description": "A visual automation platform that lets you design, build, and automate anything—from simple tasks to complex workflows—in minutes without coding.",
+    "description": "A visual automation platform that lets you design, build, and automate anything\u2014from simple tasks to complex workflows\u2014in minutes without coding.",
     "pricing": "See official pricing",
     "key_features": [
       "Visual Drag & Drop",
@@ -751,10 +751,7 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-08-31T22:59:47Z",
-    "affiliate_evidence_markers": [
-      "PartnerStack application received",
-      "submitted for Brand24 review"
-    ]
+    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Brand24 review"]
   },
   {
     "id": "socialchamp-io",
@@ -825,10 +822,7 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-08-31T23:01:13Z",
-    "affiliate_evidence_markers": [
-      "PartnerStack application received",
-      "submitted for Triple Whale review"
-    ]
+    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Triple Whale review"]
   },
   {
     "id": "boldsign",
@@ -1117,10 +1111,7 @@
     "affiliate_verified": true,
     "affiliate_status": "rejected",
     "affiliate_verified_at": "2026-09-01T08:45:37Z",
-    "affiliate_evidence_markers": [
-      "Impact email",
-      "Semrush Contract Terms Declined"
-    ]
+    "affiliate_evidence_markers": ["Impact email", "Semrush Contract Terms Declined"]
   },
   {
     "id": "hubspot",
@@ -1376,11 +1367,7 @@
     "affiliate_source_url": "https://synthesia.getrewardful.com/",
     "affiliate_final_url": "https://www.synthesia.io?via=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "Logged in successfully.",
-      "Joined August 26, 2026",
-      "https://www.synthesia.io?via=sangkwon"
-    ]
+    "affiliate_evidence_markers": ["Logged in successfully.", "Joined August 26, 2026", "https://www.synthesia.io?via=sangkwon"]
   },
   {
     "id": "octo-browser",
@@ -1630,10 +1617,7 @@
     "affiliate_verified": true,
     "affiliate_status": "approved_tracking",
     "affiliate_verified_at": "2026-08-31T22:02:27Z",
-    "affiliate_evidence_markers": [
-      "Vista Social approval email",
-      "unique referral link in email body"
-    ]
+    "affiliate_evidence_markers": ["Vista Social approval email", "unique referral link in email body"]
   },
   {
     "id": "gravity-forms",
@@ -3729,7 +3713,7 @@
     "category": "productivity",
     "category_display": "Productivity & SaaS",
     "description": "An AI-driven platform that fully automates and optimizes advertising campaigns for Amazon and Walmart sellers, maximizing their ROI.",
-    "pricing": "From €495/month plus a percentage of ad spend",
+    "pricing": "From \u20ac495/month plus a percentage of ad spend",
     "key_features": [
       "AI-driven advertising",
       "Automate ad campaigns",
@@ -3749,7 +3733,7 @@
     "evidence_source_type": "official_help_page",
     "is_manual_override": true,
     "pricing_evidence_markers": [
-      "€495",
+      "\u20ac495",
       "month"
     ],
     "http_verification_status": "verified_http_200",
@@ -4266,11 +4250,7 @@
     "affiliate_verified": true,
     "affiliate_status": "application_not_submitted",
     "affiliate_verified_at": "2026-08-31T16:05:00Z",
-    "affiliate_evidence_markers": [
-      "Claap affiliate manager email",
-      "application did not go through",
-      "correct PartnerStack link provided"
-    ]
+    "affiliate_evidence_markers": ["Claap affiliate manager email", "application did not go through", "correct PartnerStack link provided"]
   },
   {
     "id": "cloudtalk",
@@ -4677,10 +4657,7 @@
     "affiliate_status": "referral_link_requested",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
     "affiliate_status_evidence_url": "https://agent-works.ai/contact",
-    "affiliate_evidence_markers": [
-      "Message sent",
-      "Thanks for reaching out. We typically respond within 1 business day."
-    ]
+    "affiliate_evidence_markers": ["Message sent", "Thanks for reaching out. We typically respond within 1 business day."]
   },
   {
     "id": "airia",
@@ -4759,10 +4736,7 @@
     "affiliate_status": "approved_email_verification_required",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
     "affiliate_status_evidence_url": "https://affiliate.omi.me/overview",
-    "affiliate_evidence_markers": [
-      "Your account has been approved",
-      "Verify your email"
-    ]
+    "affiliate_evidence_markers": ["Your account has been approved", "Verify your email"]
   },
   {
     "id": "fireflies-ai",
@@ -4878,10 +4852,7 @@
     "affiliate_status": "program_unavailable_company_winding_down",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
     "affiliate_status_evidence_url": "https://gobii.ai/",
-    "affiliate_evidence_markers": [
-      "Gobii is winding down",
-      "final day of operations will be September 1, 2026"
-    ]
+    "affiliate_evidence_markers": ["Gobii is winding down", "final day of operations will be September 1, 2026"]
   },
   {
     "id": "voibe",
@@ -4919,15 +4890,13 @@
     "affiliate_source_url": "https://www.getvoibe.com/",
     "affiliate_final_url": "https://www.getvoibe.com/",
     "affiliate_http_status": 200,
-    "affiliate_evidence_markers": [
-      "Affiliate application has been submitted and is awaiting approval",
-      "This may take up to 48 hours"
-    ],
+    "affiliate_evidence_markers": [],
     "affiliate_verified_at": null,
     "affiliate_rejection_reason": "HTTP 200 but no strong affiliate evidence found. Required at least one compound pattern (e.g. 'affiliate program', 'commission rate', 'cookie duration'). Single-word matches in footer/privacy/blog are not accepted.",
     "affiliate_status": "affiliate_profile_pending",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
-    "affiliate_status_evidence_url": "https://affiliates.lemonsqueezy.com/programs/voibe"
+    "affiliate_status_evidence_url": "https://affiliates.lemonsqueezy.com/programs/voibe",
+    "affiliate_evidence_markers": ["Affiliate application has been submitted and is awaiting approval", "This may take up to 48 hours"]
   },
   {
     "id": "merlin-ai",

--- a/projects/GlobalSaaSHub/data/tools.next.json
+++ b/projects/GlobalSaaSHub/data/tools.next.json
@@ -82,7 +82,7 @@
     "name": "Make.com",
     "category": "dev_coding",
     "category_display": "Coding & Dev Tools",
-    "description": "A visual automation platform that lets you design, build, and automate anything\u2014from simple tasks to complex workflows\u2014in minutes without coding.",
+    "description": "A visual automation platform that lets you design, build, and automate anything—from simple tasks to complex workflows—in minutes without coding.",
     "pricing": "See official pricing",
     "key_features": [
       "Visual Drag & Drop",
@@ -751,7 +751,10 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-08-31T22:59:47Z",
-    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Brand24 review"]
+    "affiliate_evidence_markers": [
+      "PartnerStack application received",
+      "submitted for Brand24 review"
+    ]
   },
   {
     "id": "socialchamp-io",
@@ -822,7 +825,10 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-08-31T23:01:13Z",
-    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Triple Whale review"]
+    "affiliate_evidence_markers": [
+      "PartnerStack application received",
+      "submitted for Triple Whale review"
+    ]
   },
   {
     "id": "boldsign",
@@ -1111,7 +1117,10 @@
     "affiliate_verified": true,
     "affiliate_status": "rejected",
     "affiliate_verified_at": "2026-09-01T08:45:37Z",
-    "affiliate_evidence_markers": ["Impact email", "Semrush Contract Terms Declined"]
+    "affiliate_evidence_markers": [
+      "Impact email",
+      "Semrush Contract Terms Declined"
+    ]
   },
   {
     "id": "hubspot",
@@ -1367,7 +1376,11 @@
     "affiliate_source_url": "https://synthesia.getrewardful.com/",
     "affiliate_final_url": "https://www.synthesia.io?via=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["Logged in successfully.", "Joined August 26, 2026", "https://www.synthesia.io?via=sangkwon"]
+    "affiliate_evidence_markers": [
+      "Logged in successfully.",
+      "Joined August 26, 2026",
+      "https://www.synthesia.io?via=sangkwon"
+    ]
   },
   {
     "id": "octo-browser",
@@ -1617,7 +1630,10 @@
     "affiliate_verified": true,
     "affiliate_status": "approved_tracking",
     "affiliate_verified_at": "2026-08-31T22:02:27Z",
-    "affiliate_evidence_markers": ["Vista Social approval email", "unique referral link in email body"]
+    "affiliate_evidence_markers": [
+      "Vista Social approval email",
+      "unique referral link in email body"
+    ]
   },
   {
     "id": "gravity-forms",
@@ -3713,7 +3729,7 @@
     "category": "productivity",
     "category_display": "Productivity & SaaS",
     "description": "An AI-driven platform that fully automates and optimizes advertising campaigns for Amazon and Walmart sellers, maximizing their ROI.",
-    "pricing": "From \u20ac495/month plus a percentage of ad spend",
+    "pricing": "From €495/month plus a percentage of ad spend",
     "key_features": [
       "AI-driven advertising",
       "Automate ad campaigns",
@@ -3733,7 +3749,7 @@
     "evidence_source_type": "official_help_page",
     "is_manual_override": true,
     "pricing_evidence_markers": [
-      "\u20ac495",
+      "€495",
       "month"
     ],
     "http_verification_status": "verified_http_200",
@@ -4250,7 +4266,11 @@
     "affiliate_verified": true,
     "affiliate_status": "application_not_submitted",
     "affiliate_verified_at": "2026-08-31T16:05:00Z",
-    "affiliate_evidence_markers": ["Claap affiliate manager email", "application did not go through", "correct PartnerStack link provided"]
+    "affiliate_evidence_markers": [
+      "Claap affiliate manager email",
+      "application did not go through",
+      "correct PartnerStack link provided"
+    ]
   },
   {
     "id": "cloudtalk",
@@ -4469,10 +4489,12 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://www.chatbase.co/",
-    "affiliate_url": null,
-    "affiliate_status": "legacy_program_inactive_new_experts_program_available",
-    "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
-    "affiliate_status_evidence_url": "https://affiliates.chatbase.co/"
+    "affiliate_url": "https://link.chatbase.co/sang-kwon-an",
+    "affiliate_status": "approved_tracking",
+    "affiliate_status_checked_at": "2026-09-07T00:00:00+09:00",
+    "affiliate_status_evidence_url": "https://link.chatbase.co/sang-kwon-an",
+    "affiliate_verified": true,
+    "affiliate_verified_at": "2026-09-06T01:50:28+09:00"
   },
   {
     "id": "krater",
@@ -4655,7 +4677,10 @@
     "affiliate_status": "referral_link_requested",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
     "affiliate_status_evidence_url": "https://agent-works.ai/contact",
-    "affiliate_evidence_markers": ["Message sent", "Thanks for reaching out. We typically respond within 1 business day."]
+    "affiliate_evidence_markers": [
+      "Message sent",
+      "Thanks for reaching out. We typically respond within 1 business day."
+    ]
   },
   {
     "id": "airia",
@@ -4734,7 +4759,10 @@
     "affiliate_status": "approved_email_verification_required",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
     "affiliate_status_evidence_url": "https://affiliate.omi.me/overview",
-    "affiliate_evidence_markers": ["Your account has been approved", "Verify your email"]
+    "affiliate_evidence_markers": [
+      "Your account has been approved",
+      "Verify your email"
+    ]
   },
   {
     "id": "fireflies-ai",
@@ -4850,7 +4878,10 @@
     "affiliate_status": "program_unavailable_company_winding_down",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
     "affiliate_status_evidence_url": "https://gobii.ai/",
-    "affiliate_evidence_markers": ["Gobii is winding down", "final day of operations will be September 1, 2026"]
+    "affiliate_evidence_markers": [
+      "Gobii is winding down",
+      "final day of operations will be September 1, 2026"
+    ]
   },
   {
     "id": "voibe",
@@ -4888,13 +4919,15 @@
     "affiliate_source_url": "https://www.getvoibe.com/",
     "affiliate_final_url": "https://www.getvoibe.com/",
     "affiliate_http_status": 200,
-    "affiliate_evidence_markers": [],
+    "affiliate_evidence_markers": [
+      "Affiliate application has been submitted and is awaiting approval",
+      "This may take up to 48 hours"
+    ],
     "affiliate_verified_at": null,
     "affiliate_rejection_reason": "HTTP 200 but no strong affiliate evidence found. Required at least one compound pattern (e.g. 'affiliate program', 'commission rate', 'cookie duration'). Single-word matches in footer/privacy/blog are not accepted.",
     "affiliate_status": "affiliate_profile_pending",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
-    "affiliate_status_evidence_url": "https://affiliates.lemonsqueezy.com/programs/voibe",
-    "affiliate_evidence_markers": ["Affiliate application has been submitted and is awaiting approval", "This may take up to 48 hours"]
+    "affiliate_status_evidence_url": "https://affiliates.lemonsqueezy.com/programs/voibe"
   },
   {
     "id": "merlin-ai",

--- a/projects/GlobalSaaSHub/public/tool/chatbase.html
+++ b/projects/GlobalSaaSHub/public/tool/chatbase.html
@@ -94,6 +94,19 @@
       </div>
     </section>
 
+<!-- buyer-box:start -->
+<section data-buyer-decision-box="chatbase" class="rounded-2xl border border-purple-400/40 bg-slate-900 p-6 my-6 space-y-4" aria-label="Buyer decision box">
+<h2 class="text-2xl font-bold">Is Chatbase right for you?</h2>
+<div class="grid md:grid-cols-2 gap-5"><div><h3 class="font-bold">Best for</h3><ul class="list-disc pl-5 space-y-1"><li>Teams testing AI customer support</li><li>Buyers who can estimate message-credit usage</li></ul></div><div><h3 class="font-bold">Not ideal for</h3><ul class="list-disc pl-5 space-y-1"><li>A simple static FAQ is enough</li><li>Untested answers would create unacceptable risk</li></ul></div></div>
+<h3 class="font-bold">Why consider it?</h3><ul class="list-disc pl-5 space-y-1"><li>Test customer questions before scaling</li><li>Match channels to the right plan</li><li>Review credit usage before upgrading</li></ul>
+<dl><dt class="font-bold">Pricing</dt><dd>Paid plans start at $40/month on monthly billing; see the detailed table below.</dd><dt class="font-bold">Free plan</dt><dd>$0 plan with 50 message credits per month.</dd><dt class="font-bold">Free trial</dt><dd>7-day trials listed for Hobby, Standard and Pro; confirm checkout terms.</dd></dl>
+<p>Free-plan agents are deleted after 14 inactive days. Add-ons can increase total cost.</p>
+<p class="text-sm text-slate-400">Official-source check: 2026-09-07. <a data-cta-source="buyer-box-source" href="https://www.chatbase.co/pricing" target="_blank" rel="noopener noreferrer" class="underline">Features and pricing source</a>. Editorial fit guidance, not a hands-on performance test.</p>
+<p data-affiliate-disclosure="buyer-box" class="text-sm text-slate-300">COSHUMA may earn a commission on qualifying purchases through this partner link, at no extra cost to you.</p>
+<div class="flex flex-wrap gap-3"><a data-cta="affiliate" data-cta-source="buyer-box-primary" data-tool-id="chatbase" href="https://link.chatbase.co/sang-kwon-an" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-purple-600 px-5 py-3 font-bold">Explore Chatbase →</a><a data-cta="official" data-cta-source="buyer-box-official" href="https://www.chatbase.co/" target="_blank" rel="noopener noreferrer" class="rounded-xl border border-slate-500 px-5 py-3">Official website</a></div>
+<p>Compare alternatives: <a data-cta-source="buyer-box-alternative" class="underline" href="/tool/customgpt-ai.html">CustomGPT.ai</a> · <a data-cta-source="buyer-box-alternative" class="underline" href="/tool/docsbot.html">DocsBot</a></p>
+</section>
+<!-- buyer-box:end -->
     <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-6">
       <div>
         <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Current monthly pricing</div>

--- a/projects/GlobalSaaSHub/scripts/inject_buyer_decision_boxes.mjs
+++ b/projects/GlobalSaaSHub/scripts/inject_buyer_decision_boxes.mjs
@@ -5,6 +5,8 @@ const root=path.resolve(path.dirname(fileURLToPath(import.meta.url)),'..');
 const tools=JSON.parse(fs.readFileSync(path.join(root,'data/tools.json'),'utf8'));
 const configs=[{id:'omi-ai',best:['People who want searchable conversation notes','Teams reviewing spoken tasks and follow-ups'],not:['Workplaces that prohibit recording','Buyers who need verified hands-on accuracy benchmarks'],why:['Search memories instead of replaying entire conversations','Review generated tasks before acting','Share summaries for a clearer handoff'],alternatives:[['fireflies-ai','Fireflies.ai'],['fathom','Fathom']],source:'https://www.omi.me/pages/product'}];
 const esc=s=>String(s).replaceAll('&','&amp;').replaceAll('"','&quot;').replaceAll('<','&lt;').replaceAll('>','&gt;');
+Object.assign(configs[0],{pricing:'Check current pricing.',freePlan:'A free Basic plan is available; check current limits.',trial:'Not confirmed; check current pricing and trial terms.',risk:'Paid pricing differs across official pages; check checkout before buying. Review recording permissions and your workplace policy first.',checkedAt:'2026-09-07',insertionAnchor:'<!-- Description -->'});
+configs.push({id:'chatbase',best:['Teams testing AI customer support','Buyers who can estimate message-credit usage'],not:['A simple static FAQ is enough','Untested answers would create unacceptable risk'],why:['Test customer questions before scaling','Match channels to the right plan','Review credit usage before upgrading'],pricing:'Paid plans start at $40/month on monthly billing; see the detailed table below.',freePlan:'$0 plan with 50 message credits per month.',trial:'7-day trials listed for Hobby, Standard and Pro; confirm checkout terms.',risk:'Free-plan agents are deleted after 14 inactive days. Add-ons can increase total cost.',checkedAt:'2026-09-07',insertionAnchor:'    <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8 space-y-6">',source:'https://www.chatbase.co/pricing',alternatives:[['customgpt-ai','CustomGPT.ai'],['docsbot','DocsBot']]});
 for(const c of configs){
  const t=tools.find(x=>x.id===c.id);
  if(t?.affiliate_verified!==true||t.affiliate_status!=='approved_tracking')throw Error('Unverified route: '+c.id);
@@ -17,15 +19,15 @@ for(const c of configs){
 <h2 class="text-2xl font-bold">Is ${esc(t.name)} right for you?</h2>
 <div class="grid md:grid-cols-2 gap-5"><div><h3 class="font-bold">Best for</h3>${list(c.best)}</div><div><h3 class="font-bold">Not ideal for</h3>${list(c.not)}</div></div>
 <h3 class="font-bold">Why consider it?</h3>${list(c.why)}
-<dl><dt class="font-bold">Pricing</dt><dd>Check current pricing.</dd><dt class="font-bold">Free plan</dt><dd>A free Basic plan is available; check current limits.</dd><dt class="font-bold">Free trial</dt><dd>Not confirmed; check current pricing and trial terms.</dd></dl>
-<p>Paid pricing differs across official pages; check checkout before buying. Review recording permissions and your workplace policy first.</p>
-<p class="text-sm text-slate-400">Official-source check: 2026-09-07. <a data-cta-source="buyer-box-source" href="${esc(c.source)}" target="_blank" rel="noopener noreferrer" class="underline">Features and pricing source</a>. Editorial fit guidance, not a hands-on performance test.</p>
+<dl><dt class="font-bold">Pricing</dt><dd>${esc(c.pricing)}</dd><dt class="font-bold">Free plan</dt><dd>${esc(c.freePlan)}</dd><dt class="font-bold">Free trial</dt><dd>${esc(c.trial)}</dd></dl>
+<p>${esc(c.risk)}</p>
+<p class="text-sm text-slate-400">Official-source check: ${esc(c.checkedAt)}. <a data-cta-source="buyer-box-source" href="${esc(c.source)}" target="_blank" rel="noopener noreferrer" class="underline">Features and pricing source</a>. Editorial fit guidance, not a hands-on performance test.</p>
 <p data-affiliate-disclosure="buyer-box" class="text-sm text-slate-300">COSHUMA may earn a commission on qualifying purchases through this partner link, at no extra cost to you.</p>
 <div class="flex flex-wrap gap-3"><a data-cta="affiliate" data-cta-source="buyer-box-primary" data-tool-id="${c.id}" href="${esc(t.affiliate_url)}" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-purple-600 px-5 py-3 font-bold">Explore ${esc(t.name)} →</a><a data-cta="official" data-cta-source="buyer-box-official" href="${esc(t.official_url)}" target="_blank" rel="noopener noreferrer" class="rounded-xl border border-slate-500 px-5 py-3">Official website</a></div>
 <p>Compare alternatives: ${c.alternatives.map(([id,name])=>`<a data-cta-source="buyer-box-alternative" class="underline" href="/tool/${id}.html">${name}</a>`).join(' · ')}</p>
 </section>
 <!-- buyer-box:end -->`;
- html=html.includes('<!-- buyer-box:start -->')?html.replace(/<!-- buyer-box:start -->[\s\S]*?<!-- buyer-box:end -->/,box):html.replace('<!-- Description -->',box+'\n<!-- Description -->');
+ html=html.includes('<!-- buyer-box:start -->')?html.replace(/<!-- buyer-box:start -->[\s\S]*?<!-- buyer-box:end -->/,box):html.replace(c.insertionAnchor,box+'\n'+c.insertionAnchor);
  if(!html.includes(box))throw Error('Buyer box insertion failed: '+c.id);
  if(!html.includes('/affiliate-attribution.js'))html=html.replace('</head>','<script defer src="/affiliate-attribution.js"></script>\n</head>');
  html=html.replace(/<a\b(?=[^>]*data-cta=)(?![^>]*data-cta-source=)/g,'<a data-cta-source="tool-existing"');


### PR DESCRIPTION
## Summary
- Add a product-specific buyer box before the existing Chatbase pricing section; preserve all existing hero, pricing, FAQ and JSON-LD content.
- Separate per-product pricing/free plan/trial/risk/date/anchor configuration; Omi output unchanged.
- Reconcile only Chatbase raw affiliate records with existing verified production override, rechecked against Chatbase support email and official pricing.

## Validation
- npm ci and production build pass; idempotence verified.
- test:links has exactly the two existing baseline disclosure failures (taskade/relevance-ai).
- No other product data changes. No signup, commission or analytics receipt claimed.
- Check GitHub Pages canonical deployment independently of quota-limited Vercel previews.