### PR TITLE
Record Reclaim affiliate outreach and zero-cost guardrails

### DIFF
--- a/projects/GlobalSaaSHub/data/revenue-ops-2026-09-07-1941.md
+++ b/projects/GlobalSaaSHub/data/revenue-ops-2026-09-07-1941.md
@@ -1,0 +1,52 @@
+# Revenue operations evidence — 2026-09-07 19:41 KST
+
+This note records only evidence-backed COSHUMA affiliate/revenue actions. It must not be used to infer approval, a customer tracking URL, a conversion, commission, or revenue unless those are explicitly confirmed below.
+
+## Reclaim.ai
+
+- Current official affiliate documentation checked on 2026-09-07: the affiliate program is free to join, uses PartnerStack, and offers 40% commission on customers using work emails plus $1 per referred work-email signup, 25% on customers using personal emails, with a 90-day cookie.
+- Official sources:
+  - https://help.reclaim.ai/en/articles/8370417-reclaim-ai-affiliate-program
+  - https://partner.reclaim.ai/get-started
+- Gmail duplicate check found no prior Reclaim.ai affiliate/partner/referral thread before outreach.
+- A program-specific enrollment/direct-invitation request was sent to Reclaim's affiliate contact on 2026-09-07. Gmail sent-message id: `1a07b7bdd4145973`.
+- Reason for direct request: COSHUMA already has a PartnerStack account but its Network Marketplace enrollment is currently restricted, so the request asks Reclaim for direct program enrollment or an account-specific invitation instead of treating a generic PartnerStack page as a completed application.
+- Current state: `enrollment_requested`.
+- Customer-facing Reclaim affiliate/tracking URL: none verified yet.
+- Revenue: none claimed.
+
+## Joiin
+
+- Joiin's current official affiliate program remains active and is managed through Reditus: https://www.joiin.co/affiliate-partner-programme/
+- On 2026-09-07, after COSHUMA requested enrollment of its existing business account, Joiin's Chief Commercial Officer supplied an account-specific Reditus affiliate sign-up invitation by email.
+- The exact invitation URL/key is intentionally omitted from this repository because it is an enrollment credential/path, not a customer-facing referral URL.
+- Current state: `enrollment_invite_received_browser_required`.
+- Required next step: use the account-specific Reditus enrollment invitation in an authenticated browser session; if login, OTP, legal consent, or another required interactive step appears, stop only this candidate and preserve it in the browser-required queue.
+- Do not publish the Reditus invitation, marketplace URL, or dashboard URL as a customer referral link.
+- Customer-facing Joiin referral/tracking URL: none verified yet.
+- Revenue: none claimed.
+
+## Pickaxe
+
+- Current official affiliate page checked on 2026-09-07: https://pickaxe.co/affiliate
+- The program advertises a unique affiliate link, 10% customer discount, and 40% of revenue for qualifying Gold/Pro purchases.
+- However, the same official page explicitly states that affiliate earnings only accrue while the affiliate is a paying Pickaxe user; referrals made while the affiliate is not a paying user do not result in payout.
+- COSHUMA's operating rule forbids additional paid subscriptions/payments for affiliate acquisition.
+- Current state for zero-cost automation: `not_no_cost_candidate_paid_subscription_required`.
+- Do not apply automatically or buy a Pickaxe plan to unlock affiliate earnings.
+- Customer-facing Pickaxe tracking URL: none verified for COSHUMA.
+- Revenue: none claimed.
+
+## Pictory conversion support
+
+- A fresh Pictory affiliate-team check-in on 2026-09-07 said recent affiliate-link click volume was low and offered content ideas, swipe copy, banners, demo assets, and content feedback.
+- Previous direct human correspondence established `ashutosh@pictory.ai` as the working contact; replies to the automated FirstPromoter sender had previously bounced.
+- COSHUMA sent a no-cost conversion-support request to `ashutosh@pictory.ai` asking for current high-converting banner/demo assets, proven buyer-guide/comparison swipe-copy angles, and current offer/landing messaging. Gmail sent-message id: `1a07b7c1657bc1bb`.
+- This is conversion optimization support, not evidence of clicks, referrals, customers, commission, or revenue.
+
+## CartStack stale-state guardrail
+
+- CartStack already has a verified COSHUMA referral URL from its referral-program welcome email: `http://www.cartstack.com/?afmc=wb`.
+- The verified URL is already used in the CartStack buyer-intent page and the shared verified-affiliate sync, and affiliate CTA click attribution was added in merged PR #107.
+- Any structured record still showing CartStack as `application_available` / `affiliate_url: null` is stale and must not trigger another CartStack application.
+- Do not re-apply. Preserve the verified customer-facing referral URL unless newer authoritative CartStack evidence supersedes it.


### PR DESCRIPTION
## Summary
- Records a new Reclaim.ai program-specific enrollment/direct-invitation request after confirming the current free PartnerStack affiliate program and no prior COSHUMA Reclaim affiliate thread.
- Records Joiin's account-specific Reditus enrollment invitation as browser-required without exposing the invitation credential or misclassifying it as a customer referral URL.
- Excludes Pickaxe from zero-cost automatic enrollment because its current official terms require the affiliate to be a paying Pickaxe user for earnings to accrue.
- Records a no-cost Pictory conversion-support request sent to the working human affiliate contact.
- Adds a guardrail preventing stale CartStack `application_available` data from triggering a duplicate application; the verified CartStack referral URL is already live and attributed.

## Safety
- No paid subscription or payment action taken.
- No generic dashboard/onboarding/enrollment URL is published as a customer tracking URL.
- No approval, conversion, commission, or revenue is claimed without evidence.