### PR TITLE
Record verified affiliate links and current application blockers

### DIFF
--- a/projects/GlobalSaaSHub/data/affiliate-browser-results-2026-09-08.json
+++ b/projects/GlobalSaaSHub/data/affiliate-browser-results-2026-09-08.json
@@ -1,0 +1,159 @@
+{
+  "checked_at": "2026-09-07T17:06:13Z",
+  "scope": "COSHUMA requested browser-required affiliate work and remaining affiliate entries from browser_required_queue.json; non-affiliate YouTube tasks excluded.",
+  "metrics_note": "No customer acquisitions, sales, commissions, or revenue are claimed. Verification visits may increment click counters.",
+  "paid_actions": 0,
+  "items": [
+    {
+      "id": "fill",
+      "status": "approved_tracking",
+      "exact_tracking_url": "https://www.fillhq.com/?utm_medium=affiliates&fpr=sangkwon-018d58",
+      "evidence": "Prior verified welcome-email link preserved per user instruction; fresh anonymous HTTP 200 retains exact tracking parameters and renders Fill.",
+      "action": "No signup or reapplication.",
+      "destination": "https://www.fillhq.com/?utm_medium=affiliates&fpr=sangkwon-018d58",
+      "checked_at": "2026-09-07T17:06:13Z"
+    },
+    {
+      "id": "gravity-forms",
+      "status": "application_submitted",
+      "evidence": "Authenticated PartnerStack home displays Gravity / Application pending.",
+      "action": "Read only; no reapplication.",
+      "checked_at": "2026-09-07T17:06:13Z",
+      "exact_tracking_url": null
+    },
+    {
+      "id": "fillout",
+      "status": "browser_required_user_consent",
+      "blocker": "legal_agreement",
+      "evidence": "Existing Dub form has termsAgreement unchecked. Existing fields retained; missing email filled with support@coshuma.com. Page says Step 1 of 2; later steps unverified.",
+      "portal_url": "https://partners.dub.co/fillout/apply",
+      "action": "Form retained; no consent or submission.",
+      "checked_at": "2026-09-07T17:06:13Z",
+      "exact_tracking_url": null
+    },
+    {
+      "id": "kittl",
+      "status": "pending",
+      "program_approved": true,
+      "blocker": "existing_account_credentials_required",
+      "evidence": "Approval email 1a05cb0bb6ebc623 reread. Impact password login reached with support@coshuma.com. Both existing Google accounts route to new Partner Sign Up; neither signup was submitted. No saved password surfaced.",
+      "portal_url": "https://app.impact.com/login.user",
+      "action": "No duplicate account, application, or password reset. Pending means link recovery is unfinished, not approval pending.",
+      "checked_at": "2026-09-07T17:06:13Z",
+      "exact_tracking_url": null
+    },
+    {
+      "id": "helpdesk",
+      "status": "approved_tracking",
+      "exact_tracking_url": "https://www.helpdesk.com/?a=8IetMhQvR&utm_campaign=pp_helpdesk-default&utm_source=PP&d=14",
+      "evidence": "Authenticated active HelpDesk - default campaign 723911 created 2026-08-31. Exact Campaign link copied; customer destination renders HelpDesk. Text email 1a079dd172f5ca22 explicitly confirms campaign-link commissions.",
+      "portal_url": "https://partners.livechat.com/app/affiliate/campaigns/723911/overview",
+      "action": "Reused existing campaign; no new campaign.",
+      "destination": "https://www.helpdesk.com/",
+      "checked_at": "2026-09-07T17:06:13Z"
+    },
+    {
+      "id": "voibe",
+      "platform": "Lemon Squeezy",
+      "status": "approved_tracking",
+      "exact_tracking_url": "https://www.getvoibe.com/?aff=G5Yr5D",
+      "evidence": "Authenticated program initially showed status '-' and Submit affiliate request, with no prior merchant request in either mailbox. Existing repository affiliate_profile_pending was hub-profile status. One free request was submitted; program changed to Active with its exact Affiliate URL. Copied; customer page retains aff=G5Yr5D.",
+      "portal_url": "https://affiliates.lemonsqueezy.com/programs/voibe",
+      "action": "One free merchant request; no paid product signup.",
+      "destination": "https://www.getvoibe.com/?aff=G5Yr5D",
+      "checked_at": "2026-09-07T17:06:13Z"
+    },
+    {
+      "id": "time2book",
+      "status": "approved_tracking",
+      "exact_tracking_url": "https://time2book.me?aff=9TzesqKi",
+      "evidence": "Existing authenticated /affiliates dashboard displays Earn 30% per referral, this exact link and Copy link. No registration. Anonymous request returns 302, sets cookie named aff, then HTTP 200 at official www homepage. Authenticated browser instead routes to /schedule.",
+      "portal_url": "https://time2book.me/affiliates",
+      "destination": "https://www.time2book.me/",
+      "action": "Recovered existing referral link. Cookie name observed; no customer conversion test.",
+      "checked_at": "2026-09-07T17:06:13Z"
+    },
+    {
+      "id": "pipedrive",
+      "status": "pending",
+      "evidence": "Authenticated PartnerStack home displays Pipedrive / Application pending. Prior confirmation email 1a033ebe93e30c46. Support email 1a07c48b9d1d24f8 specifies Quick help > Chat with us. Its guide URL is now 404; homepage leads to Partner Portal password login. Username prepared but password unavailable.",
+      "portal_url": "https://partners.pipedrive.com/login",
+      "action": "No duplicate request. Application state confirmed through PartnerStack; partner chat itself not reached.",
+      "checked_at": "2026-09-07T17:06:13Z",
+      "exact_tracking_url": null
+    },
+    {
+      "id": "monday-com",
+      "status": "pending",
+      "evidence": "Authenticated PartnerStack home displays monday.com / Application pending. Support receipt 1a07c48a31741b90 is ticket #122275, not program approval.",
+      "action": "No duplicate application or ticket.",
+      "checked_at": "2026-09-07T17:06:13Z",
+      "exact_tracking_url": null
+    },
+    {
+      "id": "sendcloud",
+      "status": "application_submitted",
+      "evidence": "Authenticated PartnerStack home displays Sendcloud / Application pending; existing receipt 1a07bc61a476b59e.",
+      "action": "No reapplication.",
+      "checked_at": "2026-09-07T17:06:13Z",
+      "exact_tracking_url": null
+    },
+    {
+      "id": "apollo",
+      "status": "rejected",
+      "evidence": "Gmail 1a03f63c03ab9c05 dated 2026-08-26 declines Apollo.io application, later than receipt 1a033df9edcb2f45. Authenticated PartnerStack with all statuses selected also displays Apollo.io / Application declined.",
+      "action": "No reapplication; Sep 7 outreach is not evidence that rejection was reversed.",
+      "checked_at": "2026-09-07T17:06:13Z",
+      "exact_tracking_url": null
+    },
+    {
+      "id": "ai-video-cut",
+      "status": "pending",
+      "blocker": "required_business_address_and_account_setup",
+      "evidence": "Old /affiliate URL is 404; footer links to current /affiliate-program, which links to aivideocut.firstpromoter.com. Form has required Address and Password. Known name, email, country South Korea, website, company and promotion plan filled. No address invented; user asked for address. No submission, no legal agreement accepted.",
+      "portal_url": "https://aivideocut.firstpromoter.com/",
+      "action": "Prepared form preserved; outreach 1a07c4bd28897ce1 remains distinct from application.",
+      "checked_at": "2026-09-07T17:06:13Z",
+      "exact_tracking_url": null
+    },
+    {
+      "id": "taskip",
+      "status": "browser_required_user_consent",
+      "blocker": "otp",
+      "evidence": "Official affiliate page links to taskip.affonso.io. Existing-account login with support@coshuma.com reached 이메일 인증 / 일회용 코드. One code requested; no code read or entered and no repeat request.",
+      "portal_url": "https://taskip.affonso.io/auth",
+      "action": "OTP page preserved; no account/application completion claimed.",
+      "checked_at": "2026-09-07T17:06:13Z",
+      "exact_tracking_url": null
+    },
+    {
+      "id": "gumloop",
+      "status": "pending",
+      "blocker": "prior_submission_record_requires_vendor_reconciliation",
+      "evidence": "Remote main tools.json already records application_submitted dated 2026-09-01; later outreach 1a07c91048a2779e exists. Current official page opens the Airtable Creator Program form, which provides no prior-submission lookup. Neither mailbox contains a new acceptance/referral link. Blank form cannot prove no prior submission.",
+      "portal_url": "https://airtable.com/app6qESMAH3D9CHLH/pagmpSXRNAh8PpmqF/form",
+      "action": "No resubmission due to existing application record; no approval claimed.",
+      "checked_at": "2026-09-07T17:06:13Z",
+      "exact_tracking_url": null
+    },
+    {
+      "id": "beefree",
+      "status": "application_submitted",
+      "evidence": "Existing-account PartnerStack all-status search for RGE returned No data to display; both mailboxes had outreach but no prior program receipt. Official B2B/B2C directory route opened application as existing Sangkwon An / COSHUMA account. Filled truthful non-consent fields, selected Korea, Republic of, submitted once. Dashboard now shows Really Good Emails (RGE Studio) / Application pending. Fresh receipt 1a07cd33372b8a88 at 2026-09-07T17:03:30Z.",
+      "portal_url": "https://dash.partnerstack.com/home",
+      "action": "One free application; no legal checkbox, payment, or subscription.",
+      "checked_at": "2026-09-07T17:06:13Z",
+      "exact_tracking_url": null
+    },
+    {
+      "id": "clickfunnels",
+      "status": "browser_required_user_consent",
+      "blocker": "otp_then_affiliate_agreement",
+      "evidence": "Confirmation email 1a03b554562a0d88 explicitly requires Affiliate Agreement before Campaign links. Existing portal URL redirects to sign-in. Email login requested once and reached numeric-code page for support@coshuma.com.",
+      "portal_url": "https://www.clickfunnels.com/contacts/token_waiting",
+      "action": "OTP page preserved; no OTP entered, agreement accepted, or duplicate registration.",
+      "checked_at": "2026-09-07T17:06:13Z",
+      "exact_tracking_url": null
+    }
+  ]
+}

