### PR TITLE
chore(affiliate): record CloudTalk enrollment request

### DIFF
--- a/projects/GlobalSaaSHub/data/cloudtalk-affiliate-enrollment-evidence-2026-09-07.md
+++ b/projects/GlobalSaaSHub/data/cloudtalk-affiliate-enrollment-evidence-2026-09-07.md
@@ -1,0 +1,11 @@
+# CloudTalk affiliate enrollment request — 2026-09-07
+
+- Official programme: https://www.cloudtalk.io/affiliate-program/
+- Current official programme states that enrollment is free, uses PartnerStack, and offers account-specific partner tracking after approval.
+- COSHUMA had no CloudTalk enrollment/approval email found in the checked Gmail history before this outreach.
+- On 2026-09-07 COSHUMA sent a direct enrollment request to CloudTalk's published contact address hello@cloudtalk.io because the existing PartnerStack account has encountered marketplace enrollment limitations for some new programmes.
+- Requested action: direct CloudTalk PartnerStack invitation or another approved enrollment path for support@coshuma.com.
+- Current state: `enrollment_requested`; this is not a completed PartnerStack application or approval.
+- Customer-facing affiliate/referral URL: not issued / not verified yet.
+- Revenue state: no CloudTalk referral, commission, or sale has been verified.
+- Guardrail: do not use the generic CloudTalk homepage, PartnerStack dashboard, application, or onboarding URL as a customer affiliate URL.


### PR DESCRIPTION
## Summary
- Record COSHUMA's 2026-09-07 CloudTalk affiliate enrollment outreach.
- Ground the request in CloudTalk's current official free affiliate programme.
- Request a direct PartnerStack invitation because the existing PartnerStack account has encountered marketplace enrollment limits for some programmes.

## Evidence
- Official programme: https://www.cloudtalk.io/affiliate-program/
- Contact route used: hello@cloudtalk.io, published on CloudTalk's own site.

## Guardrails
- This is `enrollment_requested`, not a completed application or approval.
- No generic homepage/PartnerStack/dashboard URL is recorded as a customer tracking URL.
- No revenue is claimed.