### PR TITLE
Record MarketingBlocks affiliate enrollment request

### DIFF
--- a/projects/GlobalSaaSHub/data/marketingblocks-affiliate-enrollment-evidence-2026-09-07.md
+++ b/projects/GlobalSaaSHub/data/marketingblocks-affiliate-enrollment-evidence-2026-09-07.md
@@ -1,0 +1,27 @@
+# MarketingBlocks affiliate enrollment evidence — 2026-09-07
+
+## Decision
+
+- `affiliate_url`: `null`
+- `affiliate_status`: `enrollment_route_requested`
+- Do not publish a MarketingBlocks revenue CTA until an account-specific customer-facing affiliate link is issued and verified.
+
+## Official evidence
+
+- Current official MarketingBlocks support knowledge base: https://support.marketingblocks.ai/article/17a087a5-1639-4c51-b2ad-4cadfc3d5ce6
+- The official article states that approved affiliates receive a unique affiliate link; qualifying purchases, upgrades, and recurring purchases are attributed to the affiliate, and commissions take about 30 days to be approved.
+- The same official article lists `support@marketingblocks.ai` for assistance.
+
+## COSHUMA action
+
+- Gmail was searched before outreach; no prior MarketingBlocks affiliate conversation was found.
+- COSHUMA requested the current zero-cost affiliate application/enrollment route from the official support desk on 2026-09-07.
+- Gmail sent message id: `1a07b7acd4971a99`.
+- The request explicitly says COSHUMA will publish only the exact customer-facing tracking link issued to its account.
+
+## Current status
+
+- Enrollment route requested; the vendor has **not** yet confirmed that new applications are open.
+- Affiliate approval is **not** confirmed.
+- Exact customer-facing affiliate/tracking URL is **not** confirmed.
+- Click, signup, commission, and revenue are **not** confirmed.


### PR DESCRIPTION
Records a zero-cost affiliate enrollment-path request for the currently unclassified MarketingBlocks entry.

The vendor's current official support knowledge base confirms that approved affiliates receive unique affiliate links and tracked commissions, but it does not prove that new applications are currently open. COSHUMA therefore asked the official support desk for the current enrollment route rather than inventing an application submission or tracking URL.

No approval, customer tracking URL, or revenue is claimed.