--- a/projects/GlobalSaaSHub/data/affiliate-browser-results-2026-09-08.md
+++ b/projects/GlobalSaaSHub/data/affiliate-browser-results-2026-09-08.md
@@ -1,0 +1,56 @@
+# COSHUMA 제휴 브라우저 처리 결과 — 2026-09-08
+
+확인 시각: 2026-09-07T17:06:13Z (한국시간 9월 8일). 기존 Chrome 인증 세션과 탭을 재사용했다. PartnerStack 로그인 과정에서 서비스가 연 Google 인증 팝업 1개 외에 새 작업 탭·브라우저를 만들지 않았다. 신규 유료 결제·구독은 없다.
+
+## 항목별 결과
+
+| 항목 | 상태 | 확인 결과 |
+|---|---|---|
+| Fill | `approved_tracking` | Prior verified welcome-email link preserved per user instruction; fresh anonymous HTTP 200 retains exact tracking parameters and renders Fill. |
+| Gravity Forms | `application_submitted` | Authenticated PartnerStack home displays Gravity / Application pending. |
+| Fillout | `browser_required_user_consent` | Existing Dub form has termsAgreement unchecked. Existing fields retained; missing email filled with support@coshuma.com. Page says Step 1 of 2; later steps unverified. |
+| Kittl | `pending` | Approval email 1a05cb0bb6ebc623 reread. Impact password login reached with support@coshuma.com. Both existing Google accounts route to new Partner Sign Up; neither signup was submitted. No saved password surfaced. |
+| HelpDesk / Text | `approved_tracking` | Authenticated active HelpDesk - default campaign 723911 created 2026-08-31. Exact Campaign link copied; customer destination renders HelpDesk. Text email 1a079dd172f5ca22 explicitly confirms campaign-link commissions. |
+| Voibe / Lemon Squeezy | `approved_tracking` | Authenticated program initially showed status '-' and Submit affiliate request, with no prior merchant request in either mailbox. Existing repository affiliate_profile_pending was hub-profile status. One free request was submitted; program changed to Active with its exact Affiliate URL. Copied; customer page retains aff=G5Yr5D. |
+| Time2book | `approved_tracking` | Existing authenticated /affiliates dashboard displays Earn 30% per referral, this exact link and Copy link. No registration. Anonymous request returns 302, sets cookie named aff, then HTTP 200 at official www homepage. Authenticated browser instead routes to /schedule. |
+| Pipedrive | `pending` | Authenticated PartnerStack home displays Pipedrive / Application pending. Prior confirmation email 1a033ebe93e30c46. Support email 1a07c48b9d1d24f8 specifies Quick help > Chat with us. Its guide URL is now 404; homepage leads to Partner Portal password login. Username prepared but password unavailable. |
+| monday.com | `pending` | Authenticated PartnerStack home displays monday.com / Application pending. Support receipt 1a07c48a31741b90 is ticket #122275, not program approval. |
+| Sendcloud | `application_submitted` | Authenticated PartnerStack home displays Sendcloud / Application pending; existing receipt 1a07bc61a476b59e. |
+| Apollo | `rejected` | Gmail 1a03f63c03ab9c05 dated 2026-08-26 declines Apollo.io application, later than receipt 1a033df9edcb2f45. Authenticated PartnerStack with all statuses selected also displays Apollo.io / Application declined. |
+| AI Video Cut | `pending` | Old /affiliate URL is 404; footer links to current /affiliate-program, which links to aivideocut.firstpromoter.com. Form has required Address and Password. Known name, email, country South Korea, website, company and promotion plan filled. No address invented; user asked for address. No submission, no legal agreement accepted. |
+| Taskip | `browser_required_user_consent` | Official affiliate page links to taskip.affonso.io. Existing-account login with support@coshuma.com reached 이메일 인증 / 일회용 코드. One code requested; no code read or entered and no repeat request. |
+| Gumloop | `pending` | Remote main tools.json already records application_submitted dated 2026-09-01; later outreach 1a07c91048a2779e exists. Current official page opens the Airtable Creator Program form, which provides no prior-submission lookup. Neither mailbox contains a new acceptance/referral link. Blank form cannot prove no prior submission. |
+| Beefree / RGE Studio | `application_submitted` | Existing-account PartnerStack all-status search for RGE returned No data to display; both mailboxes had outreach but no prior program receipt. Official B2B/B2C directory route opened application as existing Sangkwon An / COSHUMA account. Filled truthful non-consent fields, selected Korea, Republic of, submitted once. Dashboard now shows Really Good Emails (RGE Studio) / Application pending. Fresh receipt 1a07cd33372b8a88 at 2026-09-07T17:03:30Z. |
+| ClickFunnels | `browser_required_user_consent` | Confirmation email 1a03b554562a0d88 explicitly requires Affiliate Agreement before Campaign links. Existing portal URL redirects to sign-in. Email login requested once and reached numeric-code page for support@coshuma.com. |
+
+## 검증된 고객용 링크
+
+- **Fill**: `https://www.fillhq.com/?utm_medium=affiliates&fpr=sangkwon-018d58`
+  - 목적지: https://www.fillhq.com/?utm_medium=affiliates&fpr=sangkwon-018d58
+- **HelpDesk / Text**: `https://www.helpdesk.com/?a=8IetMhQvR&utm_campaign=pp_helpdesk-default&utm_source=PP&d=14`
+  - 목적지: https://www.helpdesk.com/
+- **Voibe / Lemon Squeezy**: `https://www.getvoibe.com/?aff=G5Yr5D`
+  - 목적지: https://www.getvoibe.com/?aff=G5Yr5D
+- **Time2book**: `https://time2book.me?aff=9TzesqKi`
+  - 목적지: https://www.time2book.me/
+
+## 남은 사용자 입력 및 외부 응답
+
+- **Fillout:** 프로그램 약관 체크만 사용자에게 남김. 일반 필드는 보존/보완 완료. 화면은 Step 1 of 2이므로 동의 후 추가 단계가 없는 것으로 단정하지 않음.
+- **Taskip·ClickFunnels:** 일회용 코드 입력 화면을 보존. ClickFunnels는 인증 후 Affiliate Agreement 동의가 별도로 필요함.
+- **Kittl:** 기존 Impact 비밀번호가 필요함. 두 기존 Google 계정 모두 신규 가입으로 연결되어 가입하지 않고 기존 로그인으로 돌아옴. Kittl 승인은 확인됐고 링크 회수만 미완료.
+- **AI Video Cut:** 필수 사업장 주소와 계정 설정이 남음. 알려진 일반 필드는 작성했으나 제출하지 않음.
+- **Gumloop:** 기존 application_submitted 기록과 최근 문의가 있어 재신청하지 않음. 신규 승인/링크는 확인되지 않음. 공개 신청 양식에는 이전 제출 조회 기능이 없음.
+- **Pipedrive:** PartnerStack에서 신청 대기를 확인했음. 요청한 Quick help > Chat with us 경로는 별도 Partner Portal 비밀번호 로그인에 막혀 도달하지 못함.
+
+## 증거와 해석
+
+- HelpDesk: 인증된 ACTIVE 캠페인 `723911`, 생성일 2026-08-31. Text 지원 메일 `1a079dd172f5ca22`에서 Campaign 링크 커미션 귀속 확인.
+- Voibe: 요청 제출 전 상태 `-` → 한 번 제출 후 `Active` 및 전용 Affiliate URL 표시. 프로필 승인과 merchant 승인을 구분함.
+- Time2book: 별도 가입 없이 인증된 Refer & earn 화면에서 링크 회수. 비로그인 HTTP 요청은 `aff` 쿠키를 설정하고 공식 www 홈페이지로 302 → 200 이동함. 실제 고객 전환 시험은 하지 않음.
+- Beefree: 새 접수 메일 `1a07cd33372b8a88`, 2026-09-07T17:03:30Z, 대시보드 Application pending.
+- Apollo: 8월 26일 거절 메일 `1a03f63c03ab9c05` 및 현재 대시보드 Application declined. 이후 문의 발송은 거절 해소 증거가 아님.
+- monday.com: 현재 대시보드 Application pending; 지원 티켓 #122275는 접수 대기이며 승인 아님.
+- HelpDesk 검증 전 화면에는 clicks 1 / trials 0 / sales 0 / earnings $0.00가 표시됨. 해당 클릭이 실제 고객인지 확인되지 않았으며 검증 방문도 클릭에 포함될 수 있음. 클릭·가입·커미션·매출 발생을 주장하지 않음.
+
+저장소 반영 범위는 제휴 큐와 실행 증거이다. 이 결과만으로 사이트 CTA 활성화·배포를 완료했다고 주장하지 않는다.

