### PR TITLE
fix(affiliate): record confirmed Airia and Joiin submissions

### DIFF
--- a/projects/GlobalSaaSHub/data/affiliate-submission-batch-2026-09-08.json
+++ b/projects/GlobalSaaSHub/data/affiliate-submission-batch-2026-09-08.json
@@ -43,6 +43,34 @@
       "customer_landing_verified": true,
       "checked_at": "2026-09-08T05:29:50+09:00",
       "payout_setup_complete": false
+    },
+    {
+      "id": "airia",
+      "status": "application_submitted",
+      "application_state": "submitted",
+      "review_state": "pending_review",
+      "affiliate_url": null,
+      "workflow_url": "https://dash.partnerstack.com/home",
+      "official_program_url": "https://airia.com/partners/",
+      "evidence": "Existing PartnerStack account support@coshuma.com reused. No Airia partnership matched before submission. Submitted the Airia application once with existing Sangkwon An / COSHUMA identity, https://coshuma.com, Korea Republic of, and Something else partnership type. PartnerStack then displayed Airia / Application pending, 0 clicks, 0 signups, $0.00 revenue, pending commissions and paid commissions. No tracking URL issued.",
+      "next_action": "Await review in the existing account; do not reapply or send duplicate outreach. Only record approved_tracking after actual approval and an issued exact customer-facing tracking URL are verified.",
+      "blockers": [],
+      "checked_at": "2026-09-08T05:50:35+09:00",
+      "current_dashboard_status": "Application pending"
+    },
+    {
+      "id": "joiin",
+      "status": "application_submitted",
+      "application_state": "submitted",
+      "review_state": "pending_review",
+      "affiliate_url": null,
+      "workflow_url": "https://app.getreditus.com/marketplace/joiin",
+      "official_program_url": "https://www.joiin.co/affiliate-partner-programme/",
+      "evidence": "Recovered the existing direct invitation from Joiin ticket 40896; private invite key is omitted. Existing support@coshuma.com affiliate account authenticated through Google. Direct invite resumed unrelated unfinished ReactIn onboarding; the existing Joiin program route exposed its application form. Submitted once with COSHUMA website, No for own product use, Yes for similar tools on the website, and required Joiin terms accepted under explicit user authorization. Actual confirmation: Partnership is pending review; Joiin will review your application and email when approved. Public Auto-accept marketing is not approval evidence. No new account, duplicate outreach, paid action, analytics integration, or customer tracking URL. Customer signups, commissions and revenue remain unverified and unchanged at 0.",
+      "next_action": "Await review in the existing account; do not reapply or send duplicate outreach. Only record approved_tracking after actual approval and an issued exact customer-facing tracking URL are verified.",
+      "blockers": [],
+      "checked_at": "2026-09-08T05:50:35+09:00",
+      "current_dashboard_status": "Partnership is pending review"
     }
   ]
 }

--- a/projects/GlobalSaaSHub/data/affiliate_outreach_state.json
+++ b/projects/GlobalSaaSHub/data/affiliate_outreach_state.json
@@ -347,6 +347,32 @@
       "portal_enrollment_confirmed": true,
       "verified_at": "2026-09-08T05:29:50+09:00",
       "payout_setup_complete": false
