### PR TITLE
Revenue: add verified Pictory alternative to AI Video Cut

### DIFF
--- a/projects/GlobalSaaSHub/scripts/polish_public_copy.py
+++ b/projects/GlobalSaaSHub/scripts/polish_public_copy.py
@@ -82,6 +82,14 @@ TOOL_REVENUE_ALTERNATIVES = {
         "href": "https://www.gohighlevel.com/?fp_ref=sangkwon56",
         "label": "Compare HighLevel →",
     },
+    "ai-video-cut.html": {
+        "headline": "Need a verified video-creation alternative now?",
+        "copy": "AI Video Cut is the short-form clipping tool on this page. If you also need text-to-video creation, captions, stock-media workflows and highlight reels, compare Pictory. COSHUMA's Pictory partner link below is verified; promo code COSHUMA20 is currently confirmed active and should be used alongside the link rather than instead of it.",
+        "tool_id": "pictory",
+        "source": "ai-video-cut-pictory-alternative",
+        "href": "https://pictory.ai?fpr=sangkwon-an23",
+        "label": "Compare Pictory + COSHUMA20 →",
+    },
 }
 
 # These lines are generic claims that can be misleading when applied to every product.


### PR DESCRIPTION
Adds one clearly framed monetized alternative to the currently untracked AI Video Cut tool page. The CTA uses COSHUMA's already verified Pictory customer-facing affiliate URL and displays COSHUMA20 alongside it, while keeping AI Video Cut's own official link distinct. No revenue, conversion, or approval is inferred for AI Video Cut.

Evidence already recorded in the repo/Gmail state: Pictory affiliate manager reconfirmed that the existing tracking link and COSHUMA20 remain active while payout setup is pending.