### PR TITLE
Record Reditus affiliate enrollment request

### DIFF
--- a/projects/GlobalSaaSHub/data/reditus-affiliate-enrollment-evidence-2026-09-07.md
+++ b/projects/GlobalSaaSHub/data/reditus-affiliate-enrollment-evidence-2026-09-07.md
@@ -1,0 +1,27 @@
+# Reditus affiliate enrollment evidence — 2026-09-07
+
+## Decision
+
+- `affiliate_url`: `null`
+- `affiliate_status`: `enrollment_requested_existing_account`
+- Do not use Reditus marketplace, dashboard, or generic signup URLs as a customer affiliate URL.
+
+## Official evidence
+
+- Current official Reditus Affiliate Program page: https://getreditus.com/affiliate-program
+- The official page states the Reditus affiliate program is free to join, offers up to 40% commission for 36 months, and uses last-click attribution with a 90-day cookie.
+- The same official page lists `info@getreditus.com` as a Reditus contact address.
+
+## COSHUMA action
+
+- COSHUMA already uses Reditus for affiliate-program access, so a duplicate account was intentionally avoided.
+- A request was sent to Reditus asking them to enroll the existing COSHUMA affiliate account in Reditus's own affiliate program or provide the correct account-specific route.
+- Gmail sent message id: `1a07b77eb2e25993`.
+- The message explicitly states that COSHUMA will only publish the exact customer-facing referral/tracking URL issued to the account.
+
+## Current status
+
+- Enrollment requested for the existing account.
+- Approval is **not** confirmed.
+- Exact customer-facing tracking/referral URL is **not** confirmed.
+- Click, signup, commission, and revenue are **not** confirmed.


### PR DESCRIPTION
Records a fresh zero-cost revenue-path action for the unclassified Reditus tool:

- official Reditus affiliate program remains open and free to join;
- COSHUMA already uses Reditus, so no duplicate account was created;
- an account-specific enrollment request was sent to the official Reditus contact;
- no approval, customer tracking URL, or revenue is claimed yet.

This evidence prevents generic marketplace/dashboard URLs from being mistaken for a revenue link.