### PR TITLE
chore(affiliate): record PartnerStack network re-evaluation request

### DIFF
--- a/projects/GlobalSaaSHub/data/partnerstack-network-reevaluation-evidence-2026-09-07.md
+++ b/projects/GlobalSaaSHub/data/partnerstack-network-reevaluation-evidence-2026-09-07.md
@@ -1,0 +1,10 @@
+# PartnerStack Network re-evaluation request — 2026-09-07
+
+- Authoritative restriction evidence: PartnerStack Network Team email dated 2026-07-30 states COSHUMA's access to joining new programmes through the PartnerStack Marketplace was limited because the Network Profile was not considered a strong fit at that time.
+- That same email says existing PartnerStack partnerships are unaffected and that the profile may be re-evaluated after new or corrected information is provided.
+- Since that review, COSHUMA has expanded independent SaaS buyer guides, comparison pages, pricing guides, and verified affiliate CTAs and has multiple active PartnerStack programme relationships.
+- On 2026-09-07 COSHUMA replied to PartnerStack Network Team at networkquality@partnerstack.com requesting re-evaluation or exact guidance on which Network Profile fields should be updated before reapplying through the dashboard.
+- Gmail sent-message id: `1a07aeb7f870f6ca`; parent restriction message id: `19fb3ccebebadfdd`.
+- Current state: `network_re_evaluation_requested`; this is not approval and does not restore Marketplace access by itself.
+- Revenue impact if resolved: potentially removes the common enrollment blocker for currently open PartnerStack affiliate programmes such as MindStudio, Sendcloud, Manychat and other eligible programmes already tracked by COSHUMA.
+- Guardrail: until PartnerStack confirms the restriction is lifted, do not treat an application page, marketplace page, dashboard URL, or generic product URL as an approved customer affiliate link.


### PR DESCRIPTION
## Summary
- Record the existing PartnerStack Network marketplace restriction from the authoritative 2026-07-30 email.
- Record COSHUMA's 2026-09-07 re-evaluation request after material site/partner progress.
- Preserve the distinction between a re-evaluation request and restored marketplace access.

## Evidence
- PartnerStack Network restriction message id: `19fb3ccebebadfdd`.
- Re-evaluation request sent to `networkquality@partnerstack.com`; Gmail sent-message id `1a07aeb7f870f6ca`.

## Guardrails
- Marketplace access remains unconfirmed until PartnerStack says otherwise.
- No application/dashboard/generic URL is treated as a customer tracking URL.
- No revenue is claimed.