### PR TITLE
chore(affiliate): record Joiin Reditus follow-up

### DIFF
--- a/projects/GlobalSaaSHub/data/joiin-affiliate-enrollment-evidence-2026-09-07.md
+++ b/projects/GlobalSaaSHub/data/joiin-affiliate-enrollment-evidence-2026-09-07.md
@@ -5,6 +5,8 @@
 - Programme platform: Reditus.
 - COSHUMA already has a Reditus account associated with support@coshuma.com; no duplicate Reditus account was created.
 - On 2026-09-07 COSHUMA sent an enrollment request to Joiin's official support address, support@joiin.co, asking for the correct Reditus enrollment path or a direct invitation.
+- Joiin Support replied on 2026-09-07 and confirmed the public affiliate route at https://www.joiin.co/affiliate-partner-programme/ . The official page's `Sign Up as an Affiliate` CTA resolves to the Joiin programme listing at https://app.getreditus.com/marketplace/joiin .
+- COSHUMA then replied in the same support thread requesting a direct Reditus invitation or enrollment of the existing business email so no duplicate marketplace account is created. Gmail sent-message id: `1a07b3b2652931e8`.
 - Requested promotion route: COSHUMA SaaS buyer guides, comparisons, and product pages at https://coshuma.com.
 - Current state: `enrollment_requested`; this is not recorded as a completed marketplace application until Joiin/Reditus confirms enrollment.
 - Customer-facing affiliate/referral URL: not issued / not verified yet.


### PR DESCRIPTION
Records the 2026-09-07 human support reply from Joiin confirming the official affiliate route, the exact Reditus programme listing reached by the official CTA, and COSHUMA's follow-up request for direct invitation/enrollment of the existing business account. No customer-facing affiliate URL or revenue is claimed.