### PR TITLE
Fix Tagshop search metadata and prevent sitemap omissions

### DIFF
--- a/.github/workflows/coshuma-site-deploy.yml
+++ b/.github/workflows/coshuma-site-deploy.yml
@@ -20,6 +20,8 @@ on:
       - 'projects/GlobalSaaSHub/scripts/build_search_comparisons.mjs'
       - 'projects/GlobalSaaSHub/scripts/polish_public_copy.py'
       - 'projects/GlobalSaaSHub/scripts/ensure_best_pages_in_sitemap.py'
+      - 'projects/GlobalSaaSHub/scripts/sync_revenue_seo.py'
+      - 'projects/GlobalSaaSHub/scripts/tests/test_revenue_seo.py'
       - 'projects/GlobalSaaSHub/scripts/inject_pictory_partner_offer.py'
       - 'projects/GlobalSaaSHub/scripts/inject_jotform_partner_offer.py'
       - 'projects/GlobalSaaSHub/scripts/publish_affiliate_audit.mjs'
@@ -125,6 +127,7 @@ jobs:
       - name: Verify approved tracking state and built CTAs
         working-directory: projects/GlobalSaaSHub
         run: |
+          python scripts/tests/test_revenue_seo.py dist
           node scripts/verify_approved_tracking.mjs
           node scripts/tests/browser-followup.test.mjs
           node scripts/tests/tagshop-consent.test.mjs

--- a/projects/GlobalSaaSHub/package.json
+++ b/projects/GlobalSaaSHub/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node scripts/build_search_comparisons.mjs && node scripts/monetize_verified_compare_links.mjs && node scripts/inject_buyer_decision_boxes.mjs && vite build",
+    "build": "node scripts/build_search_comparisons.mjs && node scripts/monetize_verified_compare_links.mjs && node scripts/inject_buyer_decision_boxes.mjs && python scripts/sync_revenue_seo.py && python scripts/ensure_best_pages_in_sitemap.py && vite build",
     "test:links": "python scripts/tests/test_link_integrity.py",
     "lint": "oxlint",
     "preview": "vite preview"

--- a/projects/GlobalSaaSHub/public/sitemap.xml
+++ b/projects/GlobalSaaSHub/public/sitemap.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://coshuma.com/</loc>
@@ -1924,5 +1924,85 @@
     <loc>https://coshuma.com/compare/ai-agent-store-vs-marblism.html</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://coshuma.com/best/ai-video-generators.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://coshuma.com/best/ai-voice-generators.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://coshuma.com/best/b2b-email-list-providers.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://coshuma.com/best/brand24-ai-visibility.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://coshuma.com/best/chatbase-pricing-free-trial.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://coshuma.com/best/crm-for-marketing-agencies.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://coshuma.com/best/databox-genie-ai-analyst.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://coshuma.com/best/esignature-software.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://coshuma.com/best/index.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://coshuma.com/best/landing-page-builders.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://coshuma.com/best/pictory-discount-code.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://coshuma.com/best/shopify-pricing-free-trial.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://coshuma.com/best/sudowrite-free-trial-pricing.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://coshuma.com/best/unbounce-discount.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://coshuma.com/best/where-to-buy-targeted-b2b-email-lists.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://coshuma.com/physician-email-list.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
   </url>
 </urlset>

--- a/projects/GlobalSaaSHub/public/tool/catalister.html
+++ b/projects/GlobalSaaSHub/public/tool/catalister.html
@@ -155,7 +155,8 @@
 
       </div>      <p data-affiliate-disclosure="tool" class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: This page may use a verified COSHUMA partner link. COSHUMA may earn a commission if you become a paying customer after using it, at no extra cost to you.</p>
 
-    </main>
+    <nav aria-label="Catalister comparisons" class="mt-8"><h2 class="text-xl font-bold">Compare Catalister</h2><ul><li><a href="/compare/catalister-vs-kinsta.html" class="text-purple-300 underline">Catalister vs Kinsta</a></li><li><a href="/compare/catalister-vs-quillbot.html" class="text-purple-300 underline">Catalister vs QuillBot</a></li></ul></nav>
+</main>
 
     <!-- Footer -->
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">

