### PR TITLE
chore(affiliate): record ActiveCampaign rejection evidence

### DIFF
--- a/projects/GlobalSaaSHub/data/activecampaign-affiliate-rejection-evidence-2026-08-28.md
+++ b/projects/GlobalSaaSHub/data/activecampaign-affiliate-rejection-evidence-2026-08-28.md
@@ -1,0 +1,11 @@
+# ActiveCampaign affiliate rejection evidence
+
+- PartnerStack application confirmation was received on 2026-08-24 for the COSHUMA account.
+- PartnerStack sent a newer authoritative status email on 2026-08-28 stating that ActiveCampaign declined the application.
+- Current authoritative state: `rejected`.
+- Do not re-apply automatically or treat ActiveCampaign's public affiliate page as proof that COSHUMA is eligible or approved.
+- The rejection email says a future re-application is possible after addressing ActiveCampaign's feedback, but it does not provide a specific correction that has been completed.
+- Customer-facing ActiveCampaign affiliate/tracking URL: none verified for COSHUMA.
+- Revenue state: no ActiveCampaign referral, commission, or sale has been verified.
+- Gmail evidence: rejection message id `1a049ba49a81c468`.
+- Generic PartnerStack dashboard/re-apply URLs must not be published as customer affiliate links.


### PR DESCRIPTION
## Summary
- Reconcile stale ActiveCampaign affiliate eligibility with the newer authoritative PartnerStack outcome.
- Record the 2026-08-28 rejection so future revenue runs do not submit a duplicate application.
- Keep customer-facing tracking URL unverified/null until a later explicit approval exists.

## Evidence
- PartnerStack application received: 2026-08-24.
- PartnerStack rejection email: 2026-08-28, Gmail message id `1a049ba49a81c468`.

## Guardrails
- Treat ActiveCampaign as `rejected` for application decisions until later explicit approval evidence exists.
- Do not publish dashboard/re-apply/generic links as customer affiliate URLs.
- No revenue is claimed.