### PR TITLE
Record Manychat and Fathom affiliate outreach

### DIFF
--- a/projects/GlobalSaaSHub/data/affiliate-outreach-2026-09-07-1829.md
+++ b/projects/GlobalSaaSHub/data/affiliate-outreach-2026-09-07-1829.md
@@ -1,0 +1,34 @@
+# Affiliate outreach — 2026-09-07 18:29 KST
+
+## Manychat
+
+- Repository baseline: `affiliate_url` is not confirmed; stale data listed `application_available_partnerstack`.
+- Fresh official source: https://help.manychat.com/hc/en-us/articles/20518248843164-Manychat-Partner-Program-FAQ
+- Official FAQ checked 2026-09-07: Manychat says PartnerStack Network verification is **not required** to join the Manychat program directly; Marketplace enrollment may require Network approval. Unique referral links are issued in PartnerStack after enrollment.
+- Gmail duplicate check before outreach: no prior Manychat-specific application/support thread found.
+- Action taken: sent PartnerStack Support a targeted request to enable/provide the direct Manychat application path for COSHUMA's existing PartnerStack account without creating a duplicate account.
+- Gmail sent message id: `1a07b34ffaf04027`.
+- Status: `direct_enrollment_path_requested`.
+- Customer-facing affiliate URL: **not issued / not verified**. Do not publish a generic PartnerStack URL as revenue tracking.
+
+## Fathom
+
+- Repository baseline: partner application was shown as available; no customer-specific affiliate URL is confirmed.
+- Fresh official source: https://www.fathom.ai/program/growth-partner
+- Official program checked 2026-09-07: Fathom's Growth Partner Program is open to agencies/consultants/operators, applications are handled through PartnerStack, an active Fathom account is required, business email is required, and accepted partners receive a unique PartnerStack link. Official contact: `partners@fathom.video`.
+- Gmail duplicate check before outreach: no prior Fathom partnership thread found.
+- Action taken: sent Fathom Partnerships a COSHUMA Growth Partner application-path/direct-invite request, explicitly asking not to create a duplicate PartnerStack account.
+- Gmail sent message id: `1a07b3519322e374`.
+- Status: `enrollment_path_requested`.
+- Customer-facing affiliate URL: **not issued / not verified**.
+
+## Browser-required candidates not treated as submitted
+
+- Sendcloud: official affiliate program remains live at https://www.sendcloud.com/partnerships/affiliate-program/ and is free, but the application path is PartnerStack/browser-based. Do not mark as submitted without an actual submission receipt or dashboard evidence.
+- AI Video Cut: official affiliate program remains live at https://www.aivideocut.com/affiliate-program and advertises an application form plus 24–48 hour review. No authenticated submission evidence exists in this run; keep it `browser_required` rather than `application_submitted`.
+
+## Guardrails
+
+- No generic homepage, dashboard, onboarding, or application URL was promoted as an affiliate revenue link.
+- No approval, commission, signup, or revenue is claimed in this evidence.
+- No paid subscription or purchase was made.


### PR DESCRIPTION
## Summary
- Record fresh official Manychat partner-program rules and targeted direct-enrollment request.
- Record fresh Fathom Growth Partner program rules and direct-invite/application-path request.
- Record Sendcloud and AI Video Cut as browser-required rather than falsely submitted.

## Validation
- Gmail duplicate checks completed before outreach.
- Manychat official FAQ confirms direct program enrollment does not require PartnerStack Network verification.
- Fathom official Growth Partner page confirms PartnerStack application, business-email requirement, and issuance of a unique partner link after acceptance.
- No customer-facing tracking URL, approval, conversion, or revenue is claimed.
- No paid action taken.