--- a/projects/GlobalSaaSHub/public/tool/tagshop-ai.html
+++ b/projects/GlobalSaaSHub/public/tool/tagshop-ai.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tagshop AI Pricing, Features & Review (2026) | GlobalSaaSHub</title>
-    <meta name="description" content="Generate high-converting, UGC-style AI video ads directly from product URLs or scripts in just minutes, boosting your marketing efforts.... Discover features, pricing (See official pricing), and official links for Tagshop AI on GlobalSaaSHub." />
+    <title>Tagshop AI: AI Video Ads, Features &amp; Pricing Guide | COSHUMA</title>
+    <meta name="description" content="Explore Tagshop AI for UGC-style video ads from product URLs or scripts. Review features, compare alternatives and check official pricing before choosing." />
     <link rel="canonical" href="https://coshuma.com/tool/tagshop-ai.html" />
     
     <!-- Open Graph SEO Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://coshuma.com/tool/tagshop-ai.html" />
-    <meta property="og:title" content="Tagshop AI Review & Pricing (2026) | GlobalSaaSHub" />
-    <meta property="og:description" content="Generate high-converting, UGC-style AI video ads directly from product URLs or scripts in just minutes, boosting your marketing efforts.... Check rating, pricing, and features." />
+    <meta property="og:title" content="Tagshop AI: AI Video Ads, Features &amp; Pricing Guide | COSHUMA" />
+    <meta property="og:description" content="Explore Tagshop AI for UGC-style video ads from product URLs or scripts. Review features, compare alternatives and check official pricing before choosing." />
 
     <!-- JSON-LD Structured Data for Google Indexing -->
     <script type="application/ld+json">

--- a/projects/GlobalSaaSHub/scripts/ensure_best_pages_in_sitemap.py
+++ b/projects/GlobalSaaSHub/scripts/ensure_best_pages_in_sitemap.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+from html.parser import HTMLParser
+import json
 import xml.etree.ElementTree as ET
 
 BASE_URL = "https://coshuma.com"
@@ -35,6 +37,34 @@ def add_url(url: str, priority: str = "0.9") -> None:
 best_pages = sorted(BEST_DIR.glob("*.html"))
 for page in best_pages:
     add_url(f"{BASE_URL}/best/{page.name}", "0.9")
+
+
+class IndexablePage(HTMLParser):
+    def __init__(self, text):
+        super().__init__()
+        self.canonicals = []
+        self.noindex = False
+        self.feed(text)
+
+    def handle_starttag(self, tag, attrs):
+        attrs = dict(attrs)
+        if tag == "link" and "canonical" in attrs.get("rel", "").lower().split():
+            self.canonicals.append(attrs.get("href"))
+        if tag == "meta" and attrs.get("name", "").lower() in ("robots", "googlebot"):
+            self.noindex |= "noindex" in attrs.get("content", "").lower()
+
+
+# Scan the finished pages, including hand-written pages omitted by generators.
+# Only index self-canonical pages; aliases and explicitly noindexed pages stay out.
+tool_ids = {tool["id"] for tool in json.loads((PROJECT / "data/tools.json").read_text(encoding="utf-8"))}
+for directory in ("tool", "compare"):
+    for page in sorted((PUBLIC / directory).glob("*.html")):
+        if directory == "tool" and page.stem not in tool_ids:
+            continue  # Do not promote orphaned detail pages outside the catalog.
+        url = f"{BASE_URL}/{directory}/{page.name}"
+        parsed = IndexablePage(page.read_text(encoding="utf-8"))
+        if parsed.canonicals == [url] and not parsed.noindex:
+            add_url(url, "0.8" if directory == "tool" else "0.7")
 
 # Root-level buyer-intent landing pages are hand-written and are not emitted by
 # generate_seo_pages.py. Include only pages that contain an affiliate CTA and a

