### PR TITLE
Complete AiAssistWorks enrollment and activate verified referral CTAs

### DIFF
--- a/projects/GlobalSaaSHub/data/affiliate-submission-batch-2026-09-08.json
+++ b/projects/GlobalSaaSHub/data/affiliate-submission-batch-2026-09-08.json
@@ -29,16 +29,20 @@
     },
     {
       "id": "aiassistworks",
-      "status": "browser_required_onboarding",
-      "application_state": "not_confirmed",
-      "affiliate_url": null,
-      "workflow_url": "https://aiassistworks.affonso.io/onboarding",
+      "status": "approved_tracking",
+      "application_state": "submitted",
+      "affiliate_url": "https://www.aiassistworks.com/?via=coshuma",
+      "workflow_url": "https://aiassistworks.affonso.io/",
       "official_program_url": "https://www.aiassistworks.com/affiliate-program",
-      "evidence": "2026-09-08 browser requested a fresh code; company Gmail received latest AiAssistWorks verification email at 05:22 KST. Authentication succeeded and onboarding displayed signed in as support@coshuma.com, step 1 of 2, name empty and Korea, Republic of selected. OTP blocker resolved; onboarding and application submission are not complete. No code or token retained.",
-      "next_action": "Resume existing authenticated onboarding when continuing account setup. Do not request another OTP while session remains valid. Do not mark submitted or approved until actual confirmation.",
-      "blockers": [
-        "onboarding_incomplete"
-      ]
+      "evidence": "Existing support@coshuma.com authenticated session reused. Onboarding step 1 accepted name COSHUMA with the existing Korea, Republic of selection; step 2 accepted identifier coshuma and Complete was submitted once. Success Hub and the affiliate dashboard issued https://www.aiassistworks.com/?via=coshuma. Live Chrome opened the official customer product page with via=coshuma retained. Operational enrollment and issued tracking link confirmed; no separate approval email claimed. Before verification visit, dashboard showed 0 clicks, 0 conversions and $0 commission. Payout settings remain incomplete. No new OTP, additional agreement checkbox, paid action or duplicate application occurred. Link validation is not proof of a customer signup, sale or attributed commission.",
+      "next_action": "Preserve the issued exact link and existing account; do not reapply. Payout setup remains incomplete and is separate from enrollment. Keep real customer signups, commissions and revenue at 0 without new evidence; verification visits are not customer activity.",
+      "blockers": [],
+      "review_state": "operational_enrollment_confirmed",
+      "status_origin": "authenticated_portal_issued_tracking",
+      "portal_enrollment_confirmed": true,
+      "customer_landing_verified": true,
+      "checked_at": "2026-09-08T05:29:50+09:00",
+      "payout_setup_complete": false
     }
   ]
 }

--- a/projects/GlobalSaaSHub/data/affiliate_outreach_state.json
+++ b/projects/GlobalSaaSHub/data/affiliate_outreach_state.json
@@ -334,16 +334,19 @@
       "blocker": null
     },
     "aiassistworks": {
-      "status": "browser_required_onboarding",
-      "tracking_url": null,
+      "status": "approved_tracking",
+      "tracking_url": "https://www.aiassistworks.com/?via=coshuma",
       "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
-      "note": "2026-09-08 browser requested a fresh code; company Gmail received latest AiAssistWorks verification email at 05:22 KST. Authentication succeeded and onboarding displayed signed in as support@coshuma.com, step 1 of 2, name empty and Korea, Republic of selected. OTP blocker resolved; onboarding and application submission are not complete. No code or token retained.",
-      "next_action": "Resume existing authenticated onboarding when continuing account setup. Do not request another OTP while session remains valid. Do not mark submitted or approved until actual confirmation.",
+      "note": "Existing support@coshuma.com authenticated session reused. Onboarding step 1 accepted name COSHUMA with the existing Korea, Republic of selection; step 2 accepted identifier coshuma and Complete was submitted once. Success Hub and the affiliate dashboard issued https://www.aiassistworks.com/?via=coshuma. Live Chrome opened the official customer product page with via=coshuma retained. Operational enrollment and issued tracking link confirmed; no separate approval email claimed. Before verification visit, dashboard showed 0 clicks, 0 conversions and $0 commission. Payout settings remain incomplete. No new OTP, additional agreement checkbox, paid action or duplicate application occurred. Link validation is not proof of a customer signup, sale or attributed commission.",
+      "next_action": "Preserve the issued exact link and existing account; do not reapply. Payout setup remains incomplete and is separate from enrollment. Keep real customer signups, commissions and revenue at 0 without new evidence; verification visits are not customer activity.",
       "checked_date_kst": "2026-09-08",
       "do_not_reapply": true,
-      "workflow_url": "https://aiassistworks.affonso.io/onboarding",
-      "application_state": "not_confirmed",
-      "blocker": "onboarding_incomplete"
+      "workflow_url": "https://aiassistworks.affonso.io/",
+      "application_state": "submitted",
+      "blocker": null,
+      "portal_enrollment_confirmed": true,
+      "verified_at": "2026-09-08T05:29:50+09:00",
+      "payout_setup_complete": false
     }
   }
 }

