### PR TITLE
chore(affiliate): record Synthflow referral application evidence

### DIFF
--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -3906,6 +3906,16 @@
     "primary_category": "voice_cloning",
     "comparison_group": "voice_generation",
     "official_url": "https://synthflow.ai/",
+    "affiliate_verified": false,
+    "affiliate_status": "application_submitted",
+    "affiliate_source_url": "https://synthflow.ai/partners/become-a-partner",
+    "affiliate_final_url": "https://forms.default.com/166142",
+    "affiliate_verified_at": "2026-09-07T06:52:20Z",
+    "affiliate_evidence_markers": [
+      "Thanks for filling out the form!",
+      "A Synthflow AI Channel representative will contact you shortly",
+      "Referral Partners application submitted; approval and tracking link not confirmed"
+    ],
     "pricing_source_url": null,
     "pricing_verified_at": null,
     "pricing_verified": false,

--- a/projects/GlobalSaaSHub/data/tools.next.json
+++ b/projects/GlobalSaaSHub/data/tools.next.json
@@ -3938,6 +3938,16 @@
     "primary_category": "voice_cloning",
     "comparison_group": "voice_generation",
     "official_url": "https://synthflow.ai/",
+    "affiliate_verified": false,
+    "affiliate_status": "application_submitted",
+    "affiliate_source_url": "https://synthflow.ai/partners/become-a-partner",
+    "affiliate_final_url": "https://forms.default.com/166142",
+    "affiliate_verified_at": "2026-09-07T06:52:20Z",
+    "affiliate_evidence_markers": [
+      "Thanks for filling out the form!",
+      "A Synthflow AI Channel representative will contact you shortly",
+      "Referral Partners application submitted; approval and tracking link not confirmed"
+    ],
     "pricing_source_url": null,
     "pricing_verified_at": null,
     "pricing_verified": false,

--- a/projects/GlobalSaaSHub/docs/evidence/synthflow-application-2026-09-07.md
+++ b/projects/GlobalSaaSHub/docs/evidence/synthflow-application-2026-09-07.md
@@ -1,0 +1,18 @@
+# Synthflow referral-partner application
+
+Checked: 2026-09-07T06:52:20Z.
+
+Official route: https://synthflow.ai/partners -> https://synthflow.ai/partners/become-a-partner -> embedded https://forms.default.com/166142.
+
+Before submission, both source JSON records had no affiliate URL/status, the production sync had no Synthflow override, and connected Gmail search found no prior Synthflow affiliate application correspondence.
+
+The form was submitted as COSHUMA with Referral Partners explicitly selected. The actual result screen displayed:
+
+- Thanks for filling out the form!
+- A Synthflow AI Channel representative will contact you shortly
+
+This confirms application submission only. Review outcome, approval, customer-facing tracking URL, clicks, conversions, commissions and revenue are not confirmed. Do not resubmit while awaiting a response. Keep affiliate_url null and affiliate_verified false; no monetized CTA is activated.
+
+No paid subscription, payment or legal-consent checkbox was used. Passwords and phone numbers are intentionally not recorded here.
+
+Questmate account creation/email verification is separate and is not evidence of a Questmate affiliate approval.

--- a/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
+++ b/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
@@ -59,6 +59,19 @@ const dataOverrides = {
 // create affiliate URLs; they only stop already-known outcomes from remaining
 // "unclassified" in the production revenue audit.
 const statusOverrides = {
+  'synthflow-ai': {
+    affiliate_url: null,
+    affiliate_verified: false,
+    affiliate_status: 'application_submitted',
+    affiliate_source_url: 'https://synthflow.ai/partners/become-a-partner',
+    affiliate_final_url: 'https://forms.default.com/166142',
+    affiliate_verified_at: '2026-09-07T06:52:20Z',
+    affiliate_evidence_markers: [
+      'Thanks for filling out the form!',
+      'A Synthflow AI Channel representative will contact you shortly',
+      'Referral Partners application submitted; approval and tracking link not confirmed',
+    ],
+  },
   hubspot: {
     affiliate_verified: true,
     affiliate_status: 'rejected',


### PR DESCRIPTION
## Summary

- Record Synthflow referral-partner application submission in both source JSONs and production sync.
- Preserve null affiliate_url and false affiliate_verified; no approval or monetized CTA claimed.
- Add official form route, checked timestamp, and actual submission-success text in evidence notes. Questmate is not upgraded.

## Validation

- npm ci: passed, zero vulnerabilities.
- npm run build: passed.
- JSON assertions: application_submitted, null URL, false verified in both files.
- git diff --check: passed.
- npm run test:links: existing two disclosure failures (taskade and relevance-ai), unchanged from the verified main baseline. No generated public files included.

4 scoped files, 51 additions. This records receipt only; approval, referral link, attribution and revenue remain unconfirmed.