--- a/projects/GlobalSaaSHub/scripts/sync_revenue_seo.py
+++ b/projects/GlobalSaaSHub/scripts/sync_revenue_seo.py
@@ -1,0 +1,45 @@
+"""Restore curated search metadata after generation without touching body or CTAs."""
+from pathlib import Path
+from html import escape
+import re
+
+PUBLIC = Path(__file__).resolve().parents[1] / "public"
+page = PUBLIC / "tool/tagshop-ai.html"
+title = "Tagshop AI: AI Video Ads, Features & Pricing Guide | COSHUMA"
+description = (
+    "Explore Tagshop AI for UGC-style video ads from product URLs or scripts. "
+    "Review features, compare alternatives and check official pricing before choosing."
+)
+text = page.read_text(encoding="utf-8")
+head, body = text.split("</head>", 1)
+replacements = [
+    (r"<title>.*?</title>", f"<title>{escape(title)}</title>"),
+    (r'<meta name="description" content="[^"]*"\s*/?>', f'<meta name="description" content="{escape(description)}" />'),
+    (r'<meta property="og:title" content="[^"]*"\s*/?>', f'<meta property="og:title" content="{escape(title)}" />'),
+    (r'<meta property="og:description" content="[^"]*"\s*/?>', f'<meta property="og:description" content="{escape(description)}" />'),
+]
+for pattern, replacement in replacements:
+    head, count = re.subn(pattern, lambda _: replacement, head, flags=re.S)
+    if count != 1:
+        raise ValueError(f"Expected exactly one metadata field: {pattern}")
+updated = head + "</head>" + body
+if updated != text:
+    page.write_text(updated, encoding="utf-8")
+print("Curated Tagshop AI search metadata synchronized; body and CTAs preserved.")
+
+# Give both existing Catalister comparisons a crawlable link from the profile.
+page = PUBLIC / "tool/catalister.html"
+text = page.read_text(encoding="utf-8")
+links = []
+for other, label in (("kinsta", "Kinsta"), ("quillbot", "QuillBot")):
+    href = f"/compare/catalister-vs-{other}.html"
+    if f'href="{href}"' not in text:
+        if not (PUBLIC / href.lstrip("/")).is_file():
+            raise ValueError(f"Missing comparison: {href}")
+        links.append(f'<li><a href="{href}" class="text-purple-300 underline">Catalister vs {label}</a></li>')
+if links:
+    if text.count("</main>") != 1:
+        raise ValueError("Expected one Catalister main closing anchor")
+    section = '<nav aria-label="Catalister comparisons" class="mt-8"><h2 class="text-xl font-bold">Compare Catalister</h2><ul>' + "".join(links) + '</ul></nav>\n'
+    page.write_text(text.replace("</main>", section + "</main>"), encoding="utf-8")
+print("Catalister comparison internal links checked.")