+    },
+    "airia": {
+      "status": "application_submitted",
+      "tracking_url": null,
+      "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+      "note": "Existing PartnerStack account support@coshuma.com reused. No Airia partnership matched before submission. Submitted the Airia application once with existing Sangkwon An / COSHUMA identity, https://coshuma.com, Korea Republic of, and Something else partnership type. PartnerStack then displayed Airia / Application pending, 0 clicks, 0 signups, $0.00 revenue, pending commissions and paid commissions. No tracking URL issued.",
+      "next_action": "Await review in the existing account; do not reapply or send duplicate outreach. Only record approved_tracking after actual approval and an issued exact customer-facing tracking URL are verified.",
+      "checked_date_kst": "2026-09-08",
+      "do_not_reapply": true,
+      "workflow_url": "https://dash.partnerstack.com/home",
+      "application_state": "submitted",
+      "review_state": "pending_review",
+      "blocker": null
+    },
+    "joiin": {
+      "status": "application_submitted",
+      "tracking_url": null,
+      "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+      "note": "Recovered the existing direct invitation from Joiin ticket 40896; private invite key is omitted. Existing support@coshuma.com affiliate account authenticated through Google. Direct invite resumed unrelated unfinished ReactIn onboarding; the existing Joiin program route exposed its application form. Submitted once with COSHUMA website, No for own product use, Yes for similar tools on the website, and required Joiin terms accepted under explicit user authorization. Actual confirmation: Partnership is pending review; Joiin will review your application and email when approved. Public Auto-accept marketing is not approval evidence. No new account, duplicate outreach, paid action, analytics integration, or customer tracking URL. Customer signups, commissions and revenue remain unverified and unchanged at 0.",
+      "next_action": "Await review in the existing account; do not reapply or send duplicate outreach. Only record approved_tracking after actual approval and an issued exact customer-facing tracking URL are verified.",
+      "checked_date_kst": "2026-09-08",
+      "do_not_reapply": true,
+      "workflow_url": "https://app.getreditus.com/marketplace/joiin",
+      "application_state": "submitted",
+      "review_state": "pending_review",
+      "blocker": null
     }
   }
 }

--- a/projects/GlobalSaaSHub/data/airia-partnerstack-browser-required-2026-09-08.md
+++ b/projects/GlobalSaaSHub/data/airia-partnerstack-browser-required-2026-09-08.md
@@ -1,5 +1,7 @@
 # Airia partner-program evidence — 2026-09-08
 
+> Superseded by authenticated browser submission on 2026-09-08: application_submitted / pending_review; affiliate_url remains null. See affiliate-submission-batch-2026-09-08.json. Historical pre-submission evidence follows.
+
 ## Current first-party program
 
 - Airia's current official partner page is `https://airia.com/partners/`.

--- a/projects/GlobalSaaSHub/data/browser_required_queue.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.json
@@ -558,5 +558,43 @@
     "application_submitted": true,
     "portal_enrollment_confirmed": true,
     "payout_setup_complete": false
+  },
+  {
+    "id": "airia-affiliate-browser-followup",
+    "tool_id": "airia",
+    "status": "resolved",
+    "affiliate_status": "application_submitted",
+    "cost": "0",
+    "exact_tracking_url": null,
+    "workflow_url": "https://dash.partnerstack.com/home",
+    "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+    "reason": "Existing PartnerStack account support@coshuma.com reused. No Airia partnership matched before submission. Submitted the Airia application once with existing Sangkwon An / COSHUMA identity, https://coshuma.com, Korea Republic of, and Something else partnership type. PartnerStack then displayed Airia / Application pending, 0 clicks, 0 signups, $0.00 revenue, pending commissions and paid commissions. No tracking URL issued.",
+    "next_action": "Await review in the existing account; do not reapply or send duplicate outreach. Only record approved_tracking after actual approval and an issued exact customer-facing tracking URL are verified.",
+    "verified_at": "2026-09-08T05:50:35+09:00",
+    "do_not": [
+      "Do not reapply or submit duplicate outreach.",
+      "Do not create a new account or pay.",
+      "Do not use a marketplace, invite, signup or dashboard URL as a revenue link.",
+      "Do not infer customer signups, commissions or revenue from submission."
+    ]
+  },
+  {
+    "id": "joiin-affiliate-browser-followup",
+    "tool_id": "joiin",
+    "status": "resolved",
+    "affiliate_status": "application_submitted",
+    "cost": "0",
+    "exact_tracking_url": null,
+    "workflow_url": "https://app.getreditus.com/marketplace/joiin",
+    "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+    "reason": "Recovered the existing direct invitation from Joiin ticket 40896; private invite key is omitted. Existing support@coshuma.com affiliate account authenticated through Google. Direct invite resumed unrelated unfinished ReactIn onboarding; the existing Joiin program route exposed its application form. Submitted once with COSHUMA website, No for own product use, Yes for similar tools on the website, and required Joiin terms accepted under explicit user authorization. Actual confirmation: Partnership is pending review; Joiin will review your application and email when approved. Public Auto-accept marketing is not approval evidence. No new account, duplicate outreach, paid action, analytics integration, or customer tracking URL. Customer signups, commissions and revenue remain unverified and unchanged at 0.",
+    "next_action": "Await review in the existing account; do not reapply or send duplicate outreach. Only record approved_tracking after actual approval and an issued exact customer-facing tracking URL are verified.",
+    "verified_at": "2026-09-08T05:50:35+09:00",
+    "do_not": [
+      "Do not reapply or submit duplicate outreach.",
+      "Do not create a new account or pay.",
+      "Do not use a marketplace, invite, signup or dashboard URL as a revenue link.",
+      "Do not infer customer signups, commissions or revenue from submission."
+    ]
   }
 ]