--- a/projects/GlobalSaaSHub/data/browser_required_queue.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.json
@@ -48,31 +48,40 @@
   {
     "id": "kittl-impact-approved-referral-link",
     "priority": "high",
-    "status": "browser_required",
+    "status": "pending",
     "cost": "0",
-    "verified_at": "2026-09-02T00:47:00+09:00",
-    "reason": "Kittl's Impact email explicitly welcomes COSHUMA to the Kittl Affiliate Program, while the repository still records Kittl as application_submitted with affiliate_url=null. The approval email provides brand/support resources but does not expose an account-specific customer referral URL, so no revenue URL can be safely published yet.",
-    "next_action": "Reuse an already authenticated Impact browser session, open the Kittl campaign/link-creation area, obtain the exact customer-facing tracking URL, verify its account-specific tracking identifier and destination, then update Kittl's affiliate status/data and eligible COSHUMA CTAs. Use Kittl's provided brand guidelines when preparing conversion content after the tracking URL is verified.",
+    "verified_at": "2026-09-07T17:06:13Z",
+    "reason": "Approval email 1a05cb0bb6ebc623 reread. Impact password login reached with support@coshuma.com. Both existing Google accounts route to new Partner Sign Up; neither signup was submitted. No saved password surfaced.",
+    "next_action": "No duplicate account, application, or password reset. Pending means link recovery is unfinished, not approval pending.",
     "do_not": [
       "Do not treat the Impact email redirect, notification-settings URL, Help Center or brand-guidelines URL as an affiliate/revenue link.",
       "Do not guess or construct an Impact tracking URL or campaign parameter.",
       "Do not submit another Kittl affiliate application because approval is already evidenced by the welcome email."
-    ]
+    ],
+    "affiliate_status": "pending",
+    "exact_tracking_url": null,
+    "execution_evidence": "affiliate-browser-results-2026-09-08.json",
+    "blocker": "existing_account_credentials_required"
   },
   {
     "id": "lemon-squeezy-hub-approved-program-links",
     "priority": "high",
-    "status": "browser_required",
+    "status": "approved_tracking",
     "cost": "0",
-    "verified_at": "2026-09-03T14:04:48+09:00",
-    "reason": "Lemon Squeezy sent two fresh emails confirming that COSHUMA's affiliate account/profile is approved and that the account can now join affiliate programs and start earning referrals. The approval emails do not provide a customer-facing account-specific referral URL for any individual merchant/program, so no Lemon Squeezy dashboard or onboarding link can safely be published as a revenue CTA.",
-    "next_action": "Reuse an already authenticated Lemon Squeezy affiliate browser session. First verify the current status of the existing Voibe program entry, then inspect eligible affiliate programs, join only suitable free programs that are not already pending/approved/rejected/closed, and for each approved program copy the exact customer-facing referral URL from the hub. Verify the merchant, tracking identifier and destination before updating COSHUMA data or production CTAs.",
+    "verified_at": "2026-09-07T17:06:13Z",
+    "reason": "Authenticated program initially showed status '-' and Submit affiliate request, with no prior merchant request in either mailbox. Existing repository affiliate_profile_pending was hub-profile status. One free request was submitted; program changed to Active with its exact Affiliate URL. Copied; customer page retains aff=G5Yr5D.",
+    "next_action": "Link recovered. Do not reapply. Use the exact customer URL from the execution evidence when updating eligible site CTAs.",
     "do_not": [
       "Do not treat the Lemon Squeezy affiliate hub, dashboard, onboarding, help or email-tracking redirect as an affiliate/revenue link.",
       "Do not infer that Lemon Squeezy profile approval automatically means the existing Voibe program is approved.",
       "Do not guess or construct a referral parameter or merchant link.",
       "Do not reapply to programs already pending, approved, rejected, cooling down or closed."
-    ]
+    ],
+    "affiliate_status": "approved_tracking",
+    "exact_tracking_url": "https://www.getvoibe.com/?aff=G5Yr5D",
+    "execution_evidence": "affiliate-browser-results-2026-09-08.json",
+    "resolved_at": "2026-09-07T17:06:13Z",
+    "resolution_evidence": "Authenticated program initially showed status '-' and Submit affiliate request, with no prior merchant request in either mailbox. Existing repository affiliate_profile_pending was hub-profile status. One free request was submitted; program changed to Active with its exact Affiliate URL. Copied; customer page retains aff=G5Yr5D."
   },
   {
     "id": "chatbase-dub-approved-referral-link",
@@ -95,32 +104,41 @@
     "priority": "high",
     "status": "browser_required_user_consent",
     "cost": "0",
-    "verified_at": "2026-09-04T13:38:42+09:00",
-    "reason": "ClickFunnels' affiliate confirmation email states that the COSHUMA account has joined the ClickFunnels Affiliate Program, but promotion links are only exposed in the Affiliate Center after the Affiliate Agreement is read and accepted. The repository still has affiliate_url=null for ClickFunnels, so publishing any generic ClickFunnels URL as a revenue link would be unsafe.",
-    "next_action": "When the user is available, reuse the authenticated ClickFunnels Affiliate Portal session and have the user personally review and accept the Affiliate Agreement. After acceptance, open the Campaigns tab, copy the exact customer-facing campaign/referral URL, verify its tracking identifier and destination, then update ClickFunnels affiliate data and eligible COSHUMA detail/comparison CTAs.",
+    "verified_at": "2026-09-07T17:06:13Z",
+    "reason": "Confirmation email 1a03b554562a0d88 explicitly requires Affiliate Agreement before Campaign links. Existing portal URL redirects to sign-in. Email login requested once and reached numeric-code page for support@coshuma.com.",
+    "next_action": "OTP page preserved; no OTP entered, agreement accepted, or duplicate registration.",
     "do_not": [
       "Do not accept the ClickFunnels Affiliate Agreement on the user's behalf.",
       "Do not treat the Affiliate Portal, Campaigns dashboard, email-tracking redirect or generic clickfunnels.com homepage as an affiliate/revenue link.",
       "Do not guess or construct a ClickFunnels referral or campaign URL.",
       "Do not submit another ClickFunnels affiliate application because the confirmation email already verifies program enrollment."
-    ]
+    ],
+    "affiliate_status": "browser_required_user_consent",
+    "exact_tracking_url": null,
+    "execution_evidence": "affiliate-browser-results-2026-09-08.json",
+    "blocker": "otp_then_affiliate_agreement"
   },
   {
     "id": "text-helpdesk-campaign-affiliate-link",
     "priority": "high",
-    "status": "browser_required",
+    "status": "approved_tracking",
     "cost": "0",
-    "verified_at": "2026-09-07T12:15:27+09:00",
+    "verified_at": "2026-09-07T17:06:13Z",
     "gmail_thread_id": "1a056c2fa4964d52",
     "gmail_message_id": "1a079dd172f5ca22",
-    "reason": "Text Support has now explicitly confirmed that Campaign affiliate links created in the authenticated Partner App are commission-bearing customer links, and that COSHUMA may create a HelpDesk-specific Campaign instead of using a generic URL. The exact generated HelpDesk customer-facing campaign URL has not yet been verified, so HelpDesk must remain non-monetized until that link is recovered.",
-    "next_action": "Reuse an already authenticated Text Partner App browser session and open https://partners.livechat.com/app/affiliate/campaigns. Prefer an existing active HelpDesk-specific campaign if one already exists; otherwise create a zero-cost HelpDesk-specific Campaign. Copy the exact generated customer-facing affiliate URL, verify that it routes to the intended HelpDesk signup/product destination and contains the account/campaign tracking assigned by Text, then update HelpDesk affiliate data and eligible COSHUMA HelpDesk CTAs.",
+    "reason": "Authenticated active HelpDesk - default campaign 723911 created 2026-08-31. Exact Campaign link copied; customer destination renders HelpDesk. Text email 1a079dd172f5ca22 explicitly confirms campaign-link commissions.",
+    "next_action": "Link recovered. Do not reapply. Use the exact customer URL from the execution evidence when updating eligible site CTAs.",
     "do_not": [
       "Do not treat https://partners.livechat.com/app/affiliate or /affiliate/campaigns as a revenue link; those are authenticated Partner App/dashboard locations.",
       "Do not treat a generic helpdesk.com URL, Customer Portal URL, email tracking redirect, or https://share.text.com/CkwfynGH as the HelpDesk affiliate link unless the authenticated Campaign UI itself verifies it as the generated customer-facing campaign URL.",
       "Do not guess or construct tracking parameters.",
       "Do not submit another Text/HelpDesk affiliate application because the account is already enrolled."
-    ]
+    ],
+    "affiliate_status": "approved_tracking",
+    "exact_tracking_url": "https://www.helpdesk.com/?a=8IetMhQvR&utm_campaign=pp_helpdesk-default&utm_source=PP&d=14",
+    "execution_evidence": "affiliate-browser-results-2026-09-08.json",
+    "resolved_at": "2026-09-07T17:06:13Z",
+    "resolution_evidence": "Authenticated active HelpDesk - default campaign 723911 created 2026-08-31. Exact Campaign link copied; customer destination renders HelpDesk. Text email 1a079dd172f5ca22 explicitly confirms campaign-link commissions."
   },
   {
     "id": "coshuma-short-render-boldsign",
@@ -142,5 +160,141 @@
     "coshuma_url": "https://coshuma.com/tool/boldsign.html?utm_source=youtube&utm_medium=shorts&utm_campaign=boldsign",
     "affiliate_target": "boldsign",
     "campaign_slug": "boldsign"
+  },
+  {
+    "id": "fill-browser-followup-20260908",
+    "priority": "high",
+    "status": "approved_tracking",
+    "cost": "0",
+    "verified_at": "2026-09-07T17:06:13Z",
+    "reason": "Prior verified welcome-email link preserved per user instruction; fresh anonymous HTTP 200 retains exact tracking parameters and renders Fill.",
+    "next_action": "No reapplication. Preserve this exact customer referral URL.",
+    "exact_tracking_url": "https://www.fillhq.com/?utm_medium=affiliates&fpr=sangkwon-018d58",
+    "execution_evidence": "affiliate-browser-results-2026-09-08.json"
+  },
+  {
+    "id": "gravity-forms-browser-followup-20260908",
+    "priority": "medium",
+    "status": "application_submitted",
+    "cost": "0",
+    "verified_at": "2026-09-07T17:06:13Z",
+    "reason": "Authenticated PartnerStack home displays Gravity / Application pending.",
+    "next_action": "Read only; no reapplication.",
+    "exact_tracking_url": null,
+    "execution_evidence": "affiliate-browser-results-2026-09-08.json"
+  },
+  {
+    "id": "fillout-browser-followup-20260908",
+    "priority": "medium",
+    "status": "browser_required_user_consent",
+    "cost": "0",
+    "verified_at": "2026-09-07T17:06:13Z",
+    "reason": "Existing Dub form has termsAgreement unchecked. Existing fields retained; missing email filled with support@coshuma.com. Page says Step 1 of 2; later steps unverified.",
+    "next_action": "Form retained; no consent or submission.",
+    "exact_tracking_url": null,
+    "blocker": "legal_agreement",
+    "execution_evidence": "affiliate-browser-results-2026-09-08.json"
+  },
+  {
+    "id": "time2book-browser-followup-20260908",
+    "priority": "high",
+    "status": "approved_tracking",
+    "cost": "0",
+    "verified_at": "2026-09-07T17:06:13Z",
+    "reason": "Existing authenticated /affiliates dashboard displays Earn 30% per referral, this exact link and Copy link. No registration. Anonymous request returns 302, sets cookie named aff, then HTTP 200 at official www homepage. Authenticated browser instead routes to /schedule.",
+    "next_action": "No reapplication. Preserve this exact customer referral URL.",
+    "exact_tracking_url": "https://time2book.me?aff=9TzesqKi",
+    "execution_evidence": "affiliate-browser-results-2026-09-08.json"
+  },
+  {
+    "id": "pipedrive-browser-followup-20260908",
+    "priority": "medium",
+    "status": "pending",
+    "cost": "0",
+    "verified_at": "2026-09-07T17:06:13Z",
+    "reason": "Authenticated PartnerStack home displays Pipedrive / Application pending. Prior confirmation email 1a033ebe93e30c46. Support email 1a07c48b9d1d24f8 specifies Quick help > Chat with us. Its guide URL is now 404; homepage leads to Partner Portal password login. Username prepared but password unavailable.",
+    "next_action": "No duplicate request. Application state confirmed through PartnerStack; partner chat itself not reached.",
+    "exact_tracking_url": null,
+    "execution_evidence": "affiliate-browser-results-2026-09-08.json"
+  },
+  {
+    "id": "monday-com-browser-followup-20260908",
+    "priority": "medium",
+    "status": "pending",
+    "cost": "0",
+    "verified_at": "2026-09-07T17:06:13Z",
+    "reason": "Authenticated PartnerStack home displays monday.com / Application pending. Support receipt 1a07c48a31741b90 is ticket #122275, not program approval.",
+    "next_action": "No duplicate application or ticket.",
+    "exact_tracking_url": null,
+    "execution_evidence": "affiliate-browser-results-2026-09-08.json"
+  },
+  {
+    "id": "sendcloud-browser-followup-20260908",
+    "priority": "medium",
+    "status": "application_submitted",
+    "cost": "0",
+    "verified_at": "2026-09-07T17:06:13Z",
+    "reason": "Authenticated PartnerStack home displays Sendcloud / Application pending; existing receipt 1a07bc61a476b59e.",
+    "next_action": "No reapplication.",
+    "exact_tracking_url": null,
+    "execution_evidence": "affiliate-browser-results-2026-09-08.json"
+  },
+  {
+    "id": "apollo-browser-followup-20260908",
+    "priority": "medium",
+    "status": "rejected",
+    "cost": "0",
+    "verified_at": "2026-09-07T17:06:13Z",
+    "reason": "Gmail 1a03f63c03ab9c05 dated 2026-08-26 declines Apollo.io application, later than receipt 1a033df9edcb2f45. Authenticated PartnerStack with all statuses selected also displays Apollo.io / Application declined.",
+    "next_action": "No reapplication; Sep 7 outreach is not evidence that rejection was reversed.",
+    "exact_tracking_url": null,
+    "execution_evidence": "affiliate-browser-results-2026-09-08.json"
+  },
+  {
+    "id": "ai-video-cut-browser-followup-20260908",
+    "priority": "medium",
+    "status": "pending",
+    "cost": "0",
+    "verified_at": "2026-09-07T17:06:13Z",
+    "reason": "Old /affiliate URL is 404; footer links to current /affiliate-program, which links to aivideocut.firstpromoter.com. Form has required Address and Password. Known name, email, country South Korea, website, company and promotion plan filled. No address invented; user asked for address. No submission, no legal agreement accepted.",
+    "next_action": "Prepared form preserved; outreach 1a07c4bd28897ce1 remains distinct from application.",
+    "exact_tracking_url": null,
+    "blocker": "required_business_address_and_account_setup",
+    "execution_evidence": "affiliate-browser-results-2026-09-08.json"
+  },
+  {
+    "id": "taskip-browser-followup-20260908",
+    "priority": "medium",
+    "status": "browser_required_user_consent",
+    "cost": "0",
+    "verified_at": "2026-09-07T17:06:13Z",
+    "reason": "Official affiliate page links to taskip.affonso.io. Existing-account login with support@coshuma.com reached 이메일 인증 / 일회용 코드. One code requested; no code read or entered and no repeat request.",
+    "next_action": "OTP page preserved; no account/application completion claimed.",
+    "exact_tracking_url": null,
+    "blocker": "otp",
+    "execution_evidence": "affiliate-browser-results-2026-09-08.json"
+  },
+  {
+    "id": "gumloop-browser-followup-20260908",
+    "priority": "medium",
+    "status": "pending",
+    "cost": "0",
+    "verified_at": "2026-09-07T17:06:13Z",
+    "reason": "Remote main tools.json already records application_submitted dated 2026-09-01; later outreach 1a07c91048a2779e exists. Current official page opens the Airtable Creator Program form, which provides no prior-submission lookup. Neither mailbox contains a new acceptance/referral link. Blank form cannot prove no prior submission.",
+    "next_action": "No resubmission due to existing application record; no approval claimed.",
+    "exact_tracking_url": null,
+    "blocker": "prior_submission_record_requires_vendor_reconciliation",
+    "execution_evidence": "affiliate-browser-results-2026-09-08.json"
+  },
+  {
+    "id": "beefree-browser-followup-20260908",
+    "priority": "medium",
+    "status": "application_submitted",
+    "cost": "0",
+    "verified_at": "2026-09-07T17:06:13Z",
+    "reason": "Existing-account PartnerStack all-status search for RGE returned No data to display; both mailboxes had outreach but no prior program receipt. Official B2B/B2C directory route opened application as existing Sangkwon An / COSHUMA account. Filled truthful non-consent fields, selected Korea, Republic of, submitted once. Dashboard now shows Really Good Emails (RGE Studio) / Application pending. Fresh receipt 1a07cd33372b8a88 at 2026-09-07T17:03:30Z.",
+    "next_action": "One free application; no legal checkbox, payment, or subscription.",
+    "exact_tracking_url": null,
+    "execution_evidence": "affiliate-browser-results-2026-09-08.json"
   }
 ]


### PR DESCRIPTION
The browser queue still requested HelpDesk and Voibe link recovery and lacked current application evidence. Record exact customer links for HelpDesk, Voibe and Time2book, preserve Fill, record the newly submitted Beefree/RGE Studio application, and prevent reapplication to pending or rejected programs.

The evidence covers 16 requested affiliate items, including live PartnerStack pending states, Apollo rejection, and explicit OTP, legal-consent, credential and required-address blockers. Only queue/evidence files change; no site CTA activation or revenue is claimed.

Validation: authenticated browser pages and matching vendor emails; exact customer destinations checked; JSON parsed with allowed statuses, unique IDs and required approved-tracking URLs (16 items, 4 links, 0 paid actions).