### PR TITLE
Confirm n8n/Webflow submissions and fix Fill sitemap audit

### DIFF
--- a/.github/workflows/coshuma-site-deploy.yml
+++ b/.github/workflows/coshuma-site-deploy.yml
@@ -10,6 +10,8 @@ on:
       - 'projects/GlobalSaaSHub/scripts/approved_tracking_evidence.mjs'
       - 'projects/GlobalSaaSHub/scripts/browser_followup_evidence.mjs'
       - 'projects/GlobalSaaSHub/data/affiliate-browser-followup-wave3-2026-09-08.json'
+      - 'projects/GlobalSaaSHub/data/affiliate-submission-batch-2026-09-08.json'
+      - 'projects/GlobalSaaSHub/data/standalone_tool_pages.json'
       - 'projects/GlobalSaaSHub/data/tools.json'
       - 'projects/GlobalSaaSHub/data/tools.next.json'
       - 'projects/GlobalSaaSHub/scripts/sync_verified_affiliates.mjs'
@@ -128,6 +130,7 @@ jobs:
         working-directory: projects/GlobalSaaSHub
         run: |
           python scripts/tests/test_revenue_seo.py dist
+          python scripts/tests/test_link_integrity.py
           node scripts/verify_approved_tracking.mjs
           node scripts/tests/browser-followup.test.mjs
           node scripts/tests/tagshop-consent.test.mjs

--- a/projects/GlobalSaaSHub/data/affiliate-submission-batch-2026-09-08.json
+++ b/projects/GlobalSaaSHub/data/affiliate-submission-batch-2026-09-08.json
@@ -1,0 +1,44 @@
+{
+  "checked_date_kst": "2026-09-08",
+  "account": "support@coshuma.com",
+  "paid_actions": 0,
+  "results": [
+    {
+      "id": "n8n",
+      "status": "application_submitted",
+      "application_state": "submitted",
+      "review_state": "pending_review",
+      "affiliate_url": null,
+      "workflow_url": "https://dash.partnerstack.com/home",
+      "official_program_url": "https://n8n.io/affiliates/",
+      "evidence": "2026-09-08 authenticated browser: checked the prepared required I agree acknowledgement under explicit user authorization and submitted once. PartnerStack home then displayed n8n GmbH / Application pending. Clicks and signups 0; revenue, pending and paid commissions $0.00. No approval or customer tracking URL issued.",
+      "next_action": "Await program review in the existing account. Do not reapply. Recover only an issued customer-facing tracking URL after approval evidence.",
+      "blockers": []
+    },
+    {
+      "id": "webflow",
+      "status": "application_submitted",
+      "application_state": "submitted",
+      "review_state": "pending_review",
+      "affiliate_url": null,
+      "workflow_url": "https://webflow.com/solutions/affiliates",
+      "official_program_url": "https://webflow.com/solutions/affiliates",
+      "evidence": "2026-09-08 authenticated browser: existing prepared form, final Program terms accepted under explicit user authorization; submitted once. Affiliate Program Application success and Thank you for applying displayed, with response expected in 1-2 weeks by email or PartnerStack. Optional email marketing checkbox remained unchecked. Approval and customer tracking URL not confirmed.",
+      "next_action": "Await review email or PartnerStack update; do not submit again or duplicate outreach. No further consent request is needed for this submitted application.",
+      "blockers": []
+    },
+    {
+      "id": "aiassistworks",
+      "status": "browser_required_onboarding",
+      "application_state": "not_confirmed",
+      "affiliate_url": null,
+      "workflow_url": "https://aiassistworks.affonso.io/onboarding",
+      "official_program_url": "https://www.aiassistworks.com/affiliate-program",
+      "evidence": "2026-09-08 browser requested a fresh code; company Gmail received latest AiAssistWorks verification email at 05:22 KST. Authentication succeeded and onboarding displayed signed in as support@coshuma.com, step 1 of 2, name empty and Korea, Republic of selected. OTP blocker resolved; onboarding and application submission are not complete. No code or token retained.",
+      "next_action": "Resume existing authenticated onboarding when continuing account setup. Do not request another OTP while session remains valid. Do not mark submitted or approved until actual confirmation.",
+      "blockers": [
+        "onboarding_incomplete"
+      ]
+    }
+  ]
+}

