### PR TITLE
Record affiliate follow-ups and browser blockers

### DIFF
--- a/projects/GlobalSaaSHub/data/browser-required-affiliate-blockers-2026-09-07.md
+++ b/projects/GlobalSaaSHub/data/browser-required-affiliate-blockers-2026-09-07.md
@@ -18,5 +18,17 @@
 - Current blocker: browser form completion through the official Join Now route.
 - State: `browser_required_application`; customer tracking URL remains unverified.
 
+## Sendcloud
+- Current official affiliate page: https://www.sendcloud.com/partnerships/affiliate-program/
+- The vendor currently states the programme is free to join, runs on PartnerStack, pays 100% of the referred customer's first month, and uses a 90-day last-click cookie.
+- Gmail was searched on 2026-09-07 and no prior Sendcloud affiliate application/conversation was found.
+- Current blocker: the vendor routes the actual application through an interactive PartnerStack signup/application flow; this automation does not have the authenticated Work browser session needed to safely complete it.
+- State: `browser_required_application`; no submission, approval, or customer tracking URL is claimed.
+
+## AI Video Cut
+- Current official affiliate page: https://www.aivideocut.com/affiliate
+- Previous verification found the vendor requires its interactive application form; no authenticated browser submission completion evidence is available in this automation context.
+- State: `browser_required_application`; do not mark `application_submitted` until the confirmation screen or vendor email is actually observed.
+
 ## Operating rule
 These blockers must not stop other COSHUMA revenue work. Skip them while the user is absent, do not retry blindly, and resume only when the required browser or verification step is available. No revenue is claimed for any of these programmes yet.

--- a/projects/GlobalSaaSHub/data/cloudways-affiliate-enrollment-evidence-2026-09-07.md
+++ b/projects/GlobalSaaSHub/data/cloudways-affiliate-enrollment-evidence-2026-09-07.md
@@ -3,7 +3,7 @@
 ## Decision
 
 - `affiliate_url`: `null`
-- `affiliate_status`: `enrollment_requested`
+- `affiliate_status`: `support_ticket_received`
 - Do not publish a Cloudways revenue CTA until an account-specific customer-facing affiliate link is issued and verified.
 
 ## Official evidence
@@ -17,10 +17,11 @@
 - Gmail was searched before outreach; no prior Cloudways affiliate application/conversation was found.
 - COSHUMA sent a zero-cost enrollment/path request to the Cloudways affiliate team on 2026-09-07.
 - Gmail sent message id: `1a07b6e4176740e1`.
+- Cloudways Affiliate Support acknowledged receipt and created ticket `#966456`; Gmail message id `1a07b6e5f88035a7`.
 - The request asks for the correct free enrollment route or account-specific invitation and explicitly states that COSHUMA will only publish the exact issued customer-facing tracking link.
 
 ## Current status
 
-- Application/enrollment path requested; approval is **not** confirmed.
+- Support ticket received; affiliate approval is **not** confirmed.
 - Exact customer-facing affiliate/tracking URL is **not** confirmed.
 - Click, signup, commission, and revenue are **not** confirmed.

--- a/projects/GlobalSaaSHub/data/flowgent-affiliate-conflict-evidence-2026-09-07.md
+++ b/projects/GlobalSaaSHub/data/flowgent-affiliate-conflict-evidence-2026-09-07.md
@@ -1,0 +1,23 @@
+# FlowGent affiliate programme conflict — 2026-09-07
+
+## Decision
+
+- `affiliate_url`: `null`
+- `affiliate_status`: `program_signup_inactive_conflict`
+- Do not submit or publish a FlowGent affiliate link until the vendor resolves the conflict.
+
+## Conflicting first-party evidence
+
+- FlowGent's current official affiliate page at https://flowgent.ai/affiliate advertises a 20% lifetime recurring commission, a 60-day cookie, and says applications are open.
+- The affiliate CTA on that same official page points to FlowGent's Rewardful signup at `flowgent-ai.getrewardful.com`.
+- Following that vendor-provided signup destination currently resolves to Rewardful's `Affiliate Program Inactive` page, which says the affiliate program is no longer active.
+
+## Resolution rule
+
+The operational signup destination is more directly relevant to whether an application can actually be submitted than marketing copy on the landing page. Treat the program as conflicted/inactive for enrollment until newer first-party evidence restores a working signup route.
+
+## Current status
+
+- No application was submitted.
+- Exact customer-facing referral URL is not issued or verified.
+- No click, signup, commission, or revenue is claimed.

--- a/projects/GlobalSaaSHub/data/joiin-direct-invite-evidence-2026-09-07.md
+++ b/projects/GlobalSaaSHub/data/joiin-direct-invite-evidence-2026-09-07.md
@@ -1,0 +1,26 @@
+# Joiin direct affiliate invite evidence — 2026-09-07
+
+## Decision
+
+- `affiliate_url`: `null`
+- `affiliate_status`: `direct_invite_received_browser_required`
+- Do not publish the Reditus signup/invitation URL as a customer affiliate URL.
+
+## Evidence
+
+- Joiin's Chief Commercial Officer replied in support ticket `#40896` and supplied a direct Reditus affiliate-program signup invitation for COSHUMA.
+- Gmail message id: `1a07b68ad34b4d8d`.
+- The invitation contains a private invite key, so the full signup URL/token is intentionally not copied into repository evidence.
+- The message confirms the signup route is for Joiin's affiliate program on Reditus; it does **not** itself confirm approval or issue a customer-facing referral link.
+
+## Current blocker
+
+- Completing the direct Reditus invitation requires an authenticated browser session and may require account/session verification.
+- Keep this as browser-required while the user is absent; continue other revenue work instead of waiting.
+
+## Current status
+
+- Direct vendor invitation received.
+- Affiliate approval is **not** yet confirmed.
+- Exact customer-facing tracking/referral URL is **not** yet issued or verified.
+- Click, signup, commission, and revenue are **not** confirmed.


### PR DESCRIPTION
Fresh evidence updates:

- Cloudways: support acknowledged the enrollment request and created ticket #966456; approval/tracking URL remain unconfirmed.
- Joiin: vendor officer supplied a direct Reditus signup invitation. The private invite token is deliberately not stored; authenticated browser completion is still required.
- FlowGent: official marketing page says the affiliate programme is open, but its own Rewardful CTA currently lands on 'Affiliate Program Inactive'; fail closed until the vendor restores a working route.
- Sendcloud and AI Video Cut: record the interactive-browser application blockers rather than inventing submissions.

No generic/dashboard URLs are promoted as affiliate links and no revenue is claimed.