### PR TITLE
Normalize resolved Omi and Brand24 affiliate state

### DIFF
--- a/projects/GlobalSaaSHub/data/browser_required_queue.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.json
@@ -2,16 +2,18 @@
   {
     "id": "omi-ai-affiliate-referral-link",
     "priority": "high",
-    "status": "browser_required",
+    "status": "resolved",
     "cost": "0",
-    "verified_at": "2026-09-01T23:35:00+09:00",
-    "reason": "Omi AI's approval email verifies that the COSHUMA account is approved for referrals and can earn commissions, but the email supplies only a Get Started link that resolves to affiliate.basedhardware.com and does not expose a customer-facing unique referral URL.",
-    "next_action": "Reuse an already authenticated Omi/Based Hardware affiliate browser session, open the referral or link area, copy the exact customer-facing unique affiliate URL, verify its account-specific tracking identifier and final destination, then update only matching data records and eligible COSHUMA CTAs.",
+    "verified_at": "2026-09-07T06:48:39Z",
+    "reason": "The browser blocker is resolved. The authenticated Omi affiliate dashboard supplied the exact customer-facing referral URL https://www.omi.me/?ref=SANGKWONAN; PR #256 merged it into tool data and eligible CTAs, and production verification confirmed the CTA preserves ref=SANGKWONAN.",
+    "next_action": "None for referral-link recovery. Keep the verified customer-facing Omi URL and exclude this resolved item from browser-required/application automation.",
     "do_not": [
-      "Do not treat the affiliate.basedhardware.com dashboard/onboarding URL or its email tracking redirect as a revenue link.",
-      "Do not guess or construct a referral parameter.",
-      "Do not submit another Omi AI referral application."
-    ]
+      "Do not replace the verified URL with an affiliate dashboard, onboarding URL, email redirect, or generic Omi homepage.",
+      "Do not submit another Omi referral application or reopen this browser blocker without newer contradictory evidence that the verified referral route is invalid.",
+      "Do not infer sales, orders, commissions, clicks, or conversions from approval, publication, HTTP success, or link verification."
+    ],
+    "resolved_at": "2026-09-07T06:48:39Z",
+    "resolution_evidence": "Authenticated dashboard evidence is recorded in omi-referral-evidence-2026-09-07.md. Production https://coshuma.com/tool/omi-ai.html links to https://www.omi.me/?ref=SANGKWONAN and the customer destination responds successfully. Link verification does not imply any sale, order, commission, or conversion."
   },
   {
     "id": "coshuma-youtube-channel-branding",

--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -72,7 +72,10 @@
     "affiliate_status": "program_closed_to_new_applicants",
     "affiliate_source_url": "https://www.notion.com/en-gb/affiliates",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["20% of year one revenue", "currently not accepting new affiliates"]
+    "affiliate_evidence_markers": [
+      "20% of year one revenue",
+      "currently not accepting new affiliates"
+    ]
   },
   {
     "id": "make-com",
@@ -108,7 +111,14 @@
     "affiliate_source_url": "https://www.make.com/en/affiliate",
     "affiliate_final_url": "https://www.make.com/en?pc=coshuma",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["35% commission", "12 months", "Partner code created", "pc=coshuma", "Wise Business Basic account created", "receiving account details not issued"],
+    "affiliate_evidence_markers": [
+      "35% commission",
+      "12 months",
+      "Partner code created",
+      "pc=coshuma",
+      "Wise Business Basic account created",
+      "receiving account details not issued"
+    ],
     "payout_setup_status": "deferred_until_payout_threshold",
     "payout_setup_note": "Do not submit invented Wise bank details. Affiliate earnings may accrue on-platform; before an actual payout, complete Wise Business Advanced activation and identity verification, then register only issued receiving account details.",
     "payout_account_email": "support@coshuma.com",
@@ -151,7 +161,12 @@
     "affiliate_source_url": "https://elevenlabs.io/affiliates",
     "affiliate_final_url": "https://try.elevenlabs.io/ldc2xmh2x2t5",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["22% commission", "12 months", "active affiliate account", "Default affiliate link"]
+    "affiliate_evidence_markers": [
+      "22% commission",
+      "12 months",
+      "active affiliate account",
+      "Default affiliate link"
+    ]
   },
   {
     "id": "copy-ai",
@@ -218,7 +233,10 @@
     "affiliate_source_url": "https://www.zenrows.com/partners/affiliates",
     "affiliate_final_url": "https://www.zenrows.com/partners/apply",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["35% recurring", "approved the same day"]
+    "affiliate_evidence_markers": [
+      "35% recurring",
+      "approved the same day"
+    ]
   },
   {
     "id": "tubebuddy",
@@ -254,7 +272,11 @@
     "affiliate_source_url": "https://support.tubebuddy.com/hc/en-us/sections/8981416080411-Affiliates",
     "affiliate_final_url": "https://www.tubebuddy.com/pricing?a=coshuma",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["successfully set up your Affiliate account", "15% Commission", "Affiliate Link"]
+    "affiliate_evidence_markers": [
+      "successfully set up your Affiliate account",
+      "15% Commission",
+      "Affiliate Link"
+    ]
   },
   {
     "id": "outlierkit",
@@ -290,7 +312,11 @@
     "affiliate_source_url": "https://outlierkit.com/p/affiliate",
     "affiliate_final_url": "https://outlierkit.com/?ref=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["20% on all paid customers", "all set up and ready to go", "partner link"]
+    "affiliate_evidence_markers": [
+      "20% on all paid customers",
+      "all set up and ready to go",
+      "partner link"
+    ]
   },
   {
     "id": "pictory",
@@ -460,7 +486,11 @@
     "affiliate_source_url": "https://writesonic.com/affiliate",
     "affiliate_final_url": "https://affiliates.writesonic.com/home",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["20% recurring", "12 months", "Your application has been rejected"],
+    "affiliate_evidence_markers": [
+      "20% recurring",
+      "12 months",
+      "Your application has been rejected"
+    ],
     "affiliate_rejection_reason": "The authenticated Writesonic affiliate dashboard explicitly shows that the application was rejected."
   },
   {
@@ -498,7 +528,12 @@
     "affiliate_source_url": "https://sudowrite.notion.site/Sudowrite-Affiliate-Program-12788b26b71746f2a72cd05b7087e8c9",
     "affiliate_final_url": "https://www.sudowrite.com?via=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["Welcome to the Sudowrite partner program", "25% on all payments, first 12 months", "60 day cookie", "affiliate link"]
+    "affiliate_evidence_markers": [
+      "Welcome to the Sudowrite partner program",
+      "25% on all payments, first 12 months",
+      "60 day cookie",
+      "affiliate link"
+    ]
   },
   {
     "id": "convertkit",
@@ -541,7 +576,11 @@
     "affiliate_source_url": "https://kit.com/affiliate",
     "affiliate_final_url": "https://dash.partnerstack.com/application?company=kit&group=kitaffiliates",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["50% commission for 12 months", "PartnerStack Network marketplace access limited", "application page rendered blank"]
+    "affiliate_evidence_markers": [
+      "50% commission for 12 months",
+      "PartnerStack Network marketplace access limited",
+      "application page rendered blank"
+    ]
   },
   {
     "id": "quillbot",
@@ -576,7 +615,11 @@
     "affiliate_status": "blocked_partnerstack_marketplace_limited",
     "affiliate_source_url": "https://quillbot.com/affiliates",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["10% - 20% commission", "30-day cookie", "PartnerStack Network marketplace access limited"]
+    "affiliate_evidence_markers": [
+      "10% - 20% commission",
+      "30-day cookie",
+      "PartnerStack Network marketplace access limited"
+    ]
   },
   {
     "id": "text-cortex",
@@ -612,7 +655,10 @@
     "affiliate_source_url": "https://affiliate.textcortex.com/signup",
     "affiliate_final_url": "https://affiliate.textcortex.com/signup",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["campaign has been deactivated by the owner", "affiliate program is no longer active"]
+    "affiliate_evidence_markers": [
+      "campaign has been deactivated by the owner",
+      "affiliate program is no longer active"
+    ]
   },
   {
     "id": "vidiq",
@@ -681,7 +727,11 @@
     "affiliate_source_url": "https://www.bolddesk.com/affiliate-program/signup",
     "affiliate_final_url": "https://www.bolddesk.com/?via=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["30% of active subscription for first year", "password creation required", "payment only via Business PayPal account"]
+    "affiliate_evidence_markers": [
+      "30% of active subscription for first year",
+      "password creation required",
+      "payment only via Business PayPal account"
+    ]
   },
   {
     "id": "brand24",
@@ -689,7 +739,7 @@
     "category": "productivity",
     "category_display": "Productivity & SaaS",
     "description": "An essential social media monitoring tool that helps businesses track mentions, analyze sentiment, and understand their online presence.",
-    "affiliate_url": null,
+    "affiliate_url": "https://try.brand24.com/8xqrjxybmsbt",
     "pricing": "See official pricing",
     "key_features": [
       "Real-time Brand Monitoring",
@@ -713,9 +763,17 @@
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://brand24.com/",
     "affiliate_verified": true,
-    "affiliate_status": "application_submitted",
-    "affiliate_verified_at": "2026-08-31T22:59:47Z",
-    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Brand24 review"]
+    "affiliate_status": "approved_tracking",
+    "affiliate_verified_at": "2026-09-07T06:48:39Z",
+    "affiliate_evidence_markers": [
+      "Merged PR #229 uses the verified customer-facing PartnerStack URL",
+      "Production Brand24 CTAs use https://try.brand24.com/8xqrjxybmsbt",
+      "Live redirect preserves partner-program attribution parameters",
+      "No sale, commission, or conversion is inferred from link verification"
+    ],
+    "affiliate_source_url": "https://try.brand24.com/8xqrjxybmsbt",
+    "affiliate_final_url": "https://brand24.com/?utm_campaign=affiliategroup&utm_medium=partnerprogram",
+    "affiliate_rejection_reason": null
   },
   {
     "id": "socialchamp-io",
@@ -786,7 +844,10 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-08-31T23:01:13Z",
-    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Triple Whale review"]
+    "affiliate_evidence_markers": [
+      "PartnerStack application received",
+      "submitted for Triple Whale review"
+    ]
   },
   {
     "id": "boldsign",
@@ -822,7 +883,10 @@
     "affiliate_source_url": "https://boldsign.com/affiliate-program/signup/",
     "affiliate_final_url": "https://boldsign.com?via=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["30% of active subscription for first year", "password creation required"]
+    "affiliate_evidence_markers": [
+      "30% of active subscription for first year",
+      "password creation required"
+    ]
   },
   {
     "id": "privy",
@@ -919,7 +983,10 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Unbounce review"]
+    "affiliate_evidence_markers": [
+      "PartnerStack application received",
+      "submitted for Unbounce review"
+    ]
   },
   {
     "id": "moosend",
@@ -1080,7 +1147,10 @@
     "affiliate_verified": true,
     "affiliate_status": "rejected",
     "affiliate_verified_at": "2026-09-01T08:45:37Z",
-    "affiliate_evidence_markers": ["Impact email", "Semrush Contract Terms Declined"]
+    "affiliate_evidence_markers": [
+      "Impact email",
+      "Semrush Contract Terms Declined"
+    ]
   },
   {
     "id": "hubspot",
@@ -1144,7 +1214,10 @@
     "affiliate_verified": true,
     "affiliate_status": "rejected",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["Kinsta Affiliate Program application status", "profile is not suitable for the program at this time"]
+    "affiliate_evidence_markers": [
+      "Kinsta Affiliate Program application status",
+      "profile is not suitable for the program at this time"
+    ]
   },
   {
     "id": "shopify",
@@ -1248,7 +1321,11 @@
     "affiliate_status": "approved_account",
     "affiliate_source_url": "https://www.jotform.com/partnership/affiliate/",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["Welcome to the Jotform Affiliate Program", "30% recurring commission", "Partner Dashboard"]
+    "affiliate_evidence_markers": [
+      "Welcome to the Jotform Affiliate Program",
+      "30% recurring commission",
+      "Partner Dashboard"
+    ]
   },
   {
     "id": "webflow",
@@ -1345,7 +1422,11 @@
     "affiliate_source_url": "https://synthesia.getrewardful.com/",
     "affiliate_final_url": "https://www.synthesia.io?via=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["Logged in successfully.", "Joined August 26, 2026", "https://www.synthesia.io?via=sangkwon"]
+    "affiliate_evidence_markers": [
+      "Logged in successfully.",
+      "Joined August 26, 2026",
+      "https://www.synthesia.io?via=sangkwon"
+    ]
   },
   {
     "id": "octo-browser",
@@ -1595,7 +1676,10 @@
     "affiliate_verified": true,
     "affiliate_status": "approved_tracking",
     "affiliate_verified_at": "2026-08-31T22:02:27Z",
-    "affiliate_evidence_markers": ["Vista Social approval email", "unique referral link in email body"]
+    "affiliate_evidence_markers": [
+      "Vista Social approval email",
+      "unique referral link in email body"
+    ]
   },
   {
     "id": "gravity-forms",
@@ -1836,7 +1920,7 @@
     "category": "dev_coding",
     "category_display": "Coding & Dev Tools",
     "description": "Dorik is a no-code AI website builder that enables quick creation of professional websites without any coding knowledge. Build stunning, responsive sites effortlessly, perfect for businesses, portfolios, and personal brands.",
-    "affiliate_url": null,
+    "affiliate_url": "https://dorik.com/?ref=coshuma",
     "pricing": "See official pricing",
     "key_features": [
       "No-code website building",
@@ -1859,7 +1943,6 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://dorik.com/",
-    "affiliate_url": "https://dorik.com/?ref=coshuma",
     "affiliate_verified": true,
     "affiliate_status": "approved_tracking",
     "affiliate_source_url": "https://partners.dorik.com/success-hub",
@@ -2443,7 +2526,10 @@
     "affiliate_verified": true,
     "affiliate_status": "rejected",
     "affiliate_verified_at": "2026-09-01T09:14:55Z",
-    "affiliate_evidence_markers": ["PartnerStack decision email", "GetResponse application declined"]
+    "affiliate_evidence_markers": [
+      "PartnerStack decision email",
+      "GetResponse application declined"
+    ]
   },
   {
     "id": "kit",
@@ -2573,7 +2659,10 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["Impact application received", "application will be reviewed"]
+    "affiliate_evidence_markers": [
+      "Impact application received",
+      "application will be reviewed"
+    ]
   },
   {
     "id": "koala-ai",
@@ -3582,7 +3671,10 @@
     "affiliate_verified": true,
     "affiliate_status": "approved_tracking",
     "affiliate_verified_at": "2026-09-01T10:04:07Z",
-    "affiliate_evidence_markers": ["Text Partner Program dashboard", "Share your default signup link without campaign customization"]
+    "affiliate_evidence_markers": [
+      "Text Partner Program dashboard",
+      "Share your default signup link without campaign customization"
+    ]
   },
   {
     "id": "typedesk",
@@ -3719,7 +3811,10 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for BidX review"]
+    "affiliate_evidence_markers": [
+      "PartnerStack application received",
+      "submitted for BidX review"
+    ]
   },
   {
     "id": "tidio",
@@ -3819,7 +3914,10 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Bookyourdata review"]
+    "affiliate_evidence_markers": [
+      "PartnerStack application received",
+      "submitted for Bookyourdata review"
+    ]
   },
   {
     "id": "mindstudio",
@@ -4227,7 +4325,11 @@
     "affiliate_verified": true,
     "affiliate_status": "application_not_submitted",
     "affiliate_verified_at": "2026-08-31T16:05:00Z",
-    "affiliate_evidence_markers": ["Claap affiliate manager email", "application did not go through", "correct PartnerStack link provided"]
+    "affiliate_evidence_markers": [
+      "Claap affiliate manager email",
+      "application did not go through",
+      "correct PartnerStack link provided"
+    ]
   },
   {
     "id": "cloudtalk",
@@ -4640,7 +4742,10 @@
     "affiliate_status": "referral_link_requested",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
     "affiliate_status_evidence_url": "https://agent-works.ai/contact",
-    "affiliate_evidence_markers": ["Message sent", "Thanks for reaching out. We typically respond within 1 business day."]
+    "affiliate_evidence_markers": [
+      "Message sent",
+      "Thanks for reaching out. We typically respond within 1 business day."
+    ]
   },
   {
     "id": "airia",
@@ -4723,7 +4828,12 @@
     "affiliate_status": "approved_tracking",
     "affiliate_status_checked_at": "2026-09-07T06:16:08Z",
     "affiliate_status_evidence_url": "https://affiliate.omi.me/overview",
-    "affiliate_evidence_markers": ["Email verified", "Welcome back, Sangkwon", "Your Referral Link", "https://www.omi.me/?ref=SANGKWONAN"]
+    "affiliate_evidence_markers": [
+      "Email verified",
+      "Welcome back, Sangkwon",
+      "Your Referral Link",
+      "https://www.omi.me/?ref=SANGKWONAN"
+    ]
   },
   {
     "id": "fireflies-ai",
@@ -4798,7 +4908,10 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Gamma review"]
+    "affiliate_evidence_markers": [
+      "PartnerStack application received",
+      "submitted for Gamma review"
+    ]
   },
   {
     "id": "gobii",
@@ -4836,7 +4949,10 @@
     "affiliate_status": "program_unavailable_company_winding_down",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
     "affiliate_status_evidence_url": "https://gobii.ai/",
-    "affiliate_evidence_markers": ["Gobii is winding down", "final day of operations will be September 1, 2026"]
+    "affiliate_evidence_markers": [
+      "Gobii is winding down",
+      "final day of operations will be September 1, 2026"
+    ]
   },
   {
     "id": "voibe",
@@ -4869,13 +4985,15 @@
     "affiliate_source_url": "https://www.getvoibe.com/",
     "affiliate_final_url": "https://www.getvoibe.com/",
     "affiliate_http_status": 200,
-    "affiliate_evidence_markers": [],
+    "affiliate_evidence_markers": [
+      "Affiliate application has been submitted and is awaiting approval",
+      "This may take up to 48 hours"
+    ],
     "affiliate_verified_at": null,
     "affiliate_rejection_reason": "HTTP 200 but no strong affiliate evidence found. Required at least one compound pattern (e.g. 'affiliate program', 'commission rate', 'cookie duration'). Single-word matches in footer/privacy/blog are not accepted.",
     "affiliate_status": "affiliate_profile_pending",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
     "affiliate_status_evidence_url": "https://affiliates.lemonsqueezy.com/programs/voibe",
-    "affiliate_evidence_markers": ["Affiliate application has been submitted and is awaiting approval", "This may take up to 48 hours"],
     "primary_category": "voice_cloning",
     "comparison_group": "voice_generation",
     "official_verification_status": "verified",

--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -72,10 +72,7 @@
     "affiliate_status": "program_closed_to_new_applicants",
     "affiliate_source_url": "https://www.notion.com/en-gb/affiliates",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "20% of year one revenue",
-      "currently not accepting new affiliates"
-    ]
+    "affiliate_evidence_markers": ["20% of year one revenue", "currently not accepting new affiliates"]
   },
   {
     "id": "make-com",
@@ -111,14 +108,7 @@
     "affiliate_source_url": "https://www.make.com/en/affiliate",
     "affiliate_final_url": "https://www.make.com/en?pc=coshuma",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "35% commission",
-      "12 months",
-      "Partner code created",
-      "pc=coshuma",
-      "Wise Business Basic account created",
-      "receiving account details not issued"
-    ],
+    "affiliate_evidence_markers": ["35% commission", "12 months", "Partner code created", "pc=coshuma", "Wise Business Basic account created", "receiving account details not issued"],
     "payout_setup_status": "deferred_until_payout_threshold",
     "payout_setup_note": "Do not submit invented Wise bank details. Affiliate earnings may accrue on-platform; before an actual payout, complete Wise Business Advanced activation and identity verification, then register only issued receiving account details.",
     "payout_account_email": "support@coshuma.com",
@@ -161,12 +151,7 @@
     "affiliate_source_url": "https://elevenlabs.io/affiliates",
     "affiliate_final_url": "https://try.elevenlabs.io/ldc2xmh2x2t5",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "22% commission",
-      "12 months",
-      "active affiliate account",
-      "Default affiliate link"
-    ]
+    "affiliate_evidence_markers": ["22% commission", "12 months", "active affiliate account", "Default affiliate link"]
   },
   {
     "id": "copy-ai",
@@ -233,10 +218,7 @@
     "affiliate_source_url": "https://www.zenrows.com/partners/affiliates",
     "affiliate_final_url": "https://www.zenrows.com/partners/apply",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "35% recurring",
-      "approved the same day"
-    ]
+    "affiliate_evidence_markers": ["35% recurring", "approved the same day"]
   },
   {
     "id": "tubebuddy",
@@ -272,11 +254,7 @@
     "affiliate_source_url": "https://support.tubebuddy.com/hc/en-us/sections/8981416080411-Affiliates",
     "affiliate_final_url": "https://www.tubebuddy.com/pricing?a=coshuma",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "successfully set up your Affiliate account",
-      "15% Commission",
-      "Affiliate Link"
-    ]
+    "affiliate_evidence_markers": ["successfully set up your Affiliate account", "15% Commission", "Affiliate Link"]
   },
   {
     "id": "outlierkit",
@@ -312,11 +290,7 @@
     "affiliate_source_url": "https://outlierkit.com/p/affiliate",
     "affiliate_final_url": "https://outlierkit.com/?ref=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "20% on all paid customers",
-      "all set up and ready to go",
-      "partner link"
-    ]
+    "affiliate_evidence_markers": ["20% on all paid customers", "all set up and ready to go", "partner link"]
   },
   {
     "id": "pictory",
@@ -486,11 +460,7 @@
     "affiliate_source_url": "https://writesonic.com/affiliate",
     "affiliate_final_url": "https://affiliates.writesonic.com/home",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "20% recurring",
-      "12 months",
-      "Your application has been rejected"
-    ],
+    "affiliate_evidence_markers": ["20% recurring", "12 months", "Your application has been rejected"],
     "affiliate_rejection_reason": "The authenticated Writesonic affiliate dashboard explicitly shows that the application was rejected."
   },
   {
@@ -528,12 +498,7 @@
     "affiliate_source_url": "https://sudowrite.notion.site/Sudowrite-Affiliate-Program-12788b26b71746f2a72cd05b7087e8c9",
     "affiliate_final_url": "https://www.sudowrite.com?via=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "Welcome to the Sudowrite partner program",
-      "25% on all payments, first 12 months",
-      "60 day cookie",
-      "affiliate link"
-    ]
+    "affiliate_evidence_markers": ["Welcome to the Sudowrite partner program", "25% on all payments, first 12 months", "60 day cookie", "affiliate link"]
   },
   {
     "id": "convertkit",
@@ -576,11 +541,7 @@
     "affiliate_source_url": "https://kit.com/affiliate",
     "affiliate_final_url": "https://dash.partnerstack.com/application?company=kit&group=kitaffiliates",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "50% commission for 12 months",
-      "PartnerStack Network marketplace access limited",
-      "application page rendered blank"
-    ]
+    "affiliate_evidence_markers": ["50% commission for 12 months", "PartnerStack Network marketplace access limited", "application page rendered blank"]
   },
   {
     "id": "quillbot",
@@ -615,11 +576,7 @@
     "affiliate_status": "blocked_partnerstack_marketplace_limited",
     "affiliate_source_url": "https://quillbot.com/affiliates",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "10% - 20% commission",
-      "30-day cookie",
-      "PartnerStack Network marketplace access limited"
-    ]
+    "affiliate_evidence_markers": ["10% - 20% commission", "30-day cookie", "PartnerStack Network marketplace access limited"]
   },
   {
     "id": "text-cortex",
@@ -655,10 +612,7 @@
     "affiliate_source_url": "https://affiliate.textcortex.com/signup",
     "affiliate_final_url": "https://affiliate.textcortex.com/signup",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "campaign has been deactivated by the owner",
-      "affiliate program is no longer active"
-    ]
+    "affiliate_evidence_markers": ["campaign has been deactivated by the owner", "affiliate program is no longer active"]
   },
   {
     "id": "vidiq",
@@ -727,11 +681,7 @@
     "affiliate_source_url": "https://www.bolddesk.com/affiliate-program/signup",
     "affiliate_final_url": "https://www.bolddesk.com/?via=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "30% of active subscription for first year",
-      "password creation required",
-      "payment only via Business PayPal account"
-    ]
+    "affiliate_evidence_markers": ["30% of active subscription for first year", "password creation required", "payment only via Business PayPal account"]
   },
   {
     "id": "brand24",
@@ -844,10 +794,7 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-08-31T23:01:13Z",
-    "affiliate_evidence_markers": [
-      "PartnerStack application received",
-      "submitted for Triple Whale review"
-    ]
+    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Triple Whale review"]
   },
   {
     "id": "boldsign",
@@ -883,10 +830,7 @@
     "affiliate_source_url": "https://boldsign.com/affiliate-program/signup/",
     "affiliate_final_url": "https://boldsign.com?via=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "30% of active subscription for first year",
-      "password creation required"
-    ]
+    "affiliate_evidence_markers": ["30% of active subscription for first year", "password creation required"]
   },
   {
     "id": "privy",
@@ -983,10 +927,7 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "PartnerStack application received",
-      "submitted for Unbounce review"
-    ]
+    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Unbounce review"]
   },
   {
     "id": "moosend",
@@ -1147,10 +1088,7 @@
     "affiliate_verified": true,
     "affiliate_status": "rejected",
     "affiliate_verified_at": "2026-09-01T08:45:37Z",
-    "affiliate_evidence_markers": [
-      "Impact email",
-      "Semrush Contract Terms Declined"
-    ]
+    "affiliate_evidence_markers": ["Impact email", "Semrush Contract Terms Declined"]
   },
   {
     "id": "hubspot",
@@ -1214,10 +1152,7 @@
     "affiliate_verified": true,
     "affiliate_status": "rejected",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "Kinsta Affiliate Program application status",
-      "profile is not suitable for the program at this time"
-    ]
+    "affiliate_evidence_markers": ["Kinsta Affiliate Program application status", "profile is not suitable for the program at this time"]
   },
   {
     "id": "shopify",
@@ -1321,11 +1256,7 @@
     "affiliate_status": "approved_account",
     "affiliate_source_url": "https://www.jotform.com/partnership/affiliate/",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "Welcome to the Jotform Affiliate Program",
-      "30% recurring commission",
-      "Partner Dashboard"
-    ]
+    "affiliate_evidence_markers": ["Welcome to the Jotform Affiliate Program", "30% recurring commission", "Partner Dashboard"]
   },
   {
     "id": "webflow",
@@ -1422,11 +1353,7 @@
     "affiliate_source_url": "https://synthesia.getrewardful.com/",
     "affiliate_final_url": "https://www.synthesia.io?via=sangkwon",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "Logged in successfully.",
-      "Joined August 26, 2026",
-      "https://www.synthesia.io?via=sangkwon"
-    ]
+    "affiliate_evidence_markers": ["Logged in successfully.", "Joined August 26, 2026", "https://www.synthesia.io?via=sangkwon"]
   },
   {
     "id": "octo-browser",
@@ -1676,10 +1603,7 @@
     "affiliate_verified": true,
     "affiliate_status": "approved_tracking",
     "affiliate_verified_at": "2026-08-31T22:02:27Z",
-    "affiliate_evidence_markers": [
-      "Vista Social approval email",
-      "unique referral link in email body"
-    ]
+    "affiliate_evidence_markers": ["Vista Social approval email", "unique referral link in email body"]
   },
   {
     "id": "gravity-forms",
@@ -1920,7 +1844,7 @@
     "category": "dev_coding",
     "category_display": "Coding & Dev Tools",
     "description": "Dorik is a no-code AI website builder that enables quick creation of professional websites without any coding knowledge. Build stunning, responsive sites effortlessly, perfect for businesses, portfolios, and personal brands.",
-    "affiliate_url": "https://dorik.com/?ref=coshuma",
+    "affiliate_url": null,
     "pricing": "See official pricing",
     "key_features": [
       "No-code website building",
@@ -1943,6 +1867,7 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://dorik.com/",
+    "affiliate_url": "https://dorik.com/?ref=coshuma",
     "affiliate_verified": true,
     "affiliate_status": "approved_tracking",
     "affiliate_source_url": "https://partners.dorik.com/success-hub",
@@ -2526,10 +2451,7 @@
     "affiliate_verified": true,
     "affiliate_status": "rejected",
     "affiliate_verified_at": "2026-09-01T09:14:55Z",
-    "affiliate_evidence_markers": [
-      "PartnerStack decision email",
-      "GetResponse application declined"
-    ]
+    "affiliate_evidence_markers": ["PartnerStack decision email", "GetResponse application declined"]
   },
   {
     "id": "kit",
@@ -2659,10 +2581,7 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "Impact application received",
-      "application will be reviewed"
-    ]
+    "affiliate_evidence_markers": ["Impact application received", "application will be reviewed"]
   },
   {
     "id": "koala-ai",
@@ -3671,10 +3590,7 @@
     "affiliate_verified": true,
     "affiliate_status": "approved_tracking",
     "affiliate_verified_at": "2026-09-01T10:04:07Z",
-    "affiliate_evidence_markers": [
-      "Text Partner Program dashboard",
-      "Share your default signup link without campaign customization"
-    ]
+    "affiliate_evidence_markers": ["Text Partner Program dashboard", "Share your default signup link without campaign customization"]
   },
   {
     "id": "typedesk",
@@ -3811,10 +3727,7 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "PartnerStack application received",
-      "submitted for BidX review"
-    ]
+    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for BidX review"]
   },
   {
     "id": "tidio",
@@ -3914,10 +3827,7 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "PartnerStack application received",
-      "submitted for Bookyourdata review"
-    ]
+    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Bookyourdata review"]
   },
   {
     "id": "mindstudio",
@@ -4325,11 +4235,7 @@
     "affiliate_verified": true,
     "affiliate_status": "application_not_submitted",
     "affiliate_verified_at": "2026-08-31T16:05:00Z",
-    "affiliate_evidence_markers": [
-      "Claap affiliate manager email",
-      "application did not go through",
-      "correct PartnerStack link provided"
-    ]
+    "affiliate_evidence_markers": ["Claap affiliate manager email", "application did not go through", "correct PartnerStack link provided"]
   },
   {
     "id": "cloudtalk",
@@ -4742,10 +4648,7 @@
     "affiliate_status": "referral_link_requested",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
     "affiliate_status_evidence_url": "https://agent-works.ai/contact",
-    "affiliate_evidence_markers": [
-      "Message sent",
-      "Thanks for reaching out. We typically respond within 1 business day."
-    ]
+    "affiliate_evidence_markers": ["Message sent", "Thanks for reaching out. We typically respond within 1 business day."]
   },
   {
     "id": "airia",
@@ -4828,12 +4731,7 @@
     "affiliate_status": "approved_tracking",
     "affiliate_status_checked_at": "2026-09-07T06:16:08Z",
     "affiliate_status_evidence_url": "https://affiliate.omi.me/overview",
-    "affiliate_evidence_markers": [
-      "Email verified",
-      "Welcome back, Sangkwon",
-      "Your Referral Link",
-      "https://www.omi.me/?ref=SANGKWONAN"
-    ]
+    "affiliate_evidence_markers": ["Email verified", "Welcome back, Sangkwon", "Your Referral Link", "https://www.omi.me/?ref=SANGKWONAN"]
   },
   {
     "id": "fireflies-ai",
@@ -4908,10 +4806,7 @@
     "affiliate_verified": true,
     "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
-    "affiliate_evidence_markers": [
-      "PartnerStack application received",
-      "submitted for Gamma review"
-    ]
+    "affiliate_evidence_markers": ["PartnerStack application received", "submitted for Gamma review"]
   },
   {
     "id": "gobii",
@@ -4949,10 +4844,7 @@
     "affiliate_status": "program_unavailable_company_winding_down",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
     "affiliate_status_evidence_url": "https://gobii.ai/",
-    "affiliate_evidence_markers": [
-      "Gobii is winding down",
-      "final day of operations will be September 1, 2026"
-    ]
+    "affiliate_evidence_markers": ["Gobii is winding down", "final day of operations will be September 1, 2026"]
   },
   {
     "id": "voibe",
@@ -4985,15 +4877,13 @@
     "affiliate_source_url": "https://www.getvoibe.com/",
     "affiliate_final_url": "https://www.getvoibe.com/",
     "affiliate_http_status": 200,
-    "affiliate_evidence_markers": [
-      "Affiliate application has been submitted and is awaiting approval",
-      "This may take up to 48 hours"
-    ],
+    "affiliate_evidence_markers": [],
     "affiliate_verified_at": null,
     "affiliate_rejection_reason": "HTTP 200 but no strong affiliate evidence found. Required at least one compound pattern (e.g. 'affiliate program', 'commission rate', 'cookie duration'). Single-word matches in footer/privacy/blog are not accepted.",
     "affiliate_status": "affiliate_profile_pending",
     "affiliate_status_checked_at": "2026-09-01T00:00:00Z",
     "affiliate_status_evidence_url": "https://affiliates.lemonsqueezy.com/programs/voibe",
+    "affiliate_evidence_markers": ["Affiliate application has been submitted and is awaiting approval", "This may take up to 48 hours"],
     "primary_category": "voice_cloning",
     "comparison_group": "voice_generation",
     "official_verification_status": "verified",

--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -772,7 +772,7 @@
       "No sale, commission, or conversion is inferred from link verification"
     ],
     "affiliate_source_url": "https://try.brand24.com/8xqrjxybmsbt",