--- a/projects/GlobalSaaSHub/data/affiliate_outreach_state.json
+++ b/projects/GlobalSaaSHub/data/affiliate_outreach_state.json
@@ -219,16 +219,16 @@
       "evidence_file": "data/approved-tracking-2026-09-08.json"
     },
     "n8n": {
-      "status": "browser_required_user_consent",
+      "status": "application_submitted",
       "tracking_url": null,
-      "evidence_file": "data/affiliate-browser-followup-wave3-2026-09-08.json",
-      "note": "Official page shows 30% for 12 months. Existing authenticated PartnerStack application form displays Sangkwon An, support@coshuma.com and COSHUMA. Entered existing affiliate programs, selected blog or website, checked company website yes and entered https://coshuma.com. No prior application confirmation found in searched mailboxes; source record was application_page_unavailable. Form now loads.",
-      "next_action": "User reviews program agreement and required acknowledgement, then submits prepared application. Record application_submitted only after actual confirmation. Optional unverified n8n-use and social fields left blank.",
+      "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+      "note": "2026-09-08 authenticated browser: checked the prepared required I agree acknowledgement under explicit user authorization and submitted once. PartnerStack home then displayed n8n GmbH / Application pending. Clicks and signups 0; revenue, pending and paid commissions $0.00. No approval or customer tracking URL issued.",
+      "next_action": "Await program review in the existing account. Do not reapply. Recover only an issued customer-facing tracking URL after approval evidence.",
       "checked_date_kst": "2026-09-08",
       "do_not_reapply": true,
-      "workflow_url": "https://dash.partnerstack.com/application?company=n8n&group=affiliates2025",
-      "application_state": "not_submitted",
-      "blocker": "Required I agree acknowledgement prohibits branded-search bidding and specifies ban/commission forfeiture. Left unchecked; Submit application not clicked. Program agreement is linked on the form."
+      "workflow_url": "https://dash.partnerstack.com/home",
+      "application_state": "submitted",
+      "blocker": null
     },
     "novita-ai": {
       "status": "browser_required_user_consent",
@@ -320,6 +320,30 @@
       "next_action": "Resume the existing confirmed account at the login page and verify its dashboard or a subsequent program email. Do not create another account or resubmit the application. Record only an issued customer-facing tracking URL after approval verification. No further consent request is needed. Leave CAPTCHA or forced identity verification to the user; no paid plan.",
       "portal_enrollment_confirmed": true,
       "email_confirmed": true
+    },
+    "webflow": {
+      "status": "application_submitted",
+      "tracking_url": null,
+      "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+      "note": "2026-09-08 authenticated browser: existing prepared form, final Program terms accepted under explicit user authorization; submitted once. Affiliate Program Application success and Thank you for applying displayed, with response expected in 1-2 weeks by email or PartnerStack. Optional email marketing checkbox remained unchecked. Approval and customer tracking URL not confirmed.",
+      "next_action": "Await review email or PartnerStack update; do not submit again or duplicate outreach. No further consent request is needed for this submitted application.",
+      "checked_date_kst": "2026-09-08",
+      "do_not_reapply": true,
+      "workflow_url": "https://webflow.com/solutions/affiliates",
+      "application_state": "submitted",
+      "blocker": null
+    },
+    "aiassistworks": {
+      "status": "browser_required_onboarding",
+      "tracking_url": null,
+      "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+      "note": "2026-09-08 browser requested a fresh code; company Gmail received latest AiAssistWorks verification email at 05:22 KST. Authentication succeeded and onboarding displayed signed in as support@coshuma.com, step 1 of 2, name empty and Korea, Republic of selected. OTP blocker resolved; onboarding and application submission are not complete. No code or token retained.",
+      "next_action": "Resume existing authenticated onboarding when continuing account setup. Do not request another OTP while session remains valid. Do not mark submitted or approved until actual confirmation.",
+      "checked_date_kst": "2026-09-08",
+      "do_not_reapply": true,
+      "workflow_url": "https://aiassistworks.affonso.io/onboarding",
+      "application_state": "not_confirmed",
+      "blocker": "onboarding_incomplete"
     }
   }
 }