--- a/projects/GlobalSaaSHub/scripts/tests/test_revenue_seo.py
+++ b/projects/GlobalSaaSHub/scripts/tests/test_revenue_seo.py
@@ -1,0 +1,113 @@
+"""Focused source/dist/live SEO checks and sitemap discovery regression."""
+from pathlib import Path
+from html.parser import HTMLParser
+from urllib.request import urlopen
+from urllib.parse import urlsplit
+from urllib.robotparser import RobotFileParser
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+
+PROJECT = Path(__file__).resolve().parents[2]
+BASE = "https://coshuma.com"
+PAGES = ["tool/tagshop-ai.html", "compare/tagshop-ai-vs-tubebuddy.html",
+         "compare/tagshop-ai-vs-outlierkit.html", "tool/catalister.html",
+         "compare/catalister-vs-kinsta.html", "compare/catalister-vs-quillbot.html"]
+source = sys.argv[1] if len(sys.argv) > 1 else "public"
+
+def read(path):
+    if source == "live":
+        with urlopen(f"{BASE}/{path}", timeout=30) as response:
+            assert response.status == 200
+            return response.read().decode("utf-8")
+    return (PROJECT / source / path).read_text(encoding="utf-8")
+
+class Page(HTMLParser):
+    def __init__(self, text):
+        super().__init__()
+        self.meta, self.canonical, self.links = {}, [], []
+        self.feed(text)
+        self.title = re.findall(r"<title>(.*?)</title>", text, re.S)
+        self.schemas = [json.loads(s) for s in re.findall(
+            r'<script[^>]*type="application/ld\+json"[^>]*>(.*?)</script>', text, re.S)]
+
+    def handle_starttag(self, tag, attrs):
+        a = dict(attrs)
+        if tag == "meta":
+            self.meta.setdefault(a.get("name", a.get("property")), []).append(a.get("content"))
+        if tag == "link" and a.get("rel") == "canonical":
+            self.canonical.append(a.get("href"))
+        if tag == "a" and a.get("href"):
+            self.links.append(a["href"])
+
+sitemap = ET.fromstring(read("sitemap.xml"))
+assert sitemap.tag == "{http://www.sitemaps.org/schemas/sitemap/0.9}urlset"
+urls = [n.text for n in sitemap.findall("{*}url/{*}loc")]
+assert len(urls) == len(set(urls)), "Duplicate sitemap URLs"
+assert all(u.startswith(BASE + "/") for u in urls)
+robots = RobotFileParser()
+robots.parse(read("robots.txt").splitlines())
+assert BASE + "/sitemap.xml" in robots.site_maps()
+titles, descriptions = set(), set()
+parsed = {}
+for path in PAGES:
+    text = read(path)
+    page = parsed[path] = Page(text)
+    url = BASE + "/" + path
+    assert url in urls, path
+    assert robots.can_fetch("Googlebot", url), path
+    assert page.canonical == [url], path
+    assert len(page.title) == 1 and page.title[0].strip(), path
+    assert page.title[0] not in titles, path
+    titles.add(page.title[0])
+    for key in ("description", "og:title", "og:description", "og:url", "og:type"):
+        assert len(page.meta.get(key, [])) == 1 and page.meta[key][0].strip(), (path, key)
+    assert page.meta["og:url"] == [url]
+    assert page.meta["description"][0] not in descriptions, path
+    descriptions.add(page.meta["description"][0])
+    assert page.schemas and all(s.get("@context") == "https://schema.org" and s.get("@type") for s in page.schemas)
+    for href in page.links:
+        if href.startswith(("/tool/", "/compare/")):
+            assert (PROJECT / "public" / urlsplit(href).path.lstrip("/")).is_file(), (path, href)
+    if path.startswith("compare/"):
+        assert "/tool/" + path.split("/")[1].split("-vs-")[0] + ".html" in page.links
+    if path == "tool/tagshop-ai.html":
+        assert "data-cta=\"affiliate\"" not in text
+        assert "UGC-style video ads" in page.meta["description"][0]
+        assert "Discover features, pricing (" not in page.meta["description"][0]
+        assert not re.search(r"[$€£]\s*\d", page.meta["description"][0])
+    print("PASS", source, path)
+
+for path in PAGES[3:]:
+    assert any("/" + path in p.links or BASE + "/" + path in p.links
+               for other, p in parsed.items() if other != path), ("Missing internal inbound link", path)
+
+if source != "live":
+    # Exercise missing pages, canonical aliases, noindex and idempotence in isolation.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "scripts").mkdir()
+        (root / "data").mkdir()
+        (root / "data/tools.json").write_text('[{"id":"new"},{"id":"alias"},{"id":"private"}]')
+        public = root / "public"
+        public.mkdir()
+        script = root / "scripts/ensure_best_pages_in_sitemap.py"
+        script.write_bytes((PROJECT / "scripts" / script.name).read_bytes())
+        (public / "sitemap.xml").write_text('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"/>')
+        for directory in ("tool", "compare"):
+            (public / directory).mkdir()
+            for name in ("new", "alias", "private"):
+                canonical = f"{BASE}/{directory}/{'new' if name == 'alias' else name}.html"
+                meta = '<meta name="robots" content="noindex">' if name == "private" else ""
+                (public / directory / f"{name}.html").write_text(f'<link rel="canonical" href="{canonical}">{meta}')
+        subprocess.run([sys.executable, str(script)], check=True, capture_output=True)
+        before = (public / "sitemap.xml").read_bytes()
+        nodes = ET.fromstring(before).findall("{*}url/{*}loc")
+        assert {n.text for n in nodes} == {f"{BASE}/{d}/new.html" for d in ("tool", "compare")}
+        subprocess.run([sys.executable, str(script)], check=True, capture_output=True)
+        assert (public / "sitemap.xml").read_bytes() == before
+    print("PASS sitemap discovery, alias/noindex exclusion and idempotence")
+print("PASS robots, sitemap XML, self-canonicals, metadata uniqueness, JSON-LD syntax and internal links")


### PR DESCRIPTION
Preserve curated Tagshop AI title/description/Open Graph metadata after generation and discover self-canonical, indexable catalog tool and comparison pages during every build. Latest main already lists the six requested Tagshop/Catalister URLs; synchronize existing buyer hubs without duplicating entries. Add missing inbound links to the two Catalister comparisons. Affiliate URLs/status, CTAs, and revenue data are unchanged by this diff.

Validation: production build, focused source/dist checks for six pages (robots, XML, self-canonical, unique metadata, JSON-LD syntax, sitemap, internal links), discovery/alias/noindex/idempotence fixtures, and Tagshop consent regression passed. Add the focused check to deployment CI. Global test:links has six pre-existing failures, reproduced identically after building unchanged main 9799257: orphan fill-esignature page/count mismatch and systeme-io/fliki generated CTA URL/rel failures. Those unrelated affiliate changes are outside this SEO scope.