--- a/projects/GlobalSaaSHub/data/joiin-direct-invite-evidence-2026-09-07.md
+++ b/projects/GlobalSaaSHub/data/joiin-direct-invite-evidence-2026-09-07.md
@@ -1,5 +1,7 @@
 # Joiin direct affiliate invite evidence — 2026-09-07
 
+> Superseded by authenticated browser submission on 2026-09-08: application_submitted / pending_review; affiliate_url remains null. See affiliate-submission-batch-2026-09-08.json. Historical pre-submission evidence follows.
+
 ## Decision
 
 - `affiliate_url`: `null`

--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -4824,7 +4824,21 @@
     "pricing_source_final_url": "https://www.joiin.co/pricing/",
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
-    "official_evidence_url": "https://www.joiin.co/"
+    "official_evidence_url": "https://www.joiin.co/",
+    "affiliate_status": "application_submitted",
+    "affiliate_verified": false,
+    "affiliate_final_url": null,
+    "affiliate_evidence_markers": [
+      "Recovered the existing direct invitation from Joiin ticket 40896; private invite key is omitted. Existing support@coshuma.com affiliate account authenticated through Google. Direct invite resumed unrelated unfinished ReactIn onboarding; the existing Joiin program route exposed its application form. Submitted once with COSHUMA website, No for own product use, Yes for similar tools on the website, and required Joiin terms accepted under explicit user authorization. Actual confirmation: Partnership is pending review; Joiin will review your application and email when approved. Public Auto-accept marketing is not approval evidence. No new account, duplicate outreach, paid action, analytics integration, or customer tracking URL. Customer signups, commissions and revenue remain unverified and unchanged at 0.",
+      "Await review in the existing account; do not reapply or send duplicate outreach. Only record approved_tracking after actual approval and an issued exact customer-facing tracking URL are verified.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
+    "affiliate_status_checked_at": "2026-09-08T05:50:35+09:00",
+    "affiliate_status_evidence_url": "https://www.joiin.co/affiliate-partner-programme/",
+    "affiliate_workflow_url": "https://app.getreditus.com/marketplace/joiin",
+    "affiliate_next_action": "Await review in the existing account; do not reapply or send duplicate outreach. Only record approved_tracking after actual approval and an issued exact customer-facing tracking URL are verified.",
+    "affiliate_dashboard_status": "Partnership is pending review",
+    "affiliate_tracking_attribution_currently_verified": false
   },
   {
     "id": "agentworks",
@@ -4900,16 +4914,22 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-09-01T00:00:00Z",
     "official_evidence_url": "https://airia.com/partners/",
-    "affiliate_verified": true,
-    "affiliate_status": "blocked_partnerstack_marketplace_limited",
+    "affiliate_verified": false,
+    "affiliate_status": "application_submitted",
     "affiliate_source_url": "https://airia.com/partners/",
-    "affiliate_final_url": "https://dash.partnerstack.com/application?company=airia&group=default",
+    "affiliate_final_url": null,
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
     "affiliate_evidence_markers": [
-      "Referral partner",
-      "Apply",
-      "PartnerStack"
-    ]
+      "Existing PartnerStack account support@coshuma.com reused. No Airia partnership matched before submission. Submitted the Airia application once with existing Sangkwon An / COSHUMA identity, https://coshuma.com, Korea Republic of, and Something else partnership type. PartnerStack then displayed Airia / Application pending, 0 clicks, 0 signups, $0.00 revenue, pending commissions and paid commissions. No tracking URL issued.",
+      "Await review in the existing account; do not reapply or send duplicate outreach. Only record approved_tracking after actual approval and an issued exact customer-facing tracking URL are verified.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
+    "affiliate_status_checked_at": "2026-09-08T05:50:35+09:00",
+    "affiliate_status_evidence_url": "https://airia.com/partners/",
+    "affiliate_workflow_url": "https://dash.partnerstack.com/home",
+    "affiliate_next_action": "Await review in the existing account; do not reapply or send duplicate outreach. Only record approved_tracking after actual approval and an issued exact customer-facing tracking URL are verified.",
+    "affiliate_dashboard_status": "Application pending",
+    "affiliate_tracking_attribution_currently_verified": false
   },
   {
     "id": "omi-ai",

--- a/projects/GlobalSaaSHub/data/tools.next.json
+++ b/projects/GlobalSaaSHub/data/tools.next.json
@@ -4777,7 +4777,21 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://www.joiin.co/",
-    "affiliate_url": null
+    "affiliate_url": null,
+    "affiliate_status": "application_submitted",
+    "affiliate_verified": false,
+    "affiliate_final_url": null,
+    "affiliate_evidence_markers": [
+      "Recovered the existing direct invitation from Joiin ticket 40896; private invite key is omitted. Existing support@coshuma.com affiliate account authenticated through Google. Direct invite resumed unrelated unfinished ReactIn onboarding; the existing Joiin program route exposed its application form. Submitted once with COSHUMA website, No for own product use, Yes for similar tools on the website, and required Joiin terms accepted under explicit user authorization. Actual confirmation: Partnership is pending review; Joiin will review your application and email when approved. Public Auto-accept marketing is not approval evidence. No new account, duplicate outreach, paid action, analytics integration, or customer tracking URL. Customer signups, commissions and revenue remain unverified and unchanged at 0.",
+      "Await review in the existing account; do not reapply or send duplicate outreach. Only record approved_tracking after actual approval and an issued exact customer-facing tracking URL are verified.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
+    "affiliate_status_checked_at": "2026-09-08T05:50:35+09:00",
+    "affiliate_status_evidence_url": "https://www.joiin.co/affiliate-partner-programme/",
+    "affiliate_workflow_url": "https://app.getreditus.com/marketplace/joiin",
+    "affiliate_next_action": "Await review in the existing account; do not reapply or send duplicate outreach. Only record approved_tracking after actual approval and an issued exact customer-facing tracking URL are verified.",
+    "affiliate_dashboard_status": "Partnership is pending review",
+    "affiliate_tracking_attribution_currently_verified": false
   },
   {
     "id": "agentworks",
@@ -4850,16 +4864,22 @@
     "pricing_source_http_status": null,
     "pricing_source_final_url": null,
     "affiliate_url": null,
-    "affiliate_verified": true,
-    "affiliate_status": "blocked_partnerstack_marketplace_limited",
+    "affiliate_verified": false,
+    "affiliate_status": "application_submitted",
     "affiliate_source_url": "https://airia.com/partners/",
-    "affiliate_final_url": "https://dash.partnerstack.com/application?company=airia&group=default",
+    "affiliate_final_url": null,
     "affiliate_verified_at": "2026-09-01T00:00:00Z",
     "affiliate_evidence_markers": [
-      "Referral partner",
-      "Apply",
-      "PartnerStack"
-    ]
+      "Existing PartnerStack account support@coshuma.com reused. No Airia partnership matched before submission. Submitted the Airia application once with existing Sangkwon An / COSHUMA identity, https://coshuma.com, Korea Republic of, and Something else partnership type. PartnerStack then displayed Airia / Application pending, 0 clicks, 0 signups, $0.00 revenue, pending commissions and paid commissions. No tracking URL issued.",
+      "Await review in the existing account; do not reapply or send duplicate outreach. Only record approved_tracking after actual approval and an issued exact customer-facing tracking URL are verified.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
+    "affiliate_status_checked_at": "2026-09-08T05:50:35+09:00",
+    "affiliate_status_evidence_url": "https://airia.com/partners/",
+    "affiliate_workflow_url": "https://dash.partnerstack.com/home",
+    "affiliate_next_action": "Await review in the existing account; do not reapply or send duplicate outreach. Only record approved_tracking after actual approval and an issued exact customer-facing tracking URL are verified.",
+    "affiliate_dashboard_status": "Application pending",
+    "affiliate_tracking_attribution_currently_verified": false
   },
   {
     "id": "omi-ai",

--- a/projects/GlobalSaaSHub/scripts/tests/browser-followup.test.mjs
+++ b/projects/GlobalSaaSHub/scripts/tests/browser-followup.test.mjs
@@ -51,6 +51,12 @@ assert.equal(state.typedesk.sender, 'qmfforfhem@gmail.com');
 assert.equal(state.typedesk.portal_enrollment_confirmed, false);
 assert.equal(state.n8n.application_state, 'submitted');
 assert.equal(state.webflow.application_state, 'submitted');
+for (const id of ['airia', 'joiin']) {
+  assert.equal(state[id].status, 'application_submitted');
+  assert.equal(state[id].review_state, 'pending_review');
+  assert.equal(state[id].do_not_reapply, true);
+  assert.equal(queue.find(q => q.tool_id === id).status, 'resolved');
+}
 assert.equal(state.aiassistworks.application_state, 'submitted');
 assert.equal(state.aiassistworks.status, 'approved_tracking');
 assert.equal(state.aiassistworks.tracking_url, 'https://www.aiassistworks.com/?via=coshuma');
@@ -63,7 +69,7 @@ for (const patch of [{customer_landing_verified:false}, {portal_enrollment_confi
 }
 browserFollowups.set('aiassistworks', issued);
 assert.equal(state['novita-ai'].application_state, 'not_submitted');
-for (const id of ['n8n', 'novita-ai', 'typedesk']) {
+for (const id of ['n8n', 'novita-ai', 'typedesk', 'airia', 'joiin']) {
   const stale = {id, affiliate_url: 'https://example.com/dashboard', affiliate_verified: true};
   applyBrowserFollowup(stale);
   assert.equal(stale.affiliate_url, null);


### PR DESCRIPTION
Airia and Joiin applications were submitted once using the existing COSHUMA accounts. PartnerStack confirmed Airia / Application pending; Reditus confirmed Joiin / Partnership is pending review. Both remain application_submitted with null customer tracking URLs.

Update authoritative submission evidence, outreach state, browser queue and both tool catalogs. The existing deployment syncs consume this evidence before stale overrides; regression coverage now includes both programs and duplicate prevention. Historical pre-submission notes are marked superseded. No paid actions, new accounts or duplicate outreach occurred, and no new approval or revenue is claimed.

Validation: production build passed; browser-followup regression passed including two runs of both deployment sync scripts; link integrity passed for 151 tools and 152 pages; git diff check passed. No new approved tracking link was issued, so no CTA or SEO expansion is included.