--- a/projects/GlobalSaaSHub/data/browser_required_queue.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.json
@@ -403,14 +403,14 @@
   {
     "id": "n8n-affiliate-browser-followup",
     "tool_id": "n8n",
-    "status": "browser_required_user_consent",
-    "affiliate_status": "browser_required_user_consent",
+    "status": "resolved",
+    "affiliate_status": "application_submitted",
     "cost": "0",
     "exact_tracking_url": null,
-    "workflow_url": "https://dash.partnerstack.com/application?company=n8n&group=affiliates2025",
-    "evidence_file": "data/affiliate-browser-followup-wave3-2026-09-08.json",
-    "reason": "Required I agree acknowledgement prohibits branded-search bidding and specifies ban/commission forfeiture. Left unchecked; Submit application not clicked. Program agreement is linked on the form.",
-    "next_action": "User reviews program agreement and required acknowledgement, then submits prepared application. Record application_submitted only after actual confirmation. Optional unverified n8n-use and social fields left blank.",
+    "workflow_url": "https://dash.partnerstack.com/home",
+    "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+    "reason": "2026-09-08 authenticated browser: checked the prepared required I agree acknowledgement under explicit user authorization and submitted once. PartnerStack home then displayed n8n GmbH / Application pending. Clicks and signups 0; revenue, pending and paid commissions $0.00. No approval or customer tracking URL issued.",
+    "next_action": "Await program review in the existing account. Do not reapply. Recover only an issued customer-facing tracking URL after approval evidence.",
     "do_not": [
       "Do not reapply or submit duplicate outreach.",
       "Do not pay or create a new account.",
@@ -531,5 +531,29 @@
     "application_submitted": true,
     "email_confirmed": true,
     "program_consent_checked": true
+  },
+  {
+    "id": "webflow-affiliate-browser-followup",
+    "tool_id": "webflow",
+    "cost": "0",
+    "status": "resolved",
+    "affiliate_status": "application_submitted",
+    "exact_tracking_url": null,
+    "workflow_url": "https://webflow.com/solutions/affiliates",
+    "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+    "reason": "2026-09-08 authenticated browser: existing prepared form, final Program terms accepted under explicit user authorization; submitted once. Affiliate Program Application success and Thank you for applying displayed, with response expected in 1-2 weeks by email or PartnerStack. Optional email marketing checkbox remained unchecked. Approval and customer tracking URL not confirmed.",
+    "next_action": "Await review email or PartnerStack update; do not submit again or duplicate outreach. No further consent request is needed for this submitted application."
+  },
+  {
+    "id": "aiassistworks-affiliate-browser-followup",
+    "tool_id": "aiassistworks",
+    "cost": "0",
+    "status": "browser_required_onboarding",
+    "affiliate_status": "browser_required_onboarding",
+    "exact_tracking_url": null,
+    "workflow_url": "https://aiassistworks.affonso.io/onboarding",
+    "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+    "reason": "2026-09-08 browser requested a fresh code; company Gmail received latest AiAssistWorks verification email at 05:22 KST. Authentication succeeded and onboarding displayed signed in as support@coshuma.com, step 1 of 2, name empty and Korea, Republic of selected. OTP blocker resolved; onboarding and application submission are not complete. No code or token retained.",
+    "next_action": "Resume existing authenticated onboarding when continuing account setup. Do not request another OTP while session remains valid. Do not mark submitted or approved until actual confirmation."
   }
 ]

--- a/projects/GlobalSaaSHub/data/standalone_tool_pages.json
+++ b/projects/GlobalSaaSHub/data/standalone_tool_pages.json
@@ -1,0 +1,6 @@
+{
+  "fill-esignature": {
+    "evidence_file": "data/affiliate-browser-results-2026-09-08.json",
+    "program_id": "fill"
+  }
+}

