### PR TITLE
fix(deploy): verify confirmed Jotform revenue URL

### DIFF
--- a/.github/workflows/coshuma-site-deploy.yml
+++ b/.github/workflows/coshuma-site-deploy.yml
@@ -13,6 +13,7 @@ on:
       - 'projects/GlobalSaaSHub/scripts/polish_public_copy.py'
       - 'projects/GlobalSaaSHub/scripts/ensure_best_pages_in_sitemap.py'
       - 'projects/GlobalSaaSHub/scripts/inject_pictory_partner_offer.py'
+      - 'projects/GlobalSaaSHub/scripts/inject_jotform_partner_offer.py'
       - 'projects/GlobalSaaSHub/scripts/publish_affiliate_audit.mjs'
       - 'projects/GlobalSaaSHub/index.html'
       - 'projects/GlobalSaaSHub/package.json'
@@ -71,6 +72,9 @@ jobs:
       - name: Inject current Pictory partner offer
         run: python projects/GlobalSaaSHub/scripts/inject_pictory_partner_offer.py
 
+      - name: Inject confirmed Jotform partner links
+        run: python projects/GlobalSaaSHub/scripts/inject_jotform_partner_offer.py
+
       - name: Index buyer-intent hubs in sitemap
         run: python projects/GlobalSaaSHub/scripts/ensure_best_pages_in_sitemap.py
 
@@ -109,6 +113,12 @@ jobs:
           grep -R -q -F 'https://unbounce.partnerlinks.io/5ubjnt8lluqi' projects/GlobalSaaSHub/dist/compare
           grep -R -q -F 'https://get.murf.ai/fqac0vixj0qs' projects/GlobalSaaSHub/dist/assets
           grep -R -q -F 'https://unbounce.partnerlinks.io/5ubjnt8lluqi' projects/GlobalSaaSHub/dist/assets
+          test -f projects/GlobalSaaSHub/dist/tool/jotform.html
+          grep -q -F 'https://www.jotform.com/ai/agents/?partner=coshuma' projects/GlobalSaaSHub/dist/tool/jotform.html
+          if grep -q -F 'https://link.jotform.com/17STYVOunG?username=AnSangkwon' projects/GlobalSaaSHub/dist/tool/jotform.html; then
+            echo 'Jotform production page still contains the legacy onboarding redirect instead of the confirmed customer-facing partner URL.'
+            exit 1
+          fi
           for page in projects/GlobalSaaSHub/dist/compare/*.html; do
             [ -e "$page" ] || continue
             if grep -q 'data-cta="affiliate"' "$page" && ! grep -q 'data-affiliate-disclosure="compare"' "$page"; then


### PR DESCRIPTION
Makes the confirmed Jotform customer-facing AI Agents partner URL a first-class deploy invariant. The workflow now watches the Jotform injection script directly, runs it explicitly, requires the confirmed `https://www.jotform.com/ai/agents/?partner=coshuma` URL in the production bundle, and fails if the legacy onboarding redirect remains. The exact customer-facing URL was confirmed by Jotform Affiliate Marketing Specialist Anna Scheucher on 2026-09-07. No revenue/conversion is claimed.