### PR TITLE
Record Tagshop AI affiliate application submission

### DIFF
--- a/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
+++ b/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
@@ -98,6 +98,18 @@ const statusOverrides = {
       'Exact customer-facing referral URL not yet issued or verified',
     ],
   },
+  'tagshop-ai': {
+    affiliate_verified: true,
+    affiliate_status: 'application_submitted',
+    affiliate_verified_at: '2026-09-07T00:00:00+09:00',
+    affiliate_evidence_markers: [
+      'Tagshop AI official affiliate page says joining is free and provides dashboard referral-link access',
+      'Official affiliate terms show 30% recurring commission for 6 months and a 90-day cookie',
+      'COSHUMA affiliate application sent to official hello@tagshop.ai address',
+      'Gmail message id 1a07aa3450c58442',
+      'Exact customer-facing referral URL not yet issued or verified',
+    ],
+  },
   helpdesk: {
     affiliate_verified: true,
     affiliate_status: 'approved_account_campaign_link_pending',


### PR DESCRIPTION
## Summary
- Record the newly submitted COSHUMA Tagshop AI affiliate application in the production affiliate-status override layer.
- Keep `affiliate_url` unset until Tagshop/FirstPromoter issues an exact account-specific customer referral URL.
- Add official-program and Gmail provenance to prevent duplicate submissions.

## Evidence
- Tagshop AI's official affiliate page says the program is free to join, offers 30% recurring commission for 6 months, uses a 90-day cookie, and provides dashboard referral-link access.
- No prior Tagshop Gmail thread was found before submission.
- COSHUMA application was sent to the official `hello@tagshop.ai` address published on Tagshop's official pricing pages; Gmail message id `1a07aa3450c58442`.

No paid service, guessed tracking URL, approval claim, or revenue claim is introduced.