### PR TITLE
chore(affiliate): record Snov.io enrollment request

### DIFF
--- a/projects/GlobalSaaSHub/data/snov-affiliate-enrollment-evidence-2026-09-07.md
+++ b/projects/GlobalSaaSHub/data/snov-affiliate-enrollment-evidence-2026-09-07.md
@@ -1,0 +1,12 @@
+# Snov.io affiliate enrollment request — 2026-09-07
+
+- Official programme: https://snov.io/affiliate-program
+- Official affiliate guide: https://snov.io/knowledgebase/how-snov-io-affiliate-program-works/
+- Official partnerships contact: partnerships@snov.io (published at https://snov.io/contact-us).
+- Current official terms describe an open application flow and a personal affiliate link issued after approval.
+- On 2026-09-07 COSHUMA sent an application/enrollment request to partnerships@snov.io for https://coshuma.com.
+- Requested promotion route: independent SaaS buyer guides, comparisons, and product pages.
+- Current state: `enrollment_requested`; this is not recorded as a completed in-app application until Snov.io confirms enrollment or issues an approved affiliate profile.
+- Customer-facing affiliate/referral URL: not issued / not verified yet.
+- Revenue state: no Snov.io referral, commission, or sale has been verified.
+- Guardrail: do not use the generic Snov.io homepage, application page, dashboard, or onboarding URL as a customer affiliate URL.


### PR DESCRIPTION
## Summary
- Record COSHUMA's 2026-09-07 Snov.io affiliate enrollment outreach.
- Ground the request in Snov.io's current official affiliate programme and published partnerships contact.
- Keep the customer-facing referral URL unset until Snov.io issues an exact account-specific link.

## Evidence
- Official programme: https://snov.io/affiliate-program
- Official affiliate guide: https://snov.io/knowledgebase/how-snov-io-affiliate-program-works/
- Official contact: partnerships@snov.io via https://snov.io/contact-us

## Guardrails
- This is `enrollment_requested`, not a claim that an in-app application is completed or approved.
- No generic homepage/application/dashboard URL is treated as a tracking URL.
- No revenue is claimed.