-    "affiliate_final_url": "https://brand24.com/?utm_campaign=affiliategroup&utm_medium=partnerprogram",
+    "affiliate_final_url": "https://try.brand24.com/8xqrjxybmsbt",
     "affiliate_rejection_reason": null
   },
   {


### PR DESCRIPTION
## Summary
- mark the stale Omi browser-required queue entry resolved after dashboard and production CTA verification
- normalize Brand24 tool data to `approved_tracking` while preserving the verified customer-facing URL
- add explicit safeguards against reopening resolved work, duplicate applications, or inferring revenue from link verification

## Evidence checked
- Issue #259 and its latest comment: no newer contradictory Omi/Brand24 evidence
- merged PR #256 and `omi-referral-evidence-2026-09-07.md`
- merged PR #229
- live COSHUMA Omi CTA preserves `ref=SANGKWONAN`
- live Brand24 CTA uses `https://try.brand24.com/8xqrjxybmsbt` and redirects with partner-program attribution parameters

## Scope
Only `projects/GlobalSaaSHub/data/tools.json` and `projects/GlobalSaaSHub/data/browser_required_queue.json` are changed. Verified customer-facing URLs remain unchanged. This does not assert any clicks, sales, orders, commissions, or conversions.

Closes the Omi and Brand24 data-consistency items in #259; it does not close the broader issue.