### PR TITLE
fix(revenue): monetize Make.com vs Jotform comparison

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/make-com-vs-jotform.html
+++ b/projects/GlobalSaaSHub/public/compare/make-com-vs-jotform.html
@@ -157,8 +157,8 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Make.com →</a>
-          <a href="https://www.jotform.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Jotform →</a>
+          <a data-cta="affiliate" data-tool-id="make-com" data-cta-source="compare_make_jotform" href="https://www.make.com/?pc=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Make.com →</a>
+          <a data-cta="affiliate" data-tool-id="jotform" data-cta-source="compare_make_jotform" href="https://www.jotform.com/ai/agents/?partner=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Try Jotform AI Agents →</a>
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- Replace the generic Jotform outbound CTA on the Make.com vs Jotform comparison with COSHUMA's confirmed customer-facing Jotform partner URL.
- Add affiliate attribution metadata to both Make.com and Jotform CTAs so click collection can distinguish this comparison source.

## Evidence
- Current deployment workflow explicitly requires `https://www.jotform.com/ai/agents/?partner=coshuma` and rejects the legacy Jotform onboarding redirect.
- Make.com already uses verified COSHUMA partner code `pc=coshuma` across production comparison pages.

## Guardrails
- No pricing, discount, coupon, approval, conversion, or revenue claim added.
- No paid action or account change.
- Only the existing high-intent comparison CTA is monetized.