--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -1367,7 +1367,19 @@
     "is_manual_override": false,
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
-    "official_evidence_url": "https://webflow.com/"
+    "official_evidence_url": "https://webflow.com/",
+    "affiliate_status": "application_submitted",
+    "affiliate_verified": false,
+    "affiliate_final_url": null,
+    "affiliate_evidence_markers": [
+      "2026-09-08 authenticated browser: existing prepared form, final Program terms accepted under explicit user authorization; submitted once. Affiliate Program Application success and Thank you for applying displayed, with response expected in 1-2 weeks by email or PartnerStack. Optional email marketing checkbox remained unchecked. Approval and customer tracking URL not confirmed.",
+      "Await review email or PartnerStack update; do not submit again or duplicate outreach. No further consent request is needed for this submitted application.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
+    "affiliate_status_checked_at": "2026-09-08",
+    "affiliate_status_evidence_url": "https://webflow.com/solutions/affiliates",
+    "affiliate_workflow_url": "https://webflow.com/solutions/affiliates",
+    "affiliate_next_action": "Await review email or PartnerStack update; do not submit again or duplicate outreach. No further consent request is needed for this submitted application."
   },
   {
     "id": "reactin",
@@ -1654,7 +1666,19 @@
     "is_manual_override": false,
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
-    "official_evidence_url": "https://aiassistworks.com/"
+    "official_evidence_url": "https://aiassistworks.com/",
+    "affiliate_status": "browser_required_onboarding",
+    "affiliate_verified": false,
+    "affiliate_final_url": null,
+    "affiliate_evidence_markers": [
+      "2026-09-08 browser requested a fresh code; company Gmail received latest AiAssistWorks verification email at 05:22 KST. Authentication succeeded and onboarding displayed signed in as support@coshuma.com, step 1 of 2, name empty and Korea, Republic of selected. OTP blocker resolved; onboarding and application submission are not complete. No code or token retained.",
+      "Resume existing authenticated onboarding when continuing account setup. Do not request another OTP while session remains valid. Do not mark submitted or approved until actual confirmation.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
+    "affiliate_status_checked_at": "2026-09-08",
+    "affiliate_status_evidence_url": "https://www.aiassistworks.com/affiliate-program",
+    "affiliate_workflow_url": "https://aiassistworks.affonso.io/onboarding",
+    "affiliate_next_action": "Resume existing authenticated onboarding when continuing account setup. Do not request another OTP while session remains valid. Do not mark submitted or approved until actual confirmation."
   },
   {
     "id": "vista-social",
@@ -2786,18 +2810,18 @@
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://n8n.io/affiliates/",
     "affiliate_verified": false,
-    "affiliate_status": "browser_required_user_consent",
+    "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00+09:00",
     "affiliate_final_url": null,
     "affiliate_evidence_markers": [
-      "Official page shows 30% for 12 months. Existing authenticated PartnerStack application form displays Sangkwon An, support@coshuma.com and COSHUMA. Entered existing affiliate programs, selected blog or website, checked company website yes and entered https://coshuma.com. No prior application confirmation found in searched mailboxes; source record was application_page_unavailable. Form now loads.",
-      "User reviews program agreement and required acknowledgement, then submits prepared application. Record application_submitted only after actual confirmation. Optional unverified n8n-use and social fields left blank.",
-      "data/affiliate-browser-followup-wave3-2026-09-08.json"
+      "2026-09-08 authenticated browser: checked the prepared required I agree acknowledgement under explicit user authorization and submitted once. PartnerStack home then displayed n8n GmbH / Application pending. Clicks and signups 0; revenue, pending and paid commissions $0.00. No approval or customer tracking URL issued.",
+      "Await program review in the existing account. Do not reapply. Recover only an issued customer-facing tracking URL after approval evidence.",
+      "data/affiliate-submission-batch-2026-09-08.json"
     ],
     "affiliate_status_checked_at": "2026-09-08",
     "affiliate_status_evidence_url": "https://n8n.io/affiliates/",
-    "affiliate_workflow_url": "https://dash.partnerstack.com/application?company=n8n&group=affiliates2025",
-    "affiliate_next_action": "User reviews program agreement and required acknowledgement, then submits prepared application. Record application_submitted only after actual confirmation. Optional unverified n8n-use and social fields left blank."
+    "affiliate_workflow_url": "https://dash.partnerstack.com/home",
+    "affiliate_next_action": "Await program review in the existing account. Do not reapply. Recover only an issued customer-facing tracking URL after approval evidence."
   },
   {
     "id": "novita-ai",

--- a/projects/GlobalSaaSHub/data/tools.next.json
+++ b/projects/GlobalSaaSHub/data/tools.next.json
@@ -1329,7 +1329,19 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://webflow.com/",
-    "affiliate_url": null
+    "affiliate_url": null,
+    "affiliate_status": "application_submitted",
+    "affiliate_verified": false,
+    "affiliate_final_url": null,
+    "affiliate_evidence_markers": [
+      "2026-09-08 authenticated browser: existing prepared form, final Program terms accepted under explicit user authorization; submitted once. Affiliate Program Application success and Thank you for applying displayed, with response expected in 1-2 weeks by email or PartnerStack. Optional email marketing checkbox remained unchecked. Approval and customer tracking URL not confirmed.",
+      "Await review email or PartnerStack update; do not submit again or duplicate outreach. No further consent request is needed for this submitted application.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
+    "affiliate_status_checked_at": "2026-09-08",
+    "affiliate_status_evidence_url": "https://webflow.com/solutions/affiliates",
+    "affiliate_workflow_url": "https://webflow.com/solutions/affiliates",
+    "affiliate_next_action": "Await review email or PartnerStack update; do not submit again or duplicate outreach. No further consent request is needed for this submitted application."
   },
   {
     "id": "reactin",
@@ -1616,7 +1628,19 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://aiassistworks.com/",
-    "affiliate_url": null
+    "affiliate_url": null,
+    "affiliate_status": "browser_required_onboarding",
+    "affiliate_verified": false,
+    "affiliate_final_url": null,
+    "affiliate_evidence_markers": [
+      "2026-09-08 browser requested a fresh code; company Gmail received latest AiAssistWorks verification email at 05:22 KST. Authentication succeeded and onboarding displayed signed in as support@coshuma.com, step 1 of 2, name empty and Korea, Republic of selected. OTP blocker resolved; onboarding and application submission are not complete. No code or token retained.",
+      "Resume existing authenticated onboarding when continuing account setup. Do not request another OTP while session remains valid. Do not mark submitted or approved until actual confirmation.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
+    "affiliate_status_checked_at": "2026-09-08",
+    "affiliate_status_evidence_url": "https://www.aiassistworks.com/affiliate-program",
+    "affiliate_workflow_url": "https://aiassistworks.affonso.io/onboarding",
+    "affiliate_next_action": "Resume existing authenticated onboarding when continuing account setup. Do not request another OTP while session remains valid. Do not mark submitted or approved until actual confirmation."
   },
   {
     "id": "vista-social",
@@ -2745,18 +2769,18 @@
     "official_evidence_url": "https://n8n.io/affiliates/",
     "affiliate_url": null,
     "affiliate_verified": false,
-    "affiliate_status": "browser_required_user_consent",
+    "affiliate_status": "application_submitted",
     "affiliate_verified_at": "2026-09-01T00:00:00+09:00",
     "affiliate_final_url": null,
     "affiliate_evidence_markers": [
-      "Official page shows 30% for 12 months. Existing authenticated PartnerStack application form displays Sangkwon An, support@coshuma.com and COSHUMA. Entered existing affiliate programs, selected blog or website, checked company website yes and entered https://coshuma.com. No prior application confirmation found in searched mailboxes; source record was application_page_unavailable. Form now loads.",
-      "User reviews program agreement and required acknowledgement, then submits prepared application. Record application_submitted only after actual confirmation. Optional unverified n8n-use and social fields left blank.",
-      "data/affiliate-browser-followup-wave3-2026-09-08.json"
+      "2026-09-08 authenticated browser: checked the prepared required I agree acknowledgement under explicit user authorization and submitted once. PartnerStack home then displayed n8n GmbH / Application pending. Clicks and signups 0; revenue, pending and paid commissions $0.00. No approval or customer tracking URL issued.",
+      "Await program review in the existing account. Do not reapply. Recover only an issued customer-facing tracking URL after approval evidence.",
+      "data/affiliate-submission-batch-2026-09-08.json"
     ],
     "affiliate_status_checked_at": "2026-09-08",
     "affiliate_status_evidence_url": "https://n8n.io/affiliates/",
-    "affiliate_workflow_url": "https://dash.partnerstack.com/application?company=n8n&group=affiliates2025",
-    "affiliate_next_action": "User reviews program agreement and required acknowledgement, then submits prepared application. Record application_submitted only after actual confirmation. Optional unverified n8n-use and social fields left blank."
+    "affiliate_workflow_url": "https://dash.partnerstack.com/home",
+    "affiliate_next_action": "Await program review in the existing account. Do not reapply. Recover only an issued customer-facing tracking URL after approval evidence."
   },
   {
     "id": "novita-ai",

--- a/projects/GlobalSaaSHub/public/sitemap.xml
+++ b/projects/GlobalSaaSHub/public/sitemap.xml
@@ -2005,4 +2005,9 @@
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
+  <url>
+    <loc>https://coshuma.com/tool/fill-esignature.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/projects/GlobalSaaSHub/scripts/browser_followup_evidence.mjs
+++ b/projects/GlobalSaaSHub/scripts/browser_followup_evidence.mjs
@@ -4,6 +4,10 @@ export const browserEvidencePath = 'data/affiliate-browser-followup-wave3-2026-0
 export const browserFollowups = new Map(JSON.parse(fs.readFileSync(
   new URL('../' + browserEvidencePath, import.meta.url), 'utf8',
 )).results.map(item => [item.id, item]));
+const submissionEvidencePath = 'data/affiliate-submission-batch-2026-09-08.json';
+for (const item of JSON.parse(fs.readFileSync(new URL('../' + submissionEvidencePath, import.meta.url), 'utf8')).results) {
+  browserFollowups.set(item.id, {...item, evidence_path: submissionEvidencePath});
+}
 
 // This browser snapshot preserves existing approvals, never infers a new one
 // from a successful public landing, and keeps account access separate from CTAs.
@@ -23,7 +27,7 @@ export function applyBrowserFollowup(tool) {
     affiliate_url: approved ? item.affiliate_url : null,
     affiliate_verified: approved,
     affiliate_final_url: approved ? item.affiliate_url : null,
-    affiliate_evidence_markers: [item.evidence, item.next_action, browserEvidencePath],
+    affiliate_evidence_markers: [item.evidence, item.next_action, item.evidence_path || browserEvidencePath],
     affiliate_status_checked_at: '2026-09-08',
     affiliate_status_evidence_url: item.official_program_url || item.workflow_url,
     affiliate_workflow_url: item.workflow_url,

--- a/projects/GlobalSaaSHub/scripts/ensure_best_pages_in_sitemap.py
+++ b/projects/GlobalSaaSHub/scripts/ensure_best_pages_in_sitemap.py
@@ -57,6 +57,7 @@ class IndexablePage(HTMLParser):
 # Scan the finished pages, including hand-written pages omitted by generators.
 # Only index self-canonical pages; aliases and explicitly noindexed pages stay out.
 tool_ids = {tool["id"] for tool in json.loads((PROJECT / "data/tools.json").read_text(encoding="utf-8"))}
+tool_ids.update(json.loads((PROJECT / "data/standalone_tool_pages.json").read_text(encoding="utf-8")))
 for directory in ("tool", "compare"):
     for page in sorted((PUBLIC / directory).glob("*.html")):
         if directory == "tool" and page.stem not in tool_ids:

--- a/projects/GlobalSaaSHub/scripts/tests/browser-followup.test.mjs
+++ b/projects/GlobalSaaSHub/scripts/tests/browser-followup.test.mjs
@@ -49,7 +49,10 @@ try {
 }
 assert.equal(state.typedesk.sender, 'qmfforfhem@gmail.com');
 assert.equal(state.typedesk.portal_enrollment_confirmed, false);
-assert.equal(state.n8n.application_state, 'not_submitted');
+assert.equal(state.n8n.application_state, 'submitted');
+assert.equal(state.webflow.application_state, 'submitted');
+assert.equal(state.aiassistworks.application_state, 'not_confirmed');
+assert.equal(state.aiassistworks.status, 'browser_required_onboarding');
 assert.equal(state['novita-ai'].application_state, 'not_submitted');
 for (const id of ['n8n', 'novita-ai', 'typedesk']) {
   const stale = {id, affiliate_url: 'https://example.com/dashboard', affiliate_verified: true};
@@ -59,4 +62,4 @@ for (const id of ['n8n', 'novita-ai', 'typedesk']) {
   const page = fs.readFileSync(`dist/tool/${id}.html`, 'utf8');
   assert.ok(!page.includes(`data-cta="affiliate" data-tool-id="${id}"`));
 }
-console.log('PASS: five browser states, duplicate prevention, exact links, and repeat sync preservation');
+console.log('PASS: browser states, confirmed submissions, duplicate prevention, exact links, and repeat sync preservation');

--- a/projects/GlobalSaaSHub/scripts/tests/test_link_integrity.py
+++ b/projects/GlobalSaaSHub/scripts/tests/test_link_integrity.py
@@ -4,6 +4,7 @@ import json
 import re
 import sys
 import xml.etree.ElementTree as ET
+from html.parser import HTMLParser
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -27,6 +28,18 @@ def fail(errors, message):
     errors.append(message)
 
 
+class AffiliateLinks(HTMLParser):
+    def __init__(self, html):
+        super().__init__()
+        self.links = []
+        self.feed(html)
+
+    def handle_starttag(self, tag, attrs):
+        attrs = dict(attrs)
+        if tag == "a" and attrs.get("data-cta") == "affiliate":
+            self.links.append(attrs)
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--source", choices=("auto", "tools.json", "tools.next.json"), default="tools.json")
@@ -38,6 +51,8 @@ def main():
     if len(ids) != len(set(ids)):
         fail(errors, "tools.json contains duplicate canonical ids")
     expected_paths = {f"/tool/{tool_id}.html" for tool_id in ids}
+    standalone = json.loads((PROJECT / "data/standalone_tool_pages.json").read_text(encoding="utf-8"))
+    expected_paths.update(f"/tool/{tool_id}.html" for tool_id in standalone)
 
     app_source = (PROJECT / "src" / "App.jsx").read_text(encoding="utf-8")
     if 'href={`/tool/${tool.id}.html`}' not in app_source:
@@ -67,7 +82,7 @@ def main():
             if link not in actual_files:
                 fail(errors, f"Broken internal link in {html_file.relative_to(PUBLIC)}: {link}")
 
-    for tool_id in ids:
+    for tool_id in [*ids, *standalone]:
         path = f"/tool/{tool_id}.html"
         html = (PUBLIC / path.removeprefix("/")).read_text(encoding="utf-8")
         canonical = canonical_pattern.search(html)
@@ -93,13 +108,20 @@ def main():
             fail(errors, f"{tool_id} approved tracking data is missing or unverified")
             continue
         html = (PUBLIC / "tool" / f"{tool_id}.html").read_text(encoding="utf-8")
-        affiliate_cta = re.search(r'<a data-cta="affiliate"[^>]+>', html)
-        if not affiliate_cta or f'href="{tracking_url}"' not in affiliate_cta.group(0):
+        affiliate_ctas = AffiliateLinks(html).links
+        if not affiliate_ctas or any(a.get("href") != tracking_url for a in affiliate_ctas):
             fail(errors, f"{tool_id} generated affiliate CTA does not use its approved tracking URL")
-        if not affiliate_cta or 'rel="sponsored noopener noreferrer"' not in affiliate_cta.group(0):
+        if not affiliate_ctas or any(not {"sponsored", "noopener", "noreferrer"} <= set(a.get("rel", "").split()) for a in affiliate_ctas):
             fail(errors, f"{tool_id} affiliate CTA is missing the sponsored safety relation")
         if not ("via Verified Affiliate Link" in html or re.search(r"Affiliate disclosure:.*?commission", html, re.I | re.S)):
             fail(errors, f"{tool_id} affiliate disclosure is missing")
+    for tool_id, record in standalone.items():
+        evidence = json.loads((PROJECT / record["evidence_file"]).read_text(encoding="utf-8"))
+        item = next(item for item in evidence["items"] if item["id"] == record["program_id"])
+        html = (PUBLIC / "tool" / f"{tool_id}.html").read_text(encoding="utf-8")
+        links = AffiliateLinks(html).links
+        if item["status"] != "approved_tracking" or not item.get("exact_tracking_url") or not links or any(a.get("href") != item["exact_tracking_url"] for a in links):
+            fail(errors, f"Standalone page {tool_id} does not match its approved tracking evidence")
     if errors:
         print(f"LINK INTEGRITY: FAIL ({len(errors)} errors)")
         for error in errors:

--- a/projects/GlobalSaaSHub/scripts/tests/test_revenue_seo.py
+++ b/projects/GlobalSaaSHub/scripts/tests/test_revenue_seo.py
@@ -92,6 +92,7 @@ if source != "live":
         (root / "scripts").mkdir()
         (root / "data").mkdir()
         (root / "data/tools.json").write_text('[{"id":"new"},{"id":"alias"},{"id":"private"}]')
+        (root / "data/standalone_tool_pages.json").write_text('{"standalone":{}}')
         public = root / "public"
         public.mkdir()
         script = root / "scripts/ensure_best_pages_in_sitemap.py"
@@ -99,14 +100,14 @@ if source != "live":
         (public / "sitemap.xml").write_text('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"/>')
         for directory in ("tool", "compare"):
             (public / directory).mkdir()
-            for name in ("new", "alias", "private"):
+            for name in ("new", "alias", "private", "standalone"):
                 canonical = f"{BASE}/{directory}/{'new' if name == 'alias' else name}.html"
                 meta = '<meta name="robots" content="noindex">' if name == "private" else ""
                 (public / directory / f"{name}.html").write_text(f'<link rel="canonical" href="{canonical}">{meta}')
         subprocess.run([sys.executable, str(script)], check=True, capture_output=True)
         before = (public / "sitemap.xml").read_bytes()
         nodes = ET.fromstring(before).findall("{*}url/{*}loc")
-        assert {n.text for n in nodes} == {f"{BASE}/{d}/new.html" for d in ("tool", "compare")}
+        assert {n.text for n in nodes} == {f"{BASE}/{d}/{name}.html" for d in ("tool", "compare") for name in ("new", "standalone")}
         subprocess.run([sys.executable, str(script)], check=True, capture_output=True)
         assert (public / "sitemap.xml").read_bytes() == before
     print("PASS sitemap discovery, alias/noindex exclusion and idempotence")


### PR DESCRIPTION
n8n and Webflow now have browser-confirmed application submissions. AiAssistWorks email authentication succeeded, but onboarding remains incomplete. Newer evidence overrides old consent/OTP blockers in both deployment syncs; authoritative data and queue preserve null tracking URLs and prevent duplicate applications.

The unchanged main build reproduced six link failures: two related to the standalone Fill page and sitemap, plus four false positives caused by Systeme.io/Fliki attribute order. Register the evidence-backed Fill page for sitemap discovery and parse affiliate anchors independently of attribute order. Existing tracking URLs and revenue amounts remain unchanged.

Validation: build; link audit (151 tools/152 pages); six data contract tests; browser and Tagshop repeated sync tests; source/dist SEO; approved tracking CTA verification all passed. Deployment now runs link integrity.