### PR TITLE
chore(affiliate): record Tidio rejection evidence

### DIFF
--- a/projects/GlobalSaaSHub/data/tidio-affiliate-rejection-evidence-2026-08-25.md
+++ b/projects/GlobalSaaSHub/data/tidio-affiliate-rejection-evidence-2026-08-25.md
@@ -1,0 +1,9 @@
+# Tidio affiliate rejection evidence
+
+- PartnerStack application confirmation was received on 2026-08-24 for the COSHUMA account.
+- PartnerStack then sent a newer status email on 2026-08-25 stating that Tidio declined the application.
+- Current authoritative state: `rejected`.
+- Do not re-apply automatically or treat the public Tidio affiliate page as proof that COSHUMA is eligible or approved.
+- Customer-facing Tidio affiliate/tracking URL: none verified for COSHUMA.
+- Revenue state: no Tidio referral, commission, or sale has been verified.
+- Reason for this evidence note: structured affiliate data still showed `application_available` on 2026-09-07, which conflicts with the newer Gmail rejection evidence. The rejection must win until a later explicit approval exists.


### PR DESCRIPTION
## Summary
- Record the newer authoritative PartnerStack rejection for Tidio.
- Prevent stale `application_available` data from triggering a duplicate application.

## Evidence
- PartnerStack application received: 2026-08-24.
- PartnerStack rejection email: 2026-08-25.

## Guardrails
- Treat Tidio as `rejected` until a later explicit approval exists.
- No customer tracking URL is verified.
- No revenue is claimed.