### PR TITLE
chore(affiliate): record Catalister enrollment request

### DIFF
--- a/projects/GlobalSaaSHub/data/catalister-affiliate-application-evidence-2026-09-07.md
+++ b/projects/GlobalSaaSHub/data/catalister-affiliate-application-evidence-2026-09-07.md
@@ -1,0 +1,12 @@
+# Catalister affiliate application evidence — 2026-09-07
+
+- Official affiliate signup rechecked: https://affiliates.catalister.com/
+- Official signup currently states 30% on subscription and 10% on credits, and uses an email-code login flow powered by PromoteKit.
+- Catalister's current official site lists `info@catalister.com` as its contact email.
+- COSHUMA checked Gmail before outreach and found no prior Catalister affiliate application thread.
+- Because the signup flow requires an email-code step that cannot be completed in this non-interactive run, COSHUMA sent a direct enrollment request to `info@catalister.com` on 2026-09-07.
+- Gmail sent message id: `1a07b0244e890000`.
+- Customer-facing tracking/referral URL: not yet issued or verified.
+- Current state: `application_submitted` / awaiting Catalister response or approved account route.
+- Revenue state: no click, signup, commission, or sale has been verified for Catalister.
+- Do not use the Catalister homepage, PromoteKit login, or affiliate dashboard URL as a revenue CTA. Wait for an account-specific customer tracking link.


### PR DESCRIPTION
## Summary
- Rechecked Catalister's current official affiliate signup and terms.
- Confirmed no prior Catalister affiliate thread in Gmail.
- Sent COSHUMA's direct enrollment request because the official signup requires an email-code step.
- Added evidence to prevent duplicate application attempts and generic-URL misuse.

## Revenue state
- Application outreach submitted.
- No customer-facing tracking URL verified yet.
- No click, signup, commission, or sale claimed.

## Safety
- No paid subscription or payment action was taken.