### PR TITLE
chore(affiliate): record MindStudio enrollment request

### DIFF
--- a/projects/GlobalSaaSHub/data/mindstudio-affiliate-enrollment-evidence-2026-09-07.md
+++ b/projects/GlobalSaaSHub/data/mindstudio-affiliate-enrollment-evidence-2026-09-07.md
@@ -1,0 +1,12 @@
+# MindStudio affiliate enrollment request — 2026-09-07
+
+- Official affiliate programme: https://university.mindstudio.ai/programs/affiliate-program
+- Checked on 2026-09-07: MindStudio says its affiliate/referral programme is powered by PartnerStack, provides a unique referral link after enrollment, pays 20% of workspace subscription revenue for the first 12 months by default, and uses a 90-day cookie window.
+- Official MindStudio support contact verified on its own site: support@mindstudio.ai.
+- Gmail history checked before outreach did not show an existing MindStudio affiliate application, approval, rejection, or customer tracking link.
+- On 2026-09-07 COSHUMA sent a direct enrollment request to support@mindstudio.ai asking for a direct PartnerStack invitation or the correct official enrollment route because the existing PartnerStack account can encounter marketplace enrollment limits for some programmes.
+- Gmail sent-message id: `1a07ae8dbd133f68`.
+- Current state: `enrollment_requested`; this is not a completed PartnerStack application or approval.
+- Customer-facing affiliate/referral URL: not issued / not verified yet.
+- Revenue state: no MindStudio referral, commission, or sale has been verified.
+- Guardrail: do not use the generic MindStudio homepage, PartnerStack dashboard/application/onboarding URL, or a guessed tracking parameter as a customer affiliate URL.


### PR DESCRIPTION
## Summary
- Record COSHUMA's 2026-09-07 MindStudio affiliate enrollment outreach.
- Ground the request in MindStudio's current official PartnerStack referral programme.
- Keep the customer-facing referral URL unset until MindStudio/PartnerStack issues an exact account-specific tracking link.

## Evidence
- Official programme: https://university.mindstudio.ai/programs/affiliate-program
- Official support contact: support@mindstudio.ai
- No prior MindStudio affiliate Gmail thread was found before outreach.
- Enrollment request sent; Gmail sent-message id `1a07ae8dbd133f68`.

## Guardrails
- This is `enrollment_requested`, not approval.
- No generic homepage/dashboard/onboarding URL is treated as a revenue link.
- No revenue is claimed.