--- a/projects/GlobalSaaSHub/data/approved-tracking-2026-09-08.json
+++ b/projects/GlobalSaaSHub/data/approved-tracking-2026-09-08.json
@@ -114,6 +114,17 @@
       "destination": "https://app.catalister.com/signup?via=coshuma",
       "evidence": "Authenticated Catalister onboarding accepted First Name COSHUMA, Last Name GlobalSaaSHub and affiliate identifier coshuma. Dashboard welcomes COSHUMA, displays Your Affiliate Link app.catalister.com/signup?via=coshuma and confirms Link copied. Customer destination shows Create your account with via=coshuma retained. Operational enrollment and issued link confirmed; no separate approval email claimed. Before verification visit, dashboard displayed 0 clicks, 0 paying referrals, 0 trialing referrals, EUR 0 total/unpaid commission and EUR 0 revenue.",
       "checked_at": "2026-09-08T04:55:00+09:00"
+    },
+    {
+      "id": "aiassistworks",
+      "platform": "Affonso",
+      "status": "approved_tracking",
+      "exact_tracking_url": "https://www.aiassistworks.com/?via=coshuma",
+      "destination": "https://www.aiassistworks.com/?via=coshuma",
+      "portal_url": "https://aiassistworks.affonso.io/",
+      "checked_at": "2026-09-08T05:29:50+09:00",
+      "evidence": "Existing support@coshuma.com authenticated session reused. Onboarding step 1 accepted name COSHUMA with the existing Korea, Republic of selection; step 2 accepted identifier coshuma and Complete was submitted once. Success Hub and the affiliate dashboard issued https://www.aiassistworks.com/?via=coshuma. Live Chrome opened the official customer product page with via=coshuma retained. Operational enrollment and issued tracking link confirmed; no separate approval email claimed. Before verification visit, dashboard showed 0 clicks, 0 conversions and $0 commission. Payout settings remain incomplete. No new OTP, additional agreement checkbox, paid action or duplicate application occurred. Link validation is not proof of a customer signup, sale or attributed commission.",
+      "status_origin": "authenticated_portal_issued_tracking"
     }
   ]
 }

--- a/projects/GlobalSaaSHub/data/browser_required_queue.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.json
@@ -548,12 +548,15 @@
     "id": "aiassistworks-affiliate-browser-followup",
     "tool_id": "aiassistworks",
     "cost": "0",
-    "status": "browser_required_onboarding",
-    "affiliate_status": "browser_required_onboarding",
-    "exact_tracking_url": null,
-    "workflow_url": "https://aiassistworks.affonso.io/onboarding",
+    "status": "resolved",
+    "affiliate_status": "approved_tracking",
+    "exact_tracking_url": "https://www.aiassistworks.com/?via=coshuma",
+    "workflow_url": "https://aiassistworks.affonso.io/",
     "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
-    "reason": "2026-09-08 browser requested a fresh code; company Gmail received latest AiAssistWorks verification email at 05:22 KST. Authentication succeeded and onboarding displayed signed in as support@coshuma.com, step 1 of 2, name empty and Korea, Republic of selected. OTP blocker resolved; onboarding and application submission are not complete. No code or token retained.",
-    "next_action": "Resume existing authenticated onboarding when continuing account setup. Do not request another OTP while session remains valid. Do not mark submitted or approved until actual confirmation."
+    "reason": "Existing support@coshuma.com authenticated session reused. Onboarding step 1 accepted name COSHUMA with the existing Korea, Republic of selection; step 2 accepted identifier coshuma and Complete was submitted once. Success Hub and the affiliate dashboard issued https://www.aiassistworks.com/?via=coshuma. Live Chrome opened the official customer product page with via=coshuma retained. Operational enrollment and issued tracking link confirmed; no separate approval email claimed. Before verification visit, dashboard showed 0 clicks, 0 conversions and $0 commission. Payout settings remain incomplete. No new OTP, additional agreement checkbox, paid action or duplicate application occurred. Link validation is not proof of a customer signup, sale or attributed commission.",
+    "next_action": "Preserve the issued exact link and existing account; do not reapply. Payout setup remains incomplete and is separate from enrollment. Keep real customer signups, commissions and revenue at 0 without new evidence; verification visits are not customer activity.",
+    "application_submitted": true,
+    "portal_enrollment_confirmed": true,
+    "payout_setup_complete": false
   }
 ]

