### PR TITLE
Record GetGenie affiliate account clarification

### DIFF
--- a/projects/GlobalSaaSHub/data/getgenie-account-clarification-2026-09-07.md
+++ b/projects/GlobalSaaSHub/data/getgenie-account-clarification-2026-09-07.md
@@ -1,0 +1,20 @@
+# GetGenie affiliate account clarification — 2026-09-07
+
+## Fresh Gmail evidence
+
+- Original acceptance email (2026-08-31) was addressed to `support@coshuma.com` and stated that Sangkwon An's GetGenie affiliate application was accepted.
+- GetGenie support later replied that they could not find an affiliate account associated with the Gmail address used in the support conversation and instructed us to log in with the email used when registering.
+- The discrepancy is therefore account-email related, not evidence that the accepted COSHUMA account was revoked.
+
+## Action taken
+
+- Replied to GetGenie support on 2026-09-07 and identified `support@coshuma.com` as the email that received the original acceptance.
+- Asked GetGenie to check the accepted account under that business email and either send the exact customer-facing referral/tracking URL or send the correct login/password-reset steps to `support@coshuma.com`.
+- Gmail sent message id: `1a07b368561ec4a6`.
+
+## Current tracking-link conflict
+
+- Repository currently publishes `https://getgenie.ai?rui=3921` as a verified GetGenie affiliate URL.
+- Because the latest support conversation shows an email-account mismatch, keep the existing URL unchanged for now but treat **current account ownership / dashboard visibility as requiring reconfirmation** until GetGenie support ties the accepted `support@coshuma.com` account to the exact customer-facing URL.
+- Do not substitute the affiliate-area/dashboard URL as a customer tracking link.
+- No new approval, conversion, commission, or revenue is claimed in this evidence.


### PR DESCRIPTION
## Summary
- Preserve the fresh Gmail evidence that GetGenie's accepted affiliate account was tied to `support@coshuma.com`, while the support thread was using a different Gmail address.
- Record the clarification reply asking GetGenie to map the accepted business-email account to the exact customer-facing tracking URL.
- Keep the currently published `rui=3921` URL unchanged, but explicitly mark dashboard/account ownership as needing reconfirmation until support ties it to the accepted business account.

No approval, conversion, commission, or revenue is newly claimed.