### PR TITLE
Record VEED affiliate application outreach

### DIFF
--- a/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
+++ b/projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs
@@ -110,6 +110,18 @@ const statusOverrides = {
       'Exact customer-facing referral URL not yet issued or verified',
     ],
   },
+  veed: {
+    affiliate_verified: true,
+    affiliate_status: 'application_submitted',
+    affiliate_verified_at: '2026-09-07T00:00:00+09:00',
+    affiliate_evidence_markers: [
+      'VEED official affiliate page currently advertises recurring affiliate commission',
+      'Repository application route is Impact and no COSHUMA customer tracking URL is verified yet',
+      'COSHUMA direct enrollment request sent to official hello@veed.io support address',
+      'Gmail message id 1a07aa4c0c4a2a6d',
+      'Exact customer-facing tracking URL not yet issued or verified',
+    ],
+  },
   helpdesk: {
     affiliate_verified: true,
     affiliate_status: 'approved_account_campaign_link_pending',


### PR DESCRIPTION
## Summary
- Record the COSHUMA VEED affiliate enrollment request in the production affiliate-status override layer.
- Keep `affiliate_url` unset until VEED/Impact issues an exact account-specific customer tracking URL.
- Preserve official-program and Gmail provenance to prevent duplicate applications.

## Evidence
- VEED's official affiliate page currently advertises recurring affiliate commission.
- The repository already classifies VEED as `application_available_impact` with no affiliate URL.
- No prior VEED affiliate Gmail thread was found before outreach.
- COSHUMA direct enrollment request was sent to the official `hello@veed.io` support address; Gmail message id `1a07aa4c0c4a2a6d`.

No paid service, guessed tracking URL, approval claim, or revenue claim is introduced.