### PR TITLE
Record Cloudways outreach and ClickUp rejection evidence

### DIFF
--- a/projects/GlobalSaaSHub/data/clickup-affiliate-rejection-evidence-2026-08-25.md
+++ b/projects/GlobalSaaSHub/data/clickup-affiliate-rejection-evidence-2026-08-25.md
@@ -1,0 +1,25 @@
+# ClickUp affiliate rejection evidence — 2026-08-25
+
+## Decision
+
+- `affiliate_url`: `null`
+- `affiliate_status`: `rejected`
+- Do not reapply automatically unless newer first-party or PartnerStack evidence materially changes this state.
+
+## Official program evidence
+
+- Current official ClickUp affiliate page: https://clickup.com/partners/affiliates
+- Current official ClickUp Help article: https://help.clickup.com/hc/en-us/articles/6311978850967-Sign-up-for-the-affiliate-program
+- ClickUp still operates an affiliate program through PartnerStack and only provides the unique affiliate link after approval.
+
+## Account evidence
+
+- PartnerStack application-received email: 2026-08-24, Gmail message id `1a0335635b16ee8a`.
+- Newer PartnerStack decision email: 2026-08-25, Gmail message id `1a03902e9683c1b0`.
+- The newer decision explicitly says ClickUp declined COSHUMA's application.
+
+## Current status
+
+- Rejected is the controlling state despite `tools.json` lacking a current affiliate status for ClickUp.
+- Exact customer-facing affiliate/tracking URL is **not** issued or verified.
+- No new application was submitted in this run, preventing duplicate/rejected-program churn.

--- a/projects/GlobalSaaSHub/data/cloudways-affiliate-enrollment-evidence-2026-09-07.md
+++ b/projects/GlobalSaaSHub/data/cloudways-affiliate-enrollment-evidence-2026-09-07.md
@@ -1,0 +1,26 @@
+# Cloudways affiliate enrollment evidence — 2026-09-07
+
+## Decision
+
+- `affiliate_url`: `null`
+- `affiliate_status`: `enrollment_requested`
+- Do not publish a Cloudways revenue CTA until an account-specific customer-facing affiliate link is issued and verified.
+
+## Official evidence
+
+- Current official Cloudways Help Center article: https://support.cloudways.com/en/articles/5134056-how-to-join-cloudways-affiliate-program-faqs-benefits
+- The official article states that the Affiliate Program is active, the affiliate profile is submitted for review, and the Affiliate Panel exposes the issued Affiliate Link after enrollment.
+- It also states that a site does not need to be hosted on Cloudways to become an affiliate; an affiliate account can be opened separately.
+
+## COSHUMA action
+
+- Gmail was searched before outreach; no prior Cloudways affiliate application/conversation was found.
+- COSHUMA sent a zero-cost enrollment/path request to the Cloudways affiliate team on 2026-09-07.
+- Gmail sent message id: `1a07b6e4176740e1`.
+- The request asks for the correct free enrollment route or account-specific invitation and explicitly states that COSHUMA will only publish the exact issued customer-facing tracking link.
+
+## Current status
+
+- Application/enrollment path requested; approval is **not** confirmed.
+- Exact customer-facing affiliate/tracking URL is **not** confirmed.
+- Click, signup, commission, and revenue are **not** confirmed.


### PR DESCRIPTION
Records two affiliate-state corrections from fresh official/Gmail evidence:

- Cloudways: official affiliate program remains active; no prior COSHUMA thread was found; a zero-cost enrollment/path request was sent. Approval and exact tracking URL remain unconfirmed.
- ClickUp: current program remains active publicly, but newer PartnerStack account evidence shows COSHUMA's 2026-08-25 application was declined. No duplicate reapplication was made.

This PR does not invent or publish any affiliate URL and does not claim revenue.