### PR TITLE
Record Getgabs affiliate application submission

### DIFF
--- a/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
+++ b/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
@@ -87,6 +87,17 @@ const statusOverrides = {
       'profile review expected in 3-5 business days',
     ],
   },
+  getgabs: {
+    affiliate_verified: true,
+    affiliate_status: 'application_submitted',
+    affiliate_verified_at: '2026-09-07T00:00:00+09:00',
+    affiliate_evidence_markers: [
+      'Getgabs official affiliate page says signup is free and provides a unique referral link',
+      'COSHUMA affiliate application sent to official info@getgabs.com address',
+      'Gmail message id 1a07a9eff46a2c04',
+      'Exact customer-facing referral URL not yet issued or verified',
+    ],
+  },
   helpdesk: {
     affiliate_verified: true,
     affiliate_status: 'approved_account_campaign_link_pending',


### PR DESCRIPTION
## Summary
- Record the newly submitted COSHUMA Getgabs affiliate application in the production affiliate-status override layer.
- Preserve `affiliate_url` as unset because no account-specific customer referral URL has been issued or verified yet.
- Add Gmail message-id provenance so future automation does not submit a duplicate application.

## Evidence
- Official Getgabs affiliate page says joining is free and affiliates receive a unique referral link.
- No prior Getgabs Gmail thread was found before submission.
- COSHUMA application was sent to the official `info@getgabs.com` contact address; Gmail message id `1a07a9eff46a2c04`.

No paid service, guessed tracking URL, approval claim, or revenue claim is introduced.