--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -1644,7 +1644,7 @@
     "category": "workflow_auto",
     "category_display": "Workflow Automation",
     "description": "AiAssistWorks integrates over 100 AI models directly into Google Sheets, Docs, and Slides, enabling automated workflows within your favorite productivity suite.",
-    "affiliate_url": null,
+    "affiliate_url": "https://www.aiassistworks.com/?via=coshuma",
     "pricing": "See official pricing",
     "key_features": [
       "Integrates 100+ AI models",
@@ -1667,18 +1667,19 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://aiassistworks.com/",
-    "affiliate_status": "browser_required_onboarding",
-    "affiliate_verified": false,
-    "affiliate_final_url": null,
+    "affiliate_status": "approved_tracking",
+    "affiliate_verified": true,
+    "affiliate_final_url": "https://www.aiassistworks.com/?via=coshuma",
     "affiliate_evidence_markers": [
-      "2026-09-08 browser requested a fresh code; company Gmail received latest AiAssistWorks verification email at 05:22 KST. Authentication succeeded and onboarding displayed signed in as support@coshuma.com, step 1 of 2, name empty and Korea, Republic of selected. OTP blocker resolved; onboarding and application submission are not complete. No code or token retained.",
-      "Resume existing authenticated onboarding when continuing account setup. Do not request another OTP while session remains valid. Do not mark submitted or approved until actual confirmation.",
+      "Existing support@coshuma.com authenticated session reused. Onboarding step 1 accepted name COSHUMA with the existing Korea, Republic of selection; step 2 accepted identifier coshuma and Complete was submitted once. Success Hub and the affiliate dashboard issued https://www.aiassistworks.com/?via=coshuma. Live Chrome opened the official customer product page with via=coshuma retained. Operational enrollment and issued tracking link confirmed; no separate approval email claimed. Before verification visit, dashboard showed 0 clicks, 0 conversions and $0 commission. Payout settings remain incomplete. No new OTP, additional agreement checkbox, paid action or duplicate application occurred. Link validation is not proof of a customer signup, sale or attributed commission.",
+      "Preserve the issued exact link and existing account; do not reapply. Payout setup remains incomplete and is separate from enrollment. Keep real customer signups, commissions and revenue at 0 without new evidence; verification visits are not customer activity.",
       "data/affiliate-submission-batch-2026-09-08.json"
     ],
-    "affiliate_status_checked_at": "2026-09-08",
-    "affiliate_status_evidence_url": "https://www.aiassistworks.com/affiliate-program",
-    "affiliate_workflow_url": "https://aiassistworks.affonso.io/onboarding",
-    "affiliate_next_action": "Resume existing authenticated onboarding when continuing account setup. Do not request another OTP while session remains valid. Do not mark submitted or approved until actual confirmation."
+    "affiliate_status_checked_at": "2026-09-08T05:29:50+09:00",
+    "affiliate_status_evidence_url": "https://aiassistworks.affonso.io/",
+    "affiliate_workflow_url": "https://aiassistworks.affonso.io/",
+    "affiliate_next_action": "Preserve the issued exact link and existing account; do not reapply. Payout setup remains incomplete and is separate from enrollment. Keep real customer signups, commissions and revenue at 0 without new evidence; verification visits are not customer activity.",
+    "affiliate_verified_at": "2026-09-08T05:29:50+09:00"
   },
   {
     "id": "vista-social",

--- a/projects/GlobalSaaSHub/data/tools.next.json
+++ b/projects/GlobalSaaSHub/data/tools.next.json
@@ -1628,19 +1628,20 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://aiassistworks.com/",
-    "affiliate_url": null,
-    "affiliate_status": "browser_required_onboarding",
-    "affiliate_verified": false,
-    "affiliate_final_url": null,
+    "affiliate_url": "https://www.aiassistworks.com/?via=coshuma",
+    "affiliate_status": "approved_tracking",
+    "affiliate_verified": true,
+    "affiliate_final_url": "https://www.aiassistworks.com/?via=coshuma",
     "affiliate_evidence_markers": [
-      "2026-09-08 browser requested a fresh code; company Gmail received latest AiAssistWorks verification email at 05:22 KST. Authentication succeeded and onboarding displayed signed in as support@coshuma.com, step 1 of 2, name empty and Korea, Republic of selected. OTP blocker resolved; onboarding and application submission are not complete. No code or token retained.",
-      "Resume existing authenticated onboarding when continuing account setup. Do not request another OTP while session remains valid. Do not mark submitted or approved until actual confirmation.",
+      "Existing support@coshuma.com authenticated session reused. Onboarding step 1 accepted name COSHUMA with the existing Korea, Republic of selection; step 2 accepted identifier coshuma and Complete was submitted once. Success Hub and the affiliate dashboard issued https://www.aiassistworks.com/?via=coshuma. Live Chrome opened the official customer product page with via=coshuma retained. Operational enrollment and issued tracking link confirmed; no separate approval email claimed. Before verification visit, dashboard showed 0 clicks, 0 conversions and $0 commission. Payout settings remain incomplete. No new OTP, additional agreement checkbox, paid action or duplicate application occurred. Link validation is not proof of a customer signup, sale or attributed commission.",
+      "Preserve the issued exact link and existing account; do not reapply. Payout setup remains incomplete and is separate from enrollment. Keep real customer signups, commissions and revenue at 0 without new evidence; verification visits are not customer activity.",
       "data/affiliate-submission-batch-2026-09-08.json"
     ],
-    "affiliate_status_checked_at": "2026-09-08",
-    "affiliate_status_evidence_url": "https://www.aiassistworks.com/affiliate-program",
-    "affiliate_workflow_url": "https://aiassistworks.affonso.io/onboarding",
-    "affiliate_next_action": "Resume existing authenticated onboarding when continuing account setup. Do not request another OTP while session remains valid. Do not mark submitted or approved until actual confirmation."
+    "affiliate_status_checked_at": "2026-09-08T05:29:50+09:00",
+    "affiliate_status_evidence_url": "https://aiassistworks.affonso.io/",
+    "affiliate_workflow_url": "https://aiassistworks.affonso.io/",
+    "affiliate_next_action": "Preserve the issued exact link and existing account; do not reapply. Payout setup remains incomplete and is separate from enrollment. Keep real customer signups, commissions and revenue at 0 without new evidence; verification visits are not customer activity.",
+    "affiliate_verified_at": "2026-09-08T05:29:50+09:00"
   },
   {
     "id": "vista-social",

--- a/projects/GlobalSaaSHub/public/compare/aiassistworks-vs-bolddesk.html
+++ b/projects/GlobalSaaSHub/public/compare/aiassistworks-vs-bolddesk.html
@@ -39,6 +39,7 @@
       body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
       h1, h2, h3 { font-family: 'Outfit', sans-serif; }
     </style>
+    <script defer src="/affiliate-attribution.js"></script>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
@@ -157,10 +158,11 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://aiassistworks.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get AiAssistWorks →</a>
-          <a href="https://www.bolddesk.com/?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get BoldDesk →</a>
+          <a data-cta="affiliate" data-tool-id="aiassistworks" data-cta-source="compare-generated-auto" href="https://www.aiassistworks.com/?via=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get AiAssistWorks →</a>
+          <a data-cta="affiliate" data-tool-id="bolddesk" data-cta-source="compare-existing-affiliate-auto" href="https://www.bolddesk.com/?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get BoldDesk →</a>
         </div>
-      </div>
+      </div>      <p data-affiliate-disclosure="compare" class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: Some buttons on this comparison use verified COSHUMA partner links. COSHUMA may earn a commission if you become a paying customer after using them, at no extra cost to you.</p>
+
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">

--- a/projects/GlobalSaaSHub/public/compare/aiassistworks-vs-notion-ai.html
+++ b/projects/GlobalSaaSHub/public/compare/aiassistworks-vs-notion-ai.html
@@ -39,6 +39,7 @@
       body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
       h1, h2, h3 { font-family: 'Outfit', sans-serif; }
     </style>
+    <script defer src="/affiliate-attribution.js"></script>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
@@ -157,10 +158,11 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://aiassistworks.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get AiAssistWorks →</a>
+          <a data-cta="affiliate" data-tool-id="aiassistworks" data-cta-source="compare-generated-auto" href="https://www.aiassistworks.com/?via=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get AiAssistWorks →</a>
           <a href="https://www.notion.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Notion AI →</a>
         </div>
-      </div>
+      </div>      <p data-affiliate-disclosure="compare" class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: Some buttons on this comparison use verified COSHUMA partner links. COSHUMA may earn a commission if you become a paying customer after using them, at no extra cost to you.</p>
+
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">

--- a/projects/GlobalSaaSHub/public/tool/aiassistworks.html
+++ b/projects/GlobalSaaSHub/public/tool/aiassistworks.html
@@ -34,6 +34,7 @@
       body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
       h1, h2, h3 { font-family: 'Outfit', sans-serif; }
     </style>
+    <script defer src="/affiliate-attribution.js"></script>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
     <!-- Header Navigation -->
@@ -125,7 +126,7 @@
             <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
           </div>
-          <a data-cta="official" href="https://aiassistworks.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official AiAssistWorks Site</span><span>→</span></a>
+          <a data-cta="affiliate" data-tool-id="aiassistworks" data-cta-source="tool-primary-auto" href="https://www.aiassistworks.com/?via=coshuma" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official AiAssistWorks Site</span><span>→</span></a>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->
@@ -143,9 +144,7 @@
             ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
           </div>
           <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim AiAssistWorks Profile ($49/yr)
-            </a>
+            <a data-cta="sponsorship-inquiry" data-cta-source="tool-legacy-normalized" href="mailto:support@coshuma.com?subject=COSHUMA%20%2449%20sponsorship%20inquiry&amp;body=Product%20name%3A%0AWebsite%3A%0APlacement%20goal%3A%0A" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">Request $49 sponsored placement →</a>
           </div>
           <div class="relative pt-2">
             <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
@@ -154,7 +153,8 @@
         </div>
 
 
-      </div>
+      </div>      <p data-affiliate-disclosure="tool" class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: This page may use a verified COSHUMA partner link. COSHUMA may earn a commission if you become a paying customer after using it, at no extra cost to you.</p>
+
     </main>
 
     <!-- Footer -->

--- a/projects/GlobalSaaSHub/scripts/browser_followup_evidence.mjs
+++ b/projects/GlobalSaaSHub/scripts/browser_followup_evidence.mjs
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { approvedTracking } from './approved_tracking_evidence.mjs';
 
 export const browserEvidencePath = 'data/affiliate-browser-followup-wave3-2026-09-08.json';
 export const browserFollowups = new Map(JSON.parse(fs.readFileSync(
@@ -17,8 +18,13 @@ export function applyBrowserFollowup(tool) {
   const approved = item.status === 'approved_tracking';
   if (approved) {
     const url = new URL(item.affiliate_url);
-    if (url.protocol !== 'https:' || !url.searchParams.get('ref') ||
-        item.status_origin !== 'existing_remote_record_preserved_not_new_approval') {
+    const existing = url.searchParams.get('ref') &&
+      item.status_origin === 'existing_remote_record_preserved_not_new_approval';
+    const issued = item.status_origin === 'authenticated_portal_issued_tracking' &&
+      item.portal_enrollment_confirmed === true && item.customer_landing_verified === true &&
+      approvedTracking.get(item.id)?.exact_tracking_url === item.affiliate_url &&
+      [...url.searchParams.values()].some(value => value.trim());
+    if (url.protocol !== 'https:' || (!existing && !issued)) {
       throw new Error(`Missing exact existing referral evidence: ${item.id}`);
     }
   }
@@ -28,11 +34,12 @@ export function applyBrowserFollowup(tool) {
     affiliate_verified: approved,
     affiliate_final_url: approved ? item.affiliate_url : null,
     affiliate_evidence_markers: [item.evidence, item.next_action, item.evidence_path || browserEvidencePath],
-    affiliate_status_checked_at: '2026-09-08',
-    affiliate_status_evidence_url: item.official_program_url || item.workflow_url,
+    affiliate_status_checked_at: item.checked_at || '2026-09-08',
+    affiliate_status_evidence_url: item.portal_enrollment_confirmed ? item.workflow_url : item.official_program_url || item.workflow_url,
     affiliate_workflow_url: item.workflow_url,
     affiliate_next_action: item.next_action,
   });
+  if (approved && item.checked_at) tool.affiliate_verified_at = item.checked_at;
   if (item.current_dashboard_status) {
     tool.affiliate_dashboard_status = item.current_dashboard_status;
     tool.affiliate_tracking_attribution_currently_verified = false;

--- a/projects/GlobalSaaSHub/scripts/sync_latest_affiliate_states.mjs
+++ b/projects/GlobalSaaSHub/scripts/sync_latest_affiliate_states.mjs
@@ -124,18 +124,6 @@ const states = {
       'Browser enrollment remains required; no exact customer tracking URL is verified yet',
     ],
   },
-  aiassistworks: {
-    affiliate_url: null,
-    affiliate_verified: true,
-    affiliate_status: 'browser_required_otp',
-    affiliate_source_url: 'https://www.aiassistworks.com/affiliate-program',
-    affiliate_verified_at: observedAt,
-    affiliate_evidence_markers: [
-      'The official AiAssistWorks Affonso flow was opened for support@coshuma.com',
-      'AiAssistWorks sent a one-time-password login email at 2026-09-08 03:21 KST',
-      'OTP/browser completion is required before an exact customer-facing affiliate URL can be recovered',
-    ],
-  },
   synder: {
     affiliate_url: null,
     affiliate_verified: true,

--- a/projects/GlobalSaaSHub/scripts/tests/browser-followup.test.mjs
+++ b/projects/GlobalSaaSHub/scripts/tests/browser-followup.test.mjs
@@ -21,7 +21,7 @@ function check() {
       assert.equal(q.length, 1, id);
       assert.equal(q[0].affiliate_status, t.affiliate_status, id);
       assert.equal(q[0].exact_tracking_url, t.affiliate_url, id);
-      if (t.affiliate_url) {
+      if (t.affiliate_url && evidence.current_dashboard_status === 'otp_required') {
         assert.equal(q[0].status, 'browser_required_otp');
         assert.equal(t.affiliate_tracking_attribution_currently_verified, false);
       }
@@ -51,8 +51,17 @@ assert.equal(state.typedesk.sender, 'qmfforfhem@gmail.com');
 assert.equal(state.typedesk.portal_enrollment_confirmed, false);
 assert.equal(state.n8n.application_state, 'submitted');
 assert.equal(state.webflow.application_state, 'submitted');
-assert.equal(state.aiassistworks.application_state, 'not_confirmed');
-assert.equal(state.aiassistworks.status, 'browser_required_onboarding');
+assert.equal(state.aiassistworks.application_state, 'submitted');
+assert.equal(state.aiassistworks.status, 'approved_tracking');
+assert.equal(state.aiassistworks.tracking_url, 'https://www.aiassistworks.com/?via=coshuma');
+assert.equal(state.aiassistworks.portal_enrollment_confirmed, true);
+assert.equal(queue.find(q => q.tool_id === 'aiassistworks').status, 'resolved');
+const issued = browserFollowups.get('aiassistworks');
+for (const patch of [{customer_landing_verified:false}, {portal_enrollment_confirmed:false}, {affiliate_url:'https://www.aiassistworks.com/'}, {affiliate_url:'https://aiassistworks.affonso.io/'}]) {
+  browserFollowups.set('aiassistworks', {...issued,...patch});
+  assert.throws(() => applyBrowserFollowup({id:'aiassistworks'}));
+}
+browserFollowups.set('aiassistworks', issued);
 assert.equal(state['novita-ai'].application_state, 'not_submitted');
 for (const id of ['n8n', 'novita-ai', 'typedesk']) {
   const stale = {id, affiliate_url: 'https://example.com/dashboard', affiliate_verified: true};


### PR DESCRIPTION
Completes the preserved AiAssistWorks onboarding for support@coshuma.com and records the exact portal-issued customer link https://www.aiassistworks.com/?via=coshuma. The authenticated Success Hub and dashboard issued the link, and a real browser verified the official landing page retained via=coshuma. Dashboard conversions and commission were 0; payout setup remains incomplete.

Updates authoritative evidence, outreach state, browser queue, both tool datasets and the three product/comparison CTAs. Deployment syncs now accept the evidenced portal-issued URL and reject a missing enrollment/landing confirmation or a generic URL. Removes the superseded AiAssistWorks OTP override.

Validation: production build; six affiliate data-contract tests; full link integrity; SEO regression checks; approved-tracking and built CTA verification; repeated deployment sync preservation; browser follow-up and Tagshop regression tests. No payment or duplicate application.
