### PR TITLE
chore(affiliate): record current browser-required enrollment blockers

### DIFF
--- a/projects/GlobalSaaSHub/data/browser-required-affiliate-blockers-2026-09-07.md
+++ b/projects/GlobalSaaSHub/data/browser-required-affiliate-blockers-2026-09-07.md
@@ -1,0 +1,22 @@
+# Browser/user-verification affiliate blockers — 2026-09-07
+
+## Questmate
+- Gmail message `1a07a9d7005f84a1` confirms COSHUMA has been welcomed to Questmate's Rewardful partner programme.
+- Current blocker: email confirmation must be completed before the unique customer tracking link can be viewed in the Rewardful portal.
+- State: `email_confirmation_required`; approval/link activation is not yet verified.
+- Do not publish the Rewardful login URL or any confirmation token as a customer affiliate URL.
+
+## AiAssistWorks
+- Gmail message `1a07a9ada65fcb7e` is an affiliate-program login message containing a one-time password / login-verification link.
+- Current blocker: OTP/login verification requires user intervention under the automation guardrails.
+- State: `otp_required`; customer tracking URL remains unverified.
+- Do not store or publish the OTP/token in repository data.
+
+## JobHire.AI
+- Human support reply in Gmail message `1a07a9f8bde2ff29` confirms the affiliate programme is free to join and that enrollment must be completed through the official `Join Now` route at https://jobhire.ai/affiliate-program.
+- The agent explicitly said they cannot activate the account or assign a tracking link manually.
+- Current blocker: browser form completion through the official Join Now route.
+- State: `browser_required_application`; customer tracking URL remains unverified.
+
+## Operating rule
+These blockers must not stop other COSHUMA revenue work. Skip them while the user is absent, do not retry blindly, and resume only when the required browser or verification step is available. No revenue is claimed for any of these programmes yet.


### PR DESCRIPTION
## Summary
- Record three currently actionable-but-blocked affiliate paths without exposing secrets or inventing tracking URLs.
- Questmate: email confirmation required before Rewardful link access.
- AiAssistWorks: OTP/login verification required.
- JobHire.AI: human support confirmed free official Join Now route; browser form required and no manual tracking link can be assigned.

## Guardrails
- No OTP, confirmation token, login URL, or generic application URL is published as a customer affiliate link.
- These blockers must not stop other revenue work while the user is absent.
- No approval/revenue is claimed beyond the exact Gmail evidence.