### PR TITLE
chore(affiliate): record Joiin enrollment request

### DIFF
--- a/projects/GlobalSaaSHub/data/joiin-affiliate-enrollment-evidence-2026-09-07.md
+++ b/projects/GlobalSaaSHub/data/joiin-affiliate-enrollment-evidence-2026-09-07.md
@@ -1,0 +1,12 @@
+# Joiin affiliate enrollment request — 2026-09-07
+
+- Official programme: https://www.joiin.co/affiliate-partner-programme/
+- Official signup guidance: https://support.joiin.co/support/solutions/articles/42000117597-how-to-sign-up-to-the-joiin-affiliate-programme
+- Programme platform: Reditus.
+- COSHUMA already has a Reditus account associated with support@coshuma.com; no duplicate Reditus account was created.
+- On 2026-09-07 COSHUMA sent an enrollment request to Joiin's official support address, support@joiin.co, asking for the correct Reditus enrollment path or a direct invitation.
+- Requested promotion route: COSHUMA SaaS buyer guides, comparisons, and product pages at https://coshuma.com.
+- Current state: `enrollment_requested`; this is not recorded as a completed marketplace application until Joiin/Reditus confirms enrollment.
+- Customer-facing affiliate/referral URL: not issued / not verified yet.
+- Revenue state: no Joiin referral, commission, or sale has been verified.
+- Guardrail: do not use a generic Joiin, Reditus marketplace, dashboard, or onboarding URL as a customer affiliate URL.


### PR DESCRIPTION
## Summary
- Record COSHUMA's 2026-09-07 Joiin affiliate enrollment request.
- Ground the request in Joiin's official affiliate programme and signup guidance.
- Keep the customer-facing referral URL unset until Joiin/Reditus issues an exact account-specific tracking link.

## Evidence
- Official programme: https://www.joiin.co/affiliate-partner-programme/
- Official signup guide: https://support.joiin.co/support/solutions/articles/42000117597-how-to-sign-up-to-the-joiin-affiliate-programme
- Enrollment request sent to Joiin's published support address: support@joiin.co.

## Guardrails
- This is `enrollment_requested`, not a claim that the Reditus marketplace application is completed.
- No generic marketplace/dashboard/onboarding URL is recorded as an affiliate URL.
- No revenue is claimed.