### PR TITLE
chore(affiliate): record Reply.io enrollment request

### DIFF
--- a/projects/GlobalSaaSHub/data/replyio-affiliate-enrollment-evidence-2026-09-07.md
+++ b/projects/GlobalSaaSHub/data/replyio-affiliate-enrollment-evidence-2026-09-07.md
@@ -1,0 +1,12 @@
+# Reply.io affiliate enrollment request — 2026-09-07
+
+- Official affiliate programme: https://reply.io/affiliates/
+- Checked on 2026-09-07: Reply.io explicitly lists content creators and publishers/media networks among suitable affiliate partners.
+- The official programme says approved affiliates receive their customer-facing affiliate link through PartnerStack and lists a 90-day cookie window; standard programme commission tiers are shown on the official page.
+- Gmail history checked before outreach did not show an existing Reply.io affiliate application, approval, rejection, or customer tracking link.
+- On 2026-09-07 COSHUMA sent a direct enrollment request to Reply.io's official sales contact, sales@reply.io, asking for a direct PartnerStack invitation or another official enrollment route because the existing PartnerStack account has encountered marketplace enrollment limits for some programmes.
+- Gmail sent-message id: `1a07ad68e40ede20`.
+- Current state: `enrollment_requested`; this is not a completed PartnerStack application or approval.
+- Customer-facing affiliate/referral URL: not issued / not verified yet.
+- Revenue state: no Reply.io referral, commission, or sale has been verified.
+- Guardrail: do not use the generic Reply.io homepage, PartnerStack dashboard/application/onboarding URL, or a guessed tracking parameter as a customer affiliate URL.


### PR DESCRIPTION
## Summary
- Record COSHUMA's 2026-09-07 Reply.io affiliate enrollment outreach.
- Ground the request in Reply.io's current official affiliate programme.
- Keep the customer-facing referral URL unset until Reply.io/PartnerStack issues an exact account-specific tracking link.

## Evidence
- Official programme: https://reply.io/affiliates/
- Current programme explicitly lists content creators and publishers/media networks as suitable partners and says affiliate links are issued through PartnerStack.
- No prior Reply.io affiliate Gmail thread was found before outreach.
- Enrollment request sent to Reply.io's official sales contact; Gmail sent-message id `1a07ad68e40ede20`.

## Guardrails
- This is `enrollment_requested`, not approval.
- No generic homepage/dashboard/onboarding URL is treated as a revenue link.
- No revenue is claimed.