### PR TITLE
Publish eProfessor referral link and record the next affiliate batch

### DIFF
--- a/projects/GlobalSaaSHub/data/affiliate-batch-scan-2026-09-08-0620.json
+++ b/projects/GlobalSaaSHub/data/affiliate-batch-scan-2026-09-08-0620.json
@@ -28,7 +28,7 @@
     "account": "support@coshuma.com",
     "query": "in:anywhere {expandi framer krater activepieces nudgera featureshark surfeo eprofessor}",
     "result": "No matching messages before application and account creation; in:anywhere includes Spam and Trash.",
-    "existing_accounts": "Krater used existing authenticated Dub session; Framer email login returned new-account completion screen; eProfessor existing-account status remains unknown due Google popup interaction failure."
+    "existing_accounts": "Krater used the existing authenticated Dub session. Framer email authentication returned new-account setup and the free account was created. eProfessor Google popup failed; user-authorized email signup then created one account and issued an exact referral link. No pre-existing candidate messages were found in the company mailbox before these actions."
   },
   "other_screening": "Expandi requires 14 days active product use; no qualifying use evidence. Carv audience requirements not established. No official cash-affiliate path established for Activepieces, Nudgera, FeatureShark or Surfeo in this scan. Google Workspace not selected over dedicated SaaS/AI buyer-guide candidates.",
   "tools": [

--- a/projects/GlobalSaaSHub/data/affiliate-batch-scan-2026-09-08-0620.json
+++ b/projects/GlobalSaaSHub/data/affiliate-batch-scan-2026-09-08-0620.json
@@ -1,0 +1,1727 @@
+{
+  "checked_at": "2026-09-07T21:21:56.008052+00:00",
+  "main_sha": "af19c13423f242ddad36d8cefc6530a4543101ea",
+  "tool_count": 151,
+  "sources": [
+    "data/tools.json",
+    "data/tools.next.json",
+    "data/affiliate_outreach_state.json",
+    "data/browser_required_queue.json",
+    "scripts/sync_verified_affiliates.mjs",
+    "scripts/sync_latest_affiliate_states.mjs",
+    "data/affiliate-submission-batch-2026-09-08.json",
+    "data/affiliate-browser-followup-wave3-2026-09-08.json",
+    "data/approved-tracking-2026-09-08.json"
+  ],
+  "method": "Both deployed sync scripts were applied in an isolated checkout for screening; original main fields and evidence overrides were combined. Empty status never overrides existing enrollment evidence. Ranking is qualitative expected opportunity, not measured revenue.",
+  "selected_order": [
+    "framer",
+    "krater",
+    "eprofessor"
+  ],
+  "ranking_rationale": {
+    "framer": "Website-builder buyer-guide fit; official creator program advertises 50% for 12 months and manual applications without a required paid plan.",
+    "krater": "AI creator-suite buyer-guide fit; official Dub form offers 25% per sale for one year and no signup fee shown.",
+    "eprofessor": "Course-creator SaaS fit; official terms explicitly allow free Referral-Only Account and 20% of net profit while enrolled."
+  },
+  "pre_application_mail_check": {
+    "account": "support@coshuma.com",
+    "query": "in:anywhere {expandi framer krater activepieces nudgera featureshark surfeo eprofessor}",
+    "result": "No matching messages before application and account creation; in:anywhere includes Spam and Trash.",
+    "existing_accounts": "Krater used existing authenticated Dub session; Framer email login returned new-account completion screen; eProfessor existing-account status remains unknown due Google popup interaction failure."
+  },
+  "other_screening": "Expandi requires 14 days active product use; no qualifying use evidence. Carv audience requirements not established. No official cash-affiliate path established for Activepieces, Nudgera, FeatureShark or Surfeo in this scan. Google Workspace not selected over dedicated SaaS/AI buyer-guide candidates.",
+  "tools": [
+    {
+      "id": "gohighlevel",
+      "name": "GoHighLevel",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "notion-ai",
+      "name": "Notion AI",
+      "source_status": "program_closed_to_new_applicants",
+      "cross_checked_statuses": [
+        "program_closed_to_new_applicants"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "make-com",
+      "name": "Make.com",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "elevenlabs",
+      "name": "ElevenLabs",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "copy-ai",
+      "name": "Copy.ai",
+      "source_status": "no_affiliate_program",
+      "cross_checked_statuses": [
+        "no_affiliate_program"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "zenrows",
+      "name": "ZenRows",
+      "source_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "tubebuddy",
+      "name": "TubeBuddy",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "outlierkit",
+      "name": "OutlierKit",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "pictory",
+      "name": "Pictory",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "fliki",
+      "name": "Fliki",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "inkfluence-ai",
+      "name": "Inkfluence AI",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "jasper",
+      "name": "Jasper",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "enrollment_requested"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "writesonic",
+      "name": "Writesonic",
+      "source_status": "rejected",
+      "cross_checked_statuses": [
+        "rejected",
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "sudowrite",
+      "name": "Sudowrite",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "convertkit",
+      "name": "Kit (formerly ConvertKit)",
+      "source_status": "blocked_partnerstack_marketplace_limited",
+      "cross_checked_statuses": [
+        "blocked_partnerstack_marketplace_limited"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "quillbot",
+      "name": "QuillBot",
+      "source_status": "blocked_partnerstack_marketplace_limited",
+      "cross_checked_statuses": [
+        "blocked_partnerstack_marketplace_limited"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "text-cortex",
+      "name": "Text Cortex",
+      "source_status": "program_inactive",
+      "cross_checked_statuses": [
+        "program_inactive"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "vidiq",
+      "name": "VidIQ",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "bolddesk",
+      "name": "BoldDesk",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "brand24",
+      "name": "Brand24",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "socialchamp-io",
+      "name": "Social Champ",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "triple-whale",
+      "name": "Triple Whale",
+      "source_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "boldsign",
+      "name": "BoldSign",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "privy",
+      "name": "Privy",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "outreach_sent"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "aweber",
+      "name": "AWeber",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "unbounce",
+      "name": "Unbounce",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "moosend",
+      "name": "Moosend",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "reply-io",
+      "name": "Reply.io",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "enrollment_requested"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "omnisend",
+      "name": "Omnisend",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "time2book",
+      "name": "Time2book",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "semrush",
+      "name": "Semrush",
+      "source_status": "rejected",
+      "cross_checked_statuses": [
+        "rejected"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "hubspot",
+      "name": "HubSpot",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "rejected"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "kinsta",
+      "name": "Kinsta",
+      "source_status": "rejected",
+      "cross_checked_statuses": [
+        "rejected"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "shopify",
+      "name": "Shopify",
+      "source_status": "excluded_user_request",
+      "cross_checked_statuses": [
+        "excluded_user_request",
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "systeme-io",
+      "name": "Systeme.io",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "jotform",
+      "name": "Jotform",
+      "source_status": "approved_account",
+      "cross_checked_statuses": [
+        "approved_account",
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "webflow",
+      "name": "Webflow",
+      "source_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "queue_ids": [
+        "webflow-affiliate-browser-followup"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "reactin",
+      "name": "ReactIn",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "outreach_sent"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "synthesia",
+      "name": "Synthesia",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "octo-browser",
+      "name": "Octo Browser",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "outreach_sent"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "carv",
+      "name": "Carv",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "program_mismatch"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": "data/affiliate-candidate-triage-2026-09-08-0220.json"
+    },
+    {
+      "id": "jobhire",
+      "name": "JobHire",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "outreach_sent"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "aitable-ai",
+      "name": "AITable.ai",
+      "source_status": "program_inactive",
+      "cross_checked_statuses": [
+        "program_inactive"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "liftmycv",
+      "name": "LiftmyCV",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "blaze",
+      "name": "Blaze",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "outreach_sent"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "aiassistworks",
+      "name": "AiAssistWorks",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [
+        "aiassistworks-affiliate-browser-followup"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "vista-social",
+      "name": "Vista Social",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "gravity-forms",
+      "name": "Gravity Forms",
+      "source_status": "application_session_conflict",
+      "cross_checked_statuses": [
+        "application_session_conflict",
+        "application_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "sendcloud",
+      "name": "Sendcloud",
+      "source_status": "application_available_partnerstack",
+      "cross_checked_statuses": [
+        "application_available_partnerstack",
+        "application_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "alidropship",
+      "name": "AliDropship",
+      "source_status": "application_pending",
+      "cross_checked_statuses": [
+        "application_pending"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "nudgera",
+      "name": "Nudgera",
+      "source_status": null,
+      "cross_checked_statuses": [],
+      "queue_ids": [],
+      "decision": "not_selected_program_or_fit_unverified",
+      "additional_evidence": null
+    },
+    {
+      "id": "questmate",
+      "name": "Questmate",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "outreach_sent"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "merlin",
+      "name": "Merlin",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "decktopus",
+      "name": "Decktopus",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "dorik",
+      "name": "Dorik",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "rytr",
+      "name": "Rytr",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "frase",
+      "name": "Frase",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "heygen",
+      "name": "HeyGen",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "outreach_sent"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "veed",
+      "name": "VEED",
+      "source_status": "application_available_impact",
+      "cross_checked_statuses": [
+        "application_available_impact",
+        "application_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "reclaim-ai",
+      "name": "Reclaim AI",
+      "source_status": "application_page_unavailable",
+      "cross_checked_statuses": [
+        "application_page_unavailable",
+        "enrollment_requested"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "descript",
+      "name": "Descript",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "synder",
+      "name": "Synder",
+      "source_status": "application_page_unavailable",
+      "cross_checked_statuses": [
+        "application_page_unavailable",
+        "outreach_sent"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "gallabox",
+      "name": "Gallabox",
+      "source_status": "application_blocked_tax_id_captcha",
+      "cross_checked_statuses": [
+        "application_blocked_tax_id_captcha"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "panda-video",
+      "name": "Panda Video",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "surfer-seo",
+      "name": "Surfer SEO",
+      "source_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "murf-ai",
+      "name": "Murf AI",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "scalenut",
+      "name": "Scalenut",
+      "source_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "castmagic",
+      "name": "Castmagic",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "loopcv",
+      "name": "LoopCV",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "clickfunnels",
+      "name": "ClickFunnels",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "tapfiliate",
+      "name": "Tapfiliate",
+      "source_status": "application_blocked_captcha",
+      "cross_checked_statuses": [
+        "application_blocked_captcha",
+        "outreach_sent"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "getresponse",
+      "name": "GetResponse",
+      "source_status": "rejected",
+      "cross_checked_statuses": [
+        "rejected"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "kit",
+      "name": "Kit",
+      "source_status": "application_page_unavailable",
+      "cross_checked_statuses": [
+        "application_page_unavailable"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "teachable",
+      "name": "Teachable",
+      "source_status": "corporate_affiliate_program_not_found",
+      "cross_checked_statuses": [
+        "corporate_affiliate_program_not_found",
+        "outreach_sent"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "livechat",
+      "name": "LiveChat",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "existing_text_partner_account"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": "data/browser_required_queue.json"
+    },
+    {
+      "id": "kittl",
+      "name": "Kittl",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "koala-ai",
+      "name": "Koala AI",
+      "source_status": "campaign_registration_unavailable",
+      "cross_checked_statuses": [
+        "campaign_registration_unavailable"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "lovo",
+      "name": "Lovo",
+      "source_status": "application_blocked_vendor_site_paused",
+      "cross_checked_statuses": [
+        "application_blocked_vendor_site_paused"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "n8n",
+      "name": "n8n",
+      "source_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "queue_ids": [
+        "n8n-affiliate-browser-followup"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "novita-ai",
+      "name": "Novita AI",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [
+        "novita-ai-affiliate-browser-followup"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "followr",
+      "name": "Followr",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [
+        "followr-affiliate-browser-followup"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "10web",
+      "name": "10Web",
+      "source_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "supademo",
+      "name": "Supademo",
+      "source_status": "application_embed_unavailable",
+      "cross_checked_statuses": [
+        "application_embed_unavailable"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "colossyan",
+      "name": "Colossyan",
+      "source_status": "program_inactive",
+      "cross_checked_statuses": [
+        "program_inactive"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "beefree",
+      "name": "Beefree",
+      "source_status": "application_page_unavailable",
+      "cross_checked_statuses": [
+        "application_page_unavailable",
+        "application_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "apollo",
+      "name": "Apollo",
+      "source_status": "application_page_unavailable",
+      "cross_checked_statuses": [
+        "application_page_unavailable",
+        "rejected"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "getgenie",
+      "name": "GetGenie",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "activecampaign",
+      "name": "ActiveCampaign",
+      "source_status": "application_page_unavailable",
+      "cross_checked_statuses": [
+        "application_page_unavailable"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "sanebox",
+      "name": "Sanebox",
+      "source_status": "application_page_unavailable",
+      "cross_checked_statuses": [
+        "application_page_unavailable",
+        "outreach_sent"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "pipedrive",
+      "name": "Pipedrive",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "pending"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "framer",
+      "name": "Framer",
+      "source_status": null,
+      "cross_checked_statuses": [],
+      "queue_ids": [],
+      "decision": "selected",
+      "additional_evidence": null
+    },
+    {
+      "id": "monday-com",
+      "name": "Monday.com",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "pending"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "cartstack",
+      "name": "CartStack",
+      "source_status": "application_available",
+      "cross_checked_statuses": [
+        "application_available",
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "cloudways",
+      "name": "Cloudways",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "pending"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "featureshark",
+      "name": "FeatureShark",
+      "source_status": null,
+      "cross_checked_statuses": [],
+      "queue_ids": [],
+      "decision": "not_selected_program_or_fit_unverified",
+      "additional_evidence": null
+    },
+    {
+      "id": "clickup",
+      "name": "ClickUp",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "rejected"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": "data/clickup-affiliate-rejection-evidence-2026-08-25.md"
+    },
+    {
+      "id": "getgabs",
+      "name": "Getgabs",
+      "source_status": "application_available_instant",
+      "cross_checked_statuses": [
+        "application_available_instant",
+        "application_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "eprofessor",
+      "name": "eProfessor",
+      "source_status": null,
+      "cross_checked_statuses": [],
+      "queue_ids": [],
+      "decision": "selected",
+      "additional_evidence": null
+    },
+    {
+      "id": "docsbot",
+      "name": "DocsBot",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "surfeo",
+      "name": "Surfeo",
+      "source_status": null,
+      "cross_checked_statuses": [],
+      "queue_ids": [],
+      "decision": "not_selected_program_or_fit_unverified",
+      "additional_evidence": null
+    },
+    {
+      "id": "dub",
+      "name": "Dub",
+      "source_status": "application_not_submitted",
+      "cross_checked_statuses": [
+        "application_not_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "helpdesk",
+      "name": "HelpDesk",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "happyscribe",
+      "name": "HappyScribe",
+      "source_status": "beta_application_available",
+      "cross_checked_statuses": [
+        "beta_application_available"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "pickaxe",
+      "name": "Pickaxe",
+      "source_status": "application_available",
+      "cross_checked_statuses": [
+        "application_available",
+        "excluded_user_request"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "ai-video-cut",
+      "name": "AI Video Cut",
+      "source_status": "application_available_auto_approval",
+      "cross_checked_statuses": [
+        "application_available_auto_approval",
+        "application_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "tagshop-ai",
+      "name": "Tagshop AI",
+      "source_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "queue_ids": [
+        "tagshop-ai-affiliate-followup"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "text",
+      "name": "Text",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "typedesk",
+      "name": "Typedesk",
+      "source_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "queue_ids": [
+        "typedesk-affiliate-browser-followup"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "chatbot",
+      "name": "ChatBot",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "existing_text_partner_account"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": "data/browser_required_queue.json"
+    },
+    {
+      "id": "gojiberry",
+      "name": "Gojiberry",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [
+        "gojiberry-affiliate-browser-followup"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "bidx",
+      "name": "BidX",
+      "source_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "tidio",
+      "name": "Tidio",
+      "source_status": "application_available",
+      "cross_checked_statuses": [
+        "application_available",
+        "rejected"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": "data/tidio-affiliate-rejection-evidence-2026-08-25.md"
+    },
+    {
+      "id": "catalister",
+      "name": "Catalister",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [
+        "catalister-affiliate-followup"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "bookyourdata",
+      "name": "Bookyourdata",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "mindstudio",
+      "name": "MindStudio",
+      "source_status": "application_available_partnerstack",
+      "cross_checked_statuses": [
+        "application_available_partnerstack"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "manychat",
+      "name": "Manychat",
+      "source_status": "application_available_partnerstack",
+      "cross_checked_statuses": [
+        "application_available_partnerstack"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "synthflow-ai",
+      "name": "Synthflow AI",
+      "source_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "customgpt-ai",
+      "name": "CustomGPT.ai",
+      "source_status": "account_active_payout_setup_required",
+      "cross_checked_statuses": [
+        "account_active_payout_setup_required",
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "databox",
+      "name": "Databox",
+      "source_status": "application_pending",
+      "cross_checked_statuses": [
+        "application_pending",
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "fathom",
+      "name": "Fathom",
+      "source_status": "solution_partner_application_available",
+      "cross_checked_statuses": [
+        "solution_partner_application_available"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "taskip",
+      "name": "Taskip",
+      "source_status": "program_unavailable_ssl_error",
+      "cross_checked_statuses": [
+        "program_unavailable_ssl_error",
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "gumloop",
+      "name": "Gumloop",
+      "source_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "teknikforce",
+      "name": "Teknikforce",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "enrollment_requested"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "hide-me",
+      "name": "hide.me",
+      "source_status": "application_available",
+      "cross_checked_statuses": [
+        "application_available",
+        "application_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": "data/hideme-affiliate-application-evidence-2026-09-07.md"
+    },
+    {
+      "id": "snov-io",
+      "name": "Snov.io",
+      "source_status": "application_available",
+      "cross_checked_statuses": [
+        "application_available",
+        "enrollment_requested"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": "data/snov-affiliate-enrollment-evidence-2026-09-07.md"
+    },
+    {
+      "id": "claap",
+      "name": "Claap",
+      "source_status": "application_not_submitted",
+      "cross_checked_statuses": [
+        "application_not_submitted"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "cloudtalk",
+      "name": "CloudTalk",
+      "source_status": "application_available_partnerstack",
+      "cross_checked_statuses": [
+        "application_available_partnerstack"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "seamless",
+      "name": "Seamless",
+      "source_status": "application_blocked_region",
+      "cross_checked_statuses": [
+        "application_blocked_region"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "flowgent-ai",
+      "name": "FlowGent AI",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "existing_enrollment_conflict"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": "data/flowgent-affiliate-conflict-evidence-2026-09-07.md"
+    },
+    {
+      "id": "activepieces",
+      "name": "Activepieces",
+      "source_status": null,
+      "cross_checked_statuses": [],
+      "queue_ids": [],
+      "decision": "not_selected_program_or_fit_unverified",
+      "additional_evidence": null
+    },
+    {
+      "id": "marketingblocks",
+      "name": "MarketingBlocks",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "enrollment_requested"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "google-workspace",
+      "name": "Google Workspace",
+      "source_status": null,
+      "cross_checked_statuses": [],
+      "queue_ids": [],
+      "decision": "not_selected_program_or_fit_unverified",
+      "additional_evidence": null
+    },
+    {
+      "id": "chatbase",
+      "name": "Chatbase",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "krater",
+      "name": "Krater",
+      "source_status": null,
+      "cross_checked_statuses": [],
+      "queue_ids": [],
+      "decision": "selected",
+      "additional_evidence": null
+    },
+    {
+      "id": "expandi",
+      "name": "Expandi",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "eligibility_unverified"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": "https://expandi.io/affiliate-program/"
+    },
+    {
+      "id": "reditus",
+      "name": "Reditus",
+      "source_status": null,
+      "cross_checked_statuses": [
+        "enrollment_requested"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "joiin",
+      "name": "Joiin",
+      "source_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "queue_ids": [
+        "joiin-affiliate-browser-followup"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "agentworks",
+      "name": "AgentWorks",
+      "source_status": "referral_link_requested",
+      "cross_checked_statuses": [
+        "referral_link_requested"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "airia",
+      "name": "Airia",
+      "source_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "queue_ids": [
+        "airia-affiliate-browser-followup"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "omi-ai",
+      "name": "Omi AI",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "fireflies-ai",
+      "name": "Fireflies.ai",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "gamma",
+      "name": "Gamma",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "gobii",
+      "name": "Gobii",
+      "source_status": "program_unavailable_company_winding_down",
+      "cross_checked_statuses": [
+        "program_unavailable_company_winding_down"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "voibe",
+      "name": "Voibe",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "merlin-ai",
+      "name": "Merlin AI",
+      "source_status": "duplicate_do_not_apply",
+      "cross_checked_statuses": [
+        "duplicate_do_not_apply"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "speechify",
+      "name": "Speechify",
+      "source_status": "application_blocked_official_page_not_found",
+      "cross_checked_statuses": [
+        "application_blocked_official_page_not_found"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "babylovegrowth-ai",
+      "name": "BabyLoveGrowth.ai",
+      "source_status": "application_blocked_existing_reditus_onboarding",
+      "cross_checked_statuses": [
+        "application_blocked_existing_reditus_onboarding"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "ai-agent-store",
+      "name": "AI Agent Store",
+      "source_status": "application_blocked_affiliate_domain_ssl_error",
+      "cross_checked_statuses": [
+        "application_blocked_affiliate_domain_ssl_error"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "marblism",
+      "name": "Marblism",
+      "source_status": "account_active_payout_setup_required",
+      "cross_checked_statuses": [
+        "account_active_payout_setup_required",
+        "rejected"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "taskade",
+      "name": "Taskade",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    },
+    {
+      "id": "relevance-ai",
+      "name": "Relevance AI",
+      "source_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "queue_ids": [],
+      "decision": "excluded_existing_or_protected",
+      "additional_evidence": null
+    }
+  ]
+}

--- a/projects/GlobalSaaSHub/data/affiliate-submission-batch-2026-09-08.json
+++ b/projects/GlobalSaaSHub/data/affiliate-submission-batch-2026-09-08.json
@@ -112,18 +112,23 @@
     },
     {
       "id": "eprofessor",
-      "status": "browser_required_login",
-      "application_state": "not_submitted",
-      "affiliate_url": null,
+      "status": "approved_tracking",
+      "application_state": "submitted",
+      "affiliate_url": "https://eprofessor.com/invite/coshuma173",
       "workflow_url": "https://admin.eprofessor.com/referrals/",
       "official_program_url": "https://eprofessor.com/page/referral-program",
-      "portal_enrollment_confirmed": false,
-      "evidence": "Official terms explicitly permit a free Referral-Only Account and pay 20% of net profit, subject to continued enrollment and paid referrals. Company Gmail in:anywhere search had no matching prior messages. The official Referrals page redirected to login. Google account chooser displayed support@coshuma.com, but selection failed repeatedly with browser command timeouts, including a fresh popup. No authenticated dashboard, account creation, application submission or tracking URL was confirmed. Email signup requires a new password; none was created. Login screen retained for the user.",
-      "next_action": "Complete the existing Google company-account login, then inspect the Referrals page and existing enrollment before taking any signup action. No payment. Do not create a duplicate account.",
+      "portal_enrollment_confirmed": true,
+      "evidence": "After the Google popup failed, the user explicitly instructed completion of email signup. One free signup with COSHUMA and support@coshuma.com reached the authenticated Referrals dashboard. The dashboard issued this exact Your Referral Link and explicitly states it tracks who signs up through the account. Real Chrome opened the URL to the official customer product page. This is an account-specific issued referral path, not a generic invitation or administrative link. Operational enrollment and link issuance are confirmed; no separate approval email is claimed. Before validation, Net Earnings $0, Unpaid Balance $0, Active Subscribers 0 and Total signups 0. The dashboard says PayPal and W-9/W-8BEN setup are required before earning; payout and tax setup are incomplete and were not submitted. No payment or customer signup was performed. Validation views are not customer conversions.",
+      "next_action": "Preserve the existing account and exact issued referral link; do not reapply. PayPal and tax-document setup remain incomplete and require a separate user action before earnings can start, as stated by the dashboard. Keep real signups, commissions and revenue at 0 without evidence.",
       "blockers": [
-        "Google login popup interaction timeout; user login assistance requested"
+        "PayPal and tax setup incomplete; dashboard states required before earning"
       ],
-      "checked_at": "2026-09-07T21:21:56.008052+00:00"
+      "checked_at": "2026-09-07T21:24:29.148094+00:00",
+      "customer_landing_verified": true,
+      "customer_tracking_kind": "account_specific_referral_path",
+      "status_origin": "authenticated_portal_issued_tracking",
+      "payout_setup_complete": false,
+      "earning_setup_complete": false
     },
     {
       "id": "framer",

--- a/projects/GlobalSaaSHub/data/affiliate-submission-batch-2026-09-08.json
+++ b/projects/GlobalSaaSHub/data/affiliate-submission-batch-2026-09-08.json
@@ -95,6 +95,51 @@
       "checked_at": "2026-09-08T06:04:00+09:00",
       "current_dashboard_status": "unsupported_browser",
       "payout_setup_status": "unverified"
+    },
+    {
+      "id": "krater",
+      "status": "application_submitted",
+      "application_state": "submitted",
+      "review_state": "pending_review",
+      "affiliate_url": null,
+      "workflow_url": "https://partners.dub.co/kraterai/apply",
+      "official_program_url": "https://partners.dub.co/kraterai/apply",
+      "portal_enrollment_confirmed": true,
+      "evidence": "Authenticated Chrome: after a pre-application company Gmail in:anywhere search found no matching messages, the Dub application was submitted once with COSHUMA, support@coshuma.com, https://coshuma.com and factual buyer-guide promotion text. Program terms accepted under explicit user authorization. Step 2 of 2 displayed Application submitted and stated the review update will be sent to support@coshuma.com. The decorative dashboard illustration on this success page is not real account revenue or an issued referral link. No approval or exact tracking URL was issued.",
+      "next_action": "Await the existing Krater application review in Dub; do not reapply. Only publish an issued exact customer-facing link after approval evidence.",
+      "blockers": [],
+      "checked_at": "2026-09-07T21:21:56.008052+00:00"
+    },
+    {
+      "id": "eprofessor",
+      "status": "browser_required_login",
+      "application_state": "not_submitted",
+      "affiliate_url": null,
+      "workflow_url": "https://admin.eprofessor.com/referrals/",
+      "official_program_url": "https://eprofessor.com/page/referral-program",
+      "portal_enrollment_confirmed": false,
+      "evidence": "Official terms explicitly permit a free Referral-Only Account and pay 20% of net profit, subject to continued enrollment and paid referrals. Company Gmail in:anywhere search had no matching prior messages. The official Referrals page redirected to login. Google account chooser displayed support@coshuma.com, but selection failed repeatedly with browser command timeouts, including a fresh popup. No authenticated dashboard, account creation, application submission or tracking URL was confirmed. Email signup requires a new password; none was created. Login screen retained for the user.",
+      "next_action": "Complete the existing Google company-account login, then inspect the Referrals page and existing enrollment before taking any signup action. No payment. Do not create a duplicate account.",
+      "blockers": [
+        "Google login popup interaction timeout; user login assistance requested"
+      ],
+      "checked_at": "2026-09-07T21:21:56.008052+00:00"
+    },
+    {
+      "id": "framer",
+      "status": "browser_required_application_form",
+      "application_state": "not_submitted",
+      "affiliate_url": null,
+      "workflow_url": "https://www.framer.com/community/creator/?settings=open&settingsTab=links",
+      "official_program_url": "https://www.framer.com/creators",
+      "portal_enrollment_confirmed": false,
+      "account_created": true,
+      "evidence": "Official Creator Program advertises manual application from Community settings Links tab. Pre-action company Gmail in:anywhere search had no prior Framer messages. Email authentication was completed using the newly received verified team@framer.com activation message, and free account creation was completed as Sangkwon An under support@coshuma.com. Optional newsletter was unchecked. Official creator Links route redirected to /@sangkwon-an/?settings=open&settingsTab=links and displayed Page not found. Marketplace Account menu exposed Settings but no application form became available after activation. Account exists; affiliate submission, approval and tracking URL are not confirmed. No paid plan or marketplace product was created.",
+      "next_action": "Reuse the existing support@coshuma.com Framer account. Recover Community Settings > Links when the vendor route works; submit the manual creator application once. Do not recreate the account or publish a generic profile/dashboard URL as a referral link.",
+      "blockers": [
+        "Official Community Links route returns Page not found; Settings does not expose an application form"
+      ],
+      "checked_at": "2026-09-07T21:21:56.008052+00:00"
     }
   ]
 }

--- a/projects/GlobalSaaSHub/data/affiliate_outreach_state.json
+++ b/projects/GlobalSaaSHub/data/affiliate_outreach_state.json
@@ -390,20 +390,22 @@
       "review_state": "pending_review"
     },
     "eprofessor": {
-      "status": "browser_required_login",
-      "tracking_url": null,
+      "status": "approved_tracking",
+      "tracking_url": "https://eprofessor.com/invite/coshuma173",
       "account": "support@coshuma.com",
       "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
-      "note": "Official terms explicitly permit a free Referral-Only Account and pay 20% of net profit, subject to continued enrollment and paid referrals. Company Gmail in:anywhere search had no matching prior messages. The official Referrals page redirected to login. Google account chooser displayed support@coshuma.com, but selection failed repeatedly with browser command timeouts, including a fresh popup. No authenticated dashboard, account creation, application submission or tracking URL was confirmed. Email signup requires a new password; none was created. Login screen retained for the user.",
-      "next_action": "Complete the existing Google company-account login, then inspect the Referrals page and existing enrollment before taking any signup action. No payment. Do not create a duplicate account.",
+      "note": "After the Google popup failed, the user explicitly instructed completion of email signup. One free signup with COSHUMA and support@coshuma.com reached the authenticated Referrals dashboard. The dashboard issued this exact Your Referral Link and explicitly states it tracks who signs up through the account. Real Chrome opened the URL to the official customer product page. This is an account-specific issued referral path, not a generic invitation or administrative link. Operational enrollment and link issuance are confirmed; no separate approval email is claimed. Before validation, Net Earnings $0, Unpaid Balance $0, Active Subscribers 0 and Total signups 0. The dashboard says PayPal and W-9/W-8BEN setup are required before earning; payout and tax setup are incomplete and were not submitted. No payment or customer signup was performed. Validation views are not customer conversions.",
+      "next_action": "Preserve the existing account and exact issued referral link; do not reapply. PayPal and tax-document setup remain incomplete and require a separate user action before earnings can start, as stated by the dashboard. Keep real signups, commissions and revenue at 0 without evidence.",
       "checked_date_kst": "2026-09-08",
-      "application_state": "not_submitted",
-      "portal_enrollment_confirmed": false,
-      "do_not_reapply": false,
+      "application_state": "submitted",
+      "portal_enrollment_confirmed": true,
+      "do_not_reapply": true,
       "workflow_url": "https://admin.eprofessor.com/referrals/",
       "blockers": [
-        "Google login popup interaction timeout; user login assistance requested"
-      ]
+        "PayPal and tax setup incomplete; dashboard states required before earning"
+      ],
+      "payout_setup_complete": false,
+      "earning_setup_complete": false
     },
     "framer": {
       "status": "browser_required_application_form",

--- a/projects/GlobalSaaSHub/data/affiliate_outreach_state.json
+++ b/projects/GlobalSaaSHub/data/affiliate_outreach_state.json
@@ -373,6 +373,53 @@
       "application_state": "submitted",
       "review_state": "pending_review",
       "blocker": null
+    },
+    "krater": {
+      "status": "application_submitted",
+      "tracking_url": null,
+      "account": "support@coshuma.com",
+      "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+      "note": "Authenticated Chrome: after a pre-application company Gmail in:anywhere search found no matching messages, the Dub application was submitted once with COSHUMA, support@coshuma.com, https://coshuma.com and factual buyer-guide promotion text. Program terms accepted under explicit user authorization. Step 2 of 2 displayed Application submitted and stated the review update will be sent to support@coshuma.com. The decorative dashboard illustration on this success page is not real account revenue or an issued referral link. No approval or exact tracking URL was issued.",
+      "next_action": "Await the existing Krater application review in Dub; do not reapply. Only publish an issued exact customer-facing link after approval evidence.",
+      "checked_date_kst": "2026-09-08",
+      "application_state": "submitted",
+      "portal_enrollment_confirmed": true,
+      "do_not_reapply": true,
+      "workflow_url": "https://partners.dub.co/kraterai/apply",
+      "blockers": [],
+      "review_state": "pending_review"
+    },
+    "eprofessor": {
+      "status": "browser_required_login",
+      "tracking_url": null,
+      "account": "support@coshuma.com",
+      "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+      "note": "Official terms explicitly permit a free Referral-Only Account and pay 20% of net profit, subject to continued enrollment and paid referrals. Company Gmail in:anywhere search had no matching prior messages. The official Referrals page redirected to login. Google account chooser displayed support@coshuma.com, but selection failed repeatedly with browser command timeouts, including a fresh popup. No authenticated dashboard, account creation, application submission or tracking URL was confirmed. Email signup requires a new password; none was created. Login screen retained for the user.",
+      "next_action": "Complete the existing Google company-account login, then inspect the Referrals page and existing enrollment before taking any signup action. No payment. Do not create a duplicate account.",
+      "checked_date_kst": "2026-09-08",
+      "application_state": "not_submitted",
+      "portal_enrollment_confirmed": false,
+      "do_not_reapply": false,
+      "workflow_url": "https://admin.eprofessor.com/referrals/",
+      "blockers": [
+        "Google login popup interaction timeout; user login assistance requested"
+      ]
+    },
+    "framer": {
+      "status": "browser_required_application_form",
+      "tracking_url": null,
+      "account": "support@coshuma.com",
+      "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+      "note": "Official Creator Program advertises manual application from Community settings Links tab. Pre-action company Gmail in:anywhere search had no prior Framer messages. Email authentication was completed using the newly received verified team@framer.com activation message, and free account creation was completed as Sangkwon An under support@coshuma.com. Optional newsletter was unchecked. Official creator Links route redirected to /@sangkwon-an/?settings=open&settingsTab=links and displayed Page not found. Marketplace Account menu exposed Settings but no application form became available after activation. Account exists; affiliate submission, approval and tracking URL are not confirmed. No paid plan or marketplace product was created.",
+      "next_action": "Reuse the existing support@coshuma.com Framer account. Recover Community Settings > Links when the vendor route works; submit the manual creator application once. Do not recreate the account or publish a generic profile/dashboard URL as a referral link.",
+      "checked_date_kst": "2026-09-08",
+      "application_state": "not_submitted",
+      "portal_enrollment_confirmed": false,
+      "do_not_reapply": false,
+      "workflow_url": "https://www.framer.com/community/creator/?settings=open&settingsTab=links",
+      "blockers": [
+        "Official Community Links route returns Page not found; Settings does not expose an application form"
+      ]
     }
   }
 }

--- a/projects/GlobalSaaSHub/data/approved-tracking-2026-09-08.json
+++ b/projects/GlobalSaaSHub/data/approved-tracking-2026-09-08.json
@@ -136,6 +136,19 @@
       "checked_at": "2026-09-08T06:04:00+09:00",
       "status_origin": "authenticated_approval_email_issued_tracking",
       "source": "data/affiliate-submission-batch-2026-09-08.json"
+    },
+    {
+      "id": "eprofessor",
+      "platform": "eProfessor native referrals",
+      "status": "approved_tracking",
+      "exact_tracking_url": "https://eprofessor.com/invite/coshuma173",
+      "destination": "https://eprofessor.com/invite/coshuma173",
+      "evidence": "After the Google popup failed, the user explicitly instructed completion of email signup. One free signup with COSHUMA and support@coshuma.com reached the authenticated Referrals dashboard. The dashboard issued this exact Your Referral Link and explicitly states it tracks who signs up through the account. Real Chrome opened the URL to the official customer product page. This is an account-specific issued referral path, not a generic invitation or administrative link. Operational enrollment and link issuance are confirmed; no separate approval email is claimed. Before validation, Net Earnings $0, Unpaid Balance $0, Active Subscribers 0 and Total signups 0. The dashboard says PayPal and W-9/W-8BEN setup are required before earning; payout and tax setup are incomplete and were not submitted. No payment or customer signup was performed. Validation views are not customer conversions.",
+      "checked_at": "2026-09-07T21:24:29.148094+00:00",
+      "status_origin": "authenticated_portal_issued_tracking",
+      "source": "data/affiliate-submission-batch-2026-09-08.json",
+      "payout_setup_complete": false,
+      "earning_setup_complete": false
     }
   ]
 }

--- a/projects/GlobalSaaSHub/data/browser_required_queue.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.json
@@ -614,14 +614,16 @@
     "id": "eprofessor-affiliate-batch-20260908",
     "tool_id": "eprofessor",
     "priority": "high",
-    "status": "browser_required_login",
-    "affiliate_status": "browser_required_login",
-    "exact_tracking_url": null,
+    "status": "resolved",
+    "affiliate_status": "approved_tracking",
+    "exact_tracking_url": "https://eprofessor.com/invite/coshuma173",
     "cost": "0",
-    "verified_at": "2026-09-07T21:21:56.008052+00:00",
-    "reason": "Official terms explicitly permit a free Referral-Only Account and pay 20% of net profit, subject to continued enrollment and paid referrals. Company Gmail in:anywhere search had no matching prior messages. The official Referrals page redirected to login. Google account chooser displayed support@coshuma.com, but selection failed repeatedly with browser command timeouts, including a fresh popup. No authenticated dashboard, account creation, application submission or tracking URL was confirmed. Email signup requires a new password; none was created. Login screen retained for the user.",
-    "next_action": "Complete the existing Google company-account login, then inspect the Referrals page and existing enrollment before taking any signup action. No payment. Do not create a duplicate account.",
-    "evidence_file": "data/affiliate-submission-batch-2026-09-08.json"
+    "verified_at": "2026-09-07T21:24:29.148094+00:00",
+    "reason": "After the Google popup failed, the user explicitly instructed completion of email signup. One free signup with COSHUMA and support@coshuma.com reached the authenticated Referrals dashboard. The dashboard issued this exact Your Referral Link and explicitly states it tracks who signs up through the account. Real Chrome opened the URL to the official customer product page. This is an account-specific issued referral path, not a generic invitation or administrative link. Operational enrollment and link issuance are confirmed; no separate approval email is claimed. Before validation, Net Earnings $0, Unpaid Balance $0, Active Subscribers 0 and Total signups 0. The dashboard says PayPal and W-9/W-8BEN setup are required before earning; payout and tax setup are incomplete and were not submitted. No payment or customer signup was performed. Validation views are not customer conversions.",
+    "next_action": "Preserve the existing account and exact issued referral link; do not reapply. PayPal and tax-document setup remain incomplete and require a separate user action before earnings can start, as stated by the dashboard. Keep real signups, commissions and revenue at 0 without evidence.",
+    "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+    "payout_setup_complete": false,
+    "earning_setup_complete": false
   },
   {
     "id": "framer-affiliate-batch-20260908",

--- a/projects/GlobalSaaSHub/data/browser_required_queue.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.json
@@ -596,5 +596,44 @@
       "Do not use a marketplace, invite, signup or dashboard URL as a revenue link.",
       "Do not infer customer signups, commissions or revenue from submission."
     ]
+  },
+  {
+    "id": "krater-affiliate-batch-20260908",
+    "tool_id": "krater",
+    "priority": "high",
+    "status": "resolved",
+    "affiliate_status": "application_submitted",
+    "exact_tracking_url": null,
+    "cost": "0",
+    "verified_at": "2026-09-07T21:21:56.008052+00:00",
+    "reason": "Authenticated Chrome: after a pre-application company Gmail in:anywhere search found no matching messages, the Dub application was submitted once with COSHUMA, support@coshuma.com, https://coshuma.com and factual buyer-guide promotion text. Program terms accepted under explicit user authorization. Step 2 of 2 displayed Application submitted and stated the review update will be sent to support@coshuma.com. The decorative dashboard illustration on this success page is not real account revenue or an issued referral link. No approval or exact tracking URL was issued.",
+    "next_action": "Await the existing Krater application review in Dub; do not reapply. Only publish an issued exact customer-facing link after approval evidence.",
+    "evidence_file": "data/affiliate-submission-batch-2026-09-08.json"
+  },
+  {
+    "id": "eprofessor-affiliate-batch-20260908",
+    "tool_id": "eprofessor",
+    "priority": "high",
+    "status": "browser_required_login",
+    "affiliate_status": "browser_required_login",
+    "exact_tracking_url": null,
+    "cost": "0",
+    "verified_at": "2026-09-07T21:21:56.008052+00:00",
+    "reason": "Official terms explicitly permit a free Referral-Only Account and pay 20% of net profit, subject to continued enrollment and paid referrals. Company Gmail in:anywhere search had no matching prior messages. The official Referrals page redirected to login. Google account chooser displayed support@coshuma.com, but selection failed repeatedly with browser command timeouts, including a fresh popup. No authenticated dashboard, account creation, application submission or tracking URL was confirmed. Email signup requires a new password; none was created. Login screen retained for the user.",
+    "next_action": "Complete the existing Google company-account login, then inspect the Referrals page and existing enrollment before taking any signup action. No payment. Do not create a duplicate account.",
+    "evidence_file": "data/affiliate-submission-batch-2026-09-08.json"
+  },
+  {
+    "id": "framer-affiliate-batch-20260908",
+    "tool_id": "framer",
+    "priority": "high",
+    "status": "browser_required_application_form",
+    "affiliate_status": "browser_required_application_form",
+    "exact_tracking_url": null,
+    "cost": "0",
+    "verified_at": "2026-09-07T21:21:56.008052+00:00",
+    "reason": "Official Creator Program advertises manual application from Community settings Links tab. Pre-action company Gmail in:anywhere search had no prior Framer messages. Email authentication was completed using the newly received verified team@framer.com activation message, and free account creation was completed as Sangkwon An under support@coshuma.com. Optional newsletter was unchecked. Official creator Links route redirected to /@sangkwon-an/?settings=open&settingsTab=links and displayed Page not found. Marketplace Account menu exposed Settings but no application form became available after activation. Account exists; affiliate submission, approval and tracking URL are not confirmed. No paid plan or marketplace product was created.",
+    "next_action": "Reuse the existing support@coshuma.com Framer account. Recover Community Settings > Links when the vendor route works; submit the manual creator application once. Do not recreate the account or publish a generic profile/dashboard URL as a referral link.",
+    "evidence_file": "data/affiliate-submission-batch-2026-09-08.json"
   }
 ]

--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -3237,7 +3237,19 @@
     "is_manual_override": false,
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
-    "official_evidence_url": "https://framer.com/"
+    "official_evidence_url": "https://framer.com/",
+    "affiliate_status": "browser_required_application_form",
+    "affiliate_verified": false,
+    "affiliate_final_url": null,
+    "affiliate_evidence_markers": [
+      "Official Creator Program advertises manual application from Community settings Links tab. Pre-action company Gmail in:anywhere search had no prior Framer messages. Email authentication was completed using the newly received verified team@framer.com activation message, and free account creation was completed as Sangkwon An under support@coshuma.com. Optional newsletter was unchecked. Official creator Links route redirected to /@sangkwon-an/?settings=open&settingsTab=links and displayed Page not found. Marketplace Account menu exposed Settings but no application form became available after activation. Account exists; affiliate submission, approval and tracking URL are not confirmed. No paid plan or marketplace product was created.",
+      "Reuse the existing support@coshuma.com Framer account. Recover Community Settings > Links when the vendor route works; submit the manual creator application once. Do not recreate the account or publish a generic profile/dashboard URL as a referral link.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
+    "affiliate_status_checked_at": "2026-09-07T21:21:56.008052+00:00",
+    "affiliate_status_evidence_url": "https://www.framer.com/creators",
+    "affiliate_workflow_url": "https://www.framer.com/community/creator/?settings=open&settingsTab=links",
+    "affiliate_next_action": "Reuse the existing support@coshuma.com Framer account. Recover Community Settings > Links when the vendor route works; submit the manual creator application once. Do not recreate the account or publish a generic profile/dashboard URL as a referral link."
   },
   {
     "id": "monday-com",
@@ -3453,7 +3465,19 @@
     "is_manual_override": false,
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
-    "official_evidence_url": "https://eprofessor.com/"
+    "official_evidence_url": "https://eprofessor.com/",
+    "affiliate_status": "browser_required_login",
+    "affiliate_verified": false,
+    "affiliate_final_url": null,
+    "affiliate_evidence_markers": [
+      "Official terms explicitly permit a free Referral-Only Account and pay 20% of net profit, subject to continued enrollment and paid referrals. Company Gmail in:anywhere search had no matching prior messages. The official Referrals page redirected to login. Google account chooser displayed support@coshuma.com, but selection failed repeatedly with browser command timeouts, including a fresh popup. No authenticated dashboard, account creation, application submission or tracking URL was confirmed. Email signup requires a new password; none was created. Login screen retained for the user.",
+      "Complete the existing Google company-account login, then inspect the Referrals page and existing enrollment before taking any signup action. No payment. Do not create a duplicate account.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
+    "affiliate_status_checked_at": "2026-09-07T21:21:56.008052+00:00",
+    "affiliate_status_evidence_url": "https://eprofessor.com/page/referral-program",
+    "affiliate_workflow_url": "https://admin.eprofessor.com/referrals/",
+    "affiliate_next_action": "Complete the existing Google company-account login, then inspect the Referrals page and existing enrollment before taking any signup action. No payment. Do not create a duplicate account."
   },
   {
     "id": "docsbot",
@@ -4718,7 +4742,19 @@
     "pricing_source_final_url": "https://krater.ai/pricing",
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
-    "official_evidence_url": "https://krater.ai/"
+    "official_evidence_url": "https://krater.ai/",
+    "affiliate_status": "application_submitted",
+    "affiliate_verified": false,
+    "affiliate_final_url": null,
+    "affiliate_evidence_markers": [
+      "Authenticated Chrome: after a pre-application company Gmail in:anywhere search found no matching messages, the Dub application was submitted once with COSHUMA, support@coshuma.com, https://coshuma.com and factual buyer-guide promotion text. Program terms accepted under explicit user authorization. Step 2 of 2 displayed Application submitted and stated the review update will be sent to support@coshuma.com. The decorative dashboard illustration on this success page is not real account revenue or an issued referral link. No approval or exact tracking URL was issued.",
+      "Await the existing Krater application review in Dub; do not reapply. Only publish an issued exact customer-facing link after approval evidence.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
+    "affiliate_status_checked_at": "2026-09-07T21:21:56.008052+00:00",
+    "affiliate_status_evidence_url": "https://partners.dub.co/kraterai/apply",
+    "affiliate_workflow_url": "https://partners.dub.co/kraterai/apply",
+    "affiliate_next_action": "Await the existing Krater application review in Dub; do not reapply. Only publish an issued exact customer-facing link after approval evidence."
   },
   {
     "id": "expandi",

--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -3443,7 +3443,7 @@
     "category": "productivity",
     "category_display": "Productivity & SaaS",
     "description": "Cloud-based platform for creating, selling, and managing interactive e-learning courses and secure online assessments.",
-    "affiliate_url": null,
+    "affiliate_url": "https://eprofessor.com/invite/coshuma173",
     "pricing": "See official pricing",
     "key_features": [
       "Create interactive courses",
@@ -3466,18 +3466,19 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://eprofessor.com/",
-    "affiliate_status": "browser_required_login",
-    "affiliate_verified": false,
-    "affiliate_final_url": null,
+    "affiliate_status": "approved_tracking",
+    "affiliate_verified": true,
+    "affiliate_final_url": "https://eprofessor.com/invite/coshuma173",
     "affiliate_evidence_markers": [
-      "Official terms explicitly permit a free Referral-Only Account and pay 20% of net profit, subject to continued enrollment and paid referrals. Company Gmail in:anywhere search had no matching prior messages. The official Referrals page redirected to login. Google account chooser displayed support@coshuma.com, but selection failed repeatedly with browser command timeouts, including a fresh popup. No authenticated dashboard, account creation, application submission or tracking URL was confirmed. Email signup requires a new password; none was created. Login screen retained for the user.",
-      "Complete the existing Google company-account login, then inspect the Referrals page and existing enrollment before taking any signup action. No payment. Do not create a duplicate account.",
+      "After the Google popup failed, the user explicitly instructed completion of email signup. One free signup with COSHUMA and support@coshuma.com reached the authenticated Referrals dashboard. The dashboard issued this exact Your Referral Link and explicitly states it tracks who signs up through the account. Real Chrome opened the URL to the official customer product page. This is an account-specific issued referral path, not a generic invitation or administrative link. Operational enrollment and link issuance are confirmed; no separate approval email is claimed. Before validation, Net Earnings $0, Unpaid Balance $0, Active Subscribers 0 and Total signups 0. The dashboard says PayPal and W-9/W-8BEN setup are required before earning; payout and tax setup are incomplete and were not submitted. No payment or customer signup was performed. Validation views are not customer conversions.",
+      "Preserve the existing account and exact issued referral link; do not reapply. PayPal and tax-document setup remain incomplete and require a separate user action before earnings can start, as stated by the dashboard. Keep real signups, commissions and revenue at 0 without evidence.",
       "data/affiliate-submission-batch-2026-09-08.json"
     ],
-    "affiliate_status_checked_at": "2026-09-07T21:21:56.008052+00:00",
-    "affiliate_status_evidence_url": "https://eprofessor.com/page/referral-program",
+    "affiliate_status_checked_at": "2026-09-07T21:24:29.148094+00:00",
+    "affiliate_status_evidence_url": "https://admin.eprofessor.com/referrals/",
     "affiliate_workflow_url": "https://admin.eprofessor.com/referrals/",
-    "affiliate_next_action": "Complete the existing Google company-account login, then inspect the Referrals page and existing enrollment before taking any signup action. No payment. Do not create a duplicate account."
+    "affiliate_next_action": "Preserve the existing account and exact issued referral link; do not reapply. PayPal and tax-document setup remain incomplete and require a separate user action before earnings can start, as stated by the dashboard. Keep real signups, commissions and revenue at 0 without evidence.",
+    "affiliate_verified_at": "2026-09-07T21:24:29.148094+00:00"
   },
   {
     "id": "docsbot",

--- a/projects/GlobalSaaSHub/data/tools.next.json
+++ b/projects/GlobalSaaSHub/data/tools.next.json
@@ -3424,19 +3424,20 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://eprofessor.com/",
-    "affiliate_url": null,
-    "affiliate_status": "browser_required_login",
-    "affiliate_verified": false,
-    "affiliate_final_url": null,
+    "affiliate_url": "https://eprofessor.com/invite/coshuma173",
+    "affiliate_status": "approved_tracking",
+    "affiliate_verified": true,
+    "affiliate_final_url": "https://eprofessor.com/invite/coshuma173",
     "affiliate_evidence_markers": [
-      "Official terms explicitly permit a free Referral-Only Account and pay 20% of net profit, subject to continued enrollment and paid referrals. Company Gmail in:anywhere search had no matching prior messages. The official Referrals page redirected to login. Google account chooser displayed support@coshuma.com, but selection failed repeatedly with browser command timeouts, including a fresh popup. No authenticated dashboard, account creation, application submission or tracking URL was confirmed. Email signup requires a new password; none was created. Login screen retained for the user.",
-      "Complete the existing Google company-account login, then inspect the Referrals page and existing enrollment before taking any signup action. No payment. Do not create a duplicate account.",
+      "After the Google popup failed, the user explicitly instructed completion of email signup. One free signup with COSHUMA and support@coshuma.com reached the authenticated Referrals dashboard. The dashboard issued this exact Your Referral Link and explicitly states it tracks who signs up through the account. Real Chrome opened the URL to the official customer product page. This is an account-specific issued referral path, not a generic invitation or administrative link. Operational enrollment and link issuance are confirmed; no separate approval email is claimed. Before validation, Net Earnings $0, Unpaid Balance $0, Active Subscribers 0 and Total signups 0. The dashboard says PayPal and W-9/W-8BEN setup are required before earning; payout and tax setup are incomplete and were not submitted. No payment or customer signup was performed. Validation views are not customer conversions.",
+      "Preserve the existing account and exact issued referral link; do not reapply. PayPal and tax-document setup remain incomplete and require a separate user action before earnings can start, as stated by the dashboard. Keep real signups, commissions and revenue at 0 without evidence.",
       "data/affiliate-submission-batch-2026-09-08.json"
     ],
-    "affiliate_status_checked_at": "2026-09-07T21:21:56.008052+00:00",
-    "affiliate_status_evidence_url": "https://eprofessor.com/page/referral-program",
+    "affiliate_status_checked_at": "2026-09-07T21:24:29.148094+00:00",
+    "affiliate_status_evidence_url": "https://admin.eprofessor.com/referrals/",
     "affiliate_workflow_url": "https://admin.eprofessor.com/referrals/",
-    "affiliate_next_action": "Complete the existing Google company-account login, then inspect the Referrals page and existing enrollment before taking any signup action. No payment. Do not create a duplicate account."
+    "affiliate_next_action": "Preserve the existing account and exact issued referral link; do not reapply. PayPal and tax-document setup remain incomplete and require a separate user action before earnings can start, as stated by the dashboard. Keep real signups, commissions and revenue at 0 without evidence.",
+    "affiliate_verified_at": "2026-09-07T21:24:29.148094+00:00"
   },
   {
     "id": "docsbot",

--- a/projects/GlobalSaaSHub/data/tools.next.json
+++ b/projects/GlobalSaaSHub/data/tools.next.json
@@ -3196,7 +3196,19 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://framer.com/",
-    "affiliate_url": null
+    "affiliate_url": null,
+    "affiliate_status": "browser_required_application_form",
+    "affiliate_verified": false,
+    "affiliate_final_url": null,
+    "affiliate_evidence_markers": [
+      "Official Creator Program advertises manual application from Community settings Links tab. Pre-action company Gmail in:anywhere search had no prior Framer messages. Email authentication was completed using the newly received verified team@framer.com activation message, and free account creation was completed as Sangkwon An under support@coshuma.com. Optional newsletter was unchecked. Official creator Links route redirected to /@sangkwon-an/?settings=open&settingsTab=links and displayed Page not found. Marketplace Account menu exposed Settings but no application form became available after activation. Account exists; affiliate submission, approval and tracking URL are not confirmed. No paid plan or marketplace product was created.",
+      "Reuse the existing support@coshuma.com Framer account. Recover Community Settings > Links when the vendor route works; submit the manual creator application once. Do not recreate the account or publish a generic profile/dashboard URL as a referral link.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
+    "affiliate_status_checked_at": "2026-09-07T21:21:56.008052+00:00",
+    "affiliate_status_evidence_url": "https://www.framer.com/creators",
+    "affiliate_workflow_url": "https://www.framer.com/community/creator/?settings=open&settingsTab=links",
+    "affiliate_next_action": "Reuse the existing support@coshuma.com Framer account. Recover Community Settings > Links when the vendor route works; submit the manual creator application once. Do not recreate the account or publish a generic profile/dashboard URL as a referral link."
   },
   {
     "id": "monday-com",
@@ -3412,7 +3424,19 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://eprofessor.com/",
-    "affiliate_url": null
+    "affiliate_url": null,
+    "affiliate_status": "browser_required_login",
+    "affiliate_verified": false,
+    "affiliate_final_url": null,
+    "affiliate_evidence_markers": [
+      "Official terms explicitly permit a free Referral-Only Account and pay 20% of net profit, subject to continued enrollment and paid referrals. Company Gmail in:anywhere search had no matching prior messages. The official Referrals page redirected to login. Google account chooser displayed support@coshuma.com, but selection failed repeatedly with browser command timeouts, including a fresh popup. No authenticated dashboard, account creation, application submission or tracking URL was confirmed. Email signup requires a new password; none was created. Login screen retained for the user.",
+      "Complete the existing Google company-account login, then inspect the Referrals page and existing enrollment before taking any signup action. No payment. Do not create a duplicate account.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
+    "affiliate_status_checked_at": "2026-09-07T21:21:56.008052+00:00",
+    "affiliate_status_evidence_url": "https://eprofessor.com/page/referral-program",
+    "affiliate_workflow_url": "https://admin.eprofessor.com/referrals/",
+    "affiliate_next_action": "Complete the existing Google company-account login, then inspect the Referrals page and existing enrollment before taking any signup action. No payment. Do not create a duplicate account."
   },
   {
     "id": "docsbot",
@@ -4671,7 +4695,19 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://krater.ai/",
-    "affiliate_url": null
+    "affiliate_url": null,
+    "affiliate_status": "application_submitted",
+    "affiliate_verified": false,
+    "affiliate_final_url": null,
+    "affiliate_evidence_markers": [
+      "Authenticated Chrome: after a pre-application company Gmail in:anywhere search found no matching messages, the Dub application was submitted once with COSHUMA, support@coshuma.com, https://coshuma.com and factual buyer-guide promotion text. Program terms accepted under explicit user authorization. Step 2 of 2 displayed Application submitted and stated the review update will be sent to support@coshuma.com. The decorative dashboard illustration on this success page is not real account revenue or an issued referral link. No approval or exact tracking URL was issued.",
+      "Await the existing Krater application review in Dub; do not reapply. Only publish an issued exact customer-facing link after approval evidence.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
+    "affiliate_status_checked_at": "2026-09-07T21:21:56.008052+00:00",
+    "affiliate_status_evidence_url": "https://partners.dub.co/kraterai/apply",
+    "affiliate_workflow_url": "https://partners.dub.co/kraterai/apply",
+    "affiliate_next_action": "Await the existing Krater application review in Dub; do not reapply. Only publish an issued exact customer-facing link after approval evidence."
   },
   {
     "id": "expandi",

--- a/projects/GlobalSaaSHub/public/compare/eprofessor-vs-brand24.html
+++ b/projects/GlobalSaaSHub/public/compare/eprofessor-vs-brand24.html
@@ -39,6 +39,7 @@
       body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
       h1, h2, h3 { font-family: 'Outfit', sans-serif; }
     </style>
+    <script defer src="/affiliate-attribution.js"></script>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
@@ -157,10 +158,11 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://eprofessor.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get eProfessor →</a>
-          <a href="https://brand24.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Brand24 →</a>
+          <a data-cta="affiliate" data-tool-id="eprofessor" data-cta-source="compare-generated-auto" href="https://eprofessor.com/invite/coshuma173" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get eProfessor →</a>
+          <a data-cta="affiliate" data-tool-id="brand24" data-cta-source="compare-generated-auto" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Brand24 →</a>
         </div>
-      </div>
+      </div>      <p data-affiliate-disclosure="compare" class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: Some buttons on this comparison use verified COSHUMA partner links. COSHUMA may earn a commission if you become a paying customer after using them, at no extra cost to you.</p>
+
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">

--- a/projects/GlobalSaaSHub/public/compare/eprofessor-vs-text-cortex.html
+++ b/projects/GlobalSaaSHub/public/compare/eprofessor-vs-text-cortex.html
@@ -39,6 +39,7 @@
       body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
       h1, h2, h3 { font-family: 'Outfit', sans-serif; }
     </style>
+    <script defer src="/affiliate-attribution.js"></script>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
     <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
@@ -157,10 +158,11 @@
         </div>
 
         <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://eprofessor.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get eProfessor →</a>
+          <a data-cta="affiliate" data-tool-id="eprofessor" data-cta-source="compare-generated-auto" href="https://eprofessor.com/invite/coshuma173" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get eProfessor →</a>
           <a href="https://textcortex.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Text Cortex →</a>
         </div>
-      </div>
+      </div>      <p data-affiliate-disclosure="compare" class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: Some buttons on this comparison use verified COSHUMA partner links. COSHUMA may earn a commission if you become a paying customer after using them, at no extra cost to you.</p>
+
     </main>
 
     <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">

--- a/projects/GlobalSaaSHub/public/tool/eprofessor.html
+++ b/projects/GlobalSaaSHub/public/tool/eprofessor.html
@@ -34,6 +34,7 @@
       body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
       h1, h2, h3 { font-family: 'Outfit', sans-serif; }
     </style>
+    <script defer src="/affiliate-attribution.js"></script>
   </head>
   <body class="min-h-screen flex flex-col justify-between">
     <!-- Header Navigation -->
@@ -125,7 +126,7 @@
             <div class="text-xs uppercase font-bold text-slate-400 tracking-wider">Pricing Plan</div>
             <div class="text-xl font-extrabold text-emerald-400 mt-0.5">See official pricing</div>
           </div>
-          <a data-cta="official" href="https://eprofessor.com/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official eProfessor Site</span><span>→</span></a>
+          <a data-cta="affiliate" data-tool-id="eprofessor" data-cta-source="tool-primary-auto" href="https://eprofessor.com/invite/coshuma173" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl font-extrabold text-sm bg-slate-800 text-white text-center border border-slate-600 hover:bg-slate-700 transition-all flex items-center justify-center gap-2"><span>Visit Official eProfessor Site</span><span>→</span></a>
         </div>
 
         <!-- Claim Profile & Official Founder Badge Section -->
@@ -143,9 +144,7 @@
             ⚖️ <strong class="text-slate-300">Editorial Independence Disclosure:</strong> Claiming a profile or purchasing sponsorship does not guarantee or alter editorial ratings or ranking positions.
           </div>
           <div class="flex flex-col sm:flex-row items-center gap-3">
-            <a href="/#submit" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">
-              ⚡ Claim eProfessor Profile ($49/yr)
-            </a>
+            <a data-cta="sponsorship-inquiry" data-cta-source="tool-legacy-normalized" href="mailto:support@coshuma.com?subject=COSHUMA%20%2449%20sponsorship%20inquiry&amp;body=Product%20name%3A%0AWebsite%3A%0APlacement%20goal%3A%0A" class="w-full sm:w-auto px-4 py-2.5 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-bold text-xs text-center transition-all shadow-md">Request $49 sponsored placement →</a>
           </div>
           <div class="relative pt-2">
             <div class="text-[10px] font-bold text-slate-400 mb-1">Official Embed Badge Code:</div>
@@ -154,7 +153,8 @@
         </div>
 
 
-      </div>
+      </div>      <p data-affiliate-disclosure="tool" class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: This page may use a verified COSHUMA partner link. COSHUMA may earn a commission if you become a paying customer after using it, at no extra cost to you.</p>
+
     </main>
 
     <!-- Footer -->

--- a/projects/GlobalSaaSHub/scripts/browser_followup_evidence.mjs
+++ b/projects/GlobalSaaSHub/scripts/browser_followup_evidence.mjs
@@ -23,10 +23,15 @@ export function applyBrowserFollowup(tool) {
     const emailIssued = item.status_origin === 'authenticated_approval_email_issued_tracking' &&
       item.approval_email_confirmed === true && item.approval_email_recipient === 'support@coshuma.com' &&
       item.approval_email_sender === 'noreply-affiliates@tapfiliate.com';
+    // Native eProfessor referrals carry the issued account identifier in the path.
+    // Keep this narrow: a generic /invite or a dashboard must never pass this gate.
+    const accountPath = item.id === 'eprofessor' &&
+      item.customer_tracking_kind === 'account_specific_referral_path' &&
+      url.hostname === 'eprofessor.com' && /^\/invite\/[a-z0-9-]+$/i.test(url.pathname);
     const issued = (item.status_origin === 'authenticated_portal_issued_tracking' || emailIssued) &&
       item.portal_enrollment_confirmed === true && item.customer_landing_verified === true &&
       approvedTracking.get(item.id)?.exact_tracking_url === item.affiliate_url &&
-      [...url.searchParams.values()].some(value => value.trim());
+      (accountPath || [...url.searchParams.values()].some(value => value.trim()));
     if (url.protocol !== 'https:' || (!existing && !issued)) {
       throw new Error(`Missing exact existing referral evidence: ${item.id}`);
     }

--- a/projects/GlobalSaaSHub/scripts/tests/browser-followup.test.mjs
+++ b/projects/GlobalSaaSHub/scripts/tests/browser-followup.test.mjs
@@ -50,7 +50,7 @@ try {
 assert.equal(state.typedesk.sender, 'qmfforfhem@gmail.com');
 assert.equal(state.typedesk.portal_enrollment_confirmed, false);
 assert.equal(state.n8n.application_state, 'submitted');
-for (const [id, expected] of [['krater', 'application_submitted'], ['framer', 'browser_required_application_form'], ['eprofessor', 'browser_required_login']]) {
+for (const [id, expected] of [['krater', 'application_submitted'], ['framer', 'browser_required_application_form']]) {
   assert.equal(state[id].status, expected);
   assert.equal(state[id].tracking_url, null);
   const stale = {id, affiliate_url: 'https://example.com/dashboard', affiliate_verified: true};
@@ -62,7 +62,15 @@ for (const [id, expected] of [['krater', 'application_submitted'], ['framer', 'b
 assert.equal(state.krater.application_state, 'submitted');
 assert.equal(state.krater.do_not_reapply, true);
 assert.equal(state.framer.application_state, 'not_submitted');
-assert.equal(state.eprofessor.application_state, 'not_submitted');
+assert.equal(state.eprofessor.application_state, 'submitted');
+assert.equal(state.eprofessor.payout_setup_complete, false);
+assert.equal(state.eprofessor.earning_setup_complete, false);
+const eprofessor = browserFollowups.get('eprofessor');
+for (const patch of [{customer_landing_verified:false}, {portal_enrollment_confirmed:false}, {customer_tracking_kind:null}, {affiliate_url:'https://eprofessor.com/invite'}, {affiliate_url:'https://admin.eprofessor.com/referrals/'}, {affiliate_url:'https://eprofessor.com/invite/another-account'}]) {
+  browserFollowups.set('eprofessor', {...eprofessor,...patch});
+  assert.throws(() => applyBrowserFollowup({id:'eprofessor'}));
+}
+browserFollowups.set('eprofessor', eprofessor);
 assert.equal(state.webflow.application_state, 'submitted');
 for (const id of ['airia', 'joiin']) {
   assert.equal(state[id].status, 'application_submitted');

--- a/projects/GlobalSaaSHub/scripts/tests/browser-followup.test.mjs
+++ b/projects/GlobalSaaSHub/scripts/tests/browser-followup.test.mjs
@@ -50,6 +50,19 @@ try {
 assert.equal(state.typedesk.sender, 'qmfforfhem@gmail.com');
 assert.equal(state.typedesk.portal_enrollment_confirmed, false);
 assert.equal(state.n8n.application_state, 'submitted');
+for (const [id, expected] of [['krater', 'application_submitted'], ['framer', 'browser_required_application_form'], ['eprofessor', 'browser_required_login']]) {
+  assert.equal(state[id].status, expected);
+  assert.equal(state[id].tracking_url, null);
+  const stale = {id, affiliate_url: 'https://example.com/dashboard', affiliate_verified: true};
+  applyBrowserFollowup(stale);
+  assert.equal(stale.affiliate_status, expected);
+  assert.equal(stale.affiliate_url, null);
+  assert.equal(stale.affiliate_verified, false);
+}
+assert.equal(state.krater.application_state, 'submitted');
+assert.equal(state.krater.do_not_reapply, true);
+assert.equal(state.framer.application_state, 'not_submitted');
+assert.equal(state.eprofessor.application_state, 'not_submitted');
 assert.equal(state.webflow.application_state, 'submitted');
 for (const id of ['airia', 'joiin']) {
   assert.equal(state[id].status, 'application_submitted');


### PR DESCRIPTION
The 151-tool scan excludes existing applications and protected evidence before selecting Framer, Krater and eProfessor. Krater was submitted for review. eProfessor's free signup issued https://eprofessor.com/invite/coshuma173 in its authenticated Referrals dashboard; its official customer landing was verified and the link is applied to the detail page and two comparisons with disclosures and attribution. Framer's account was created, but its official Creator Links route returns Page not found, so its application is not marked submitted.

The sync guard accepts eProfessor's account-specific referral path only with matching authenticated issuance evidence, while rejecting generic invitations, dashboards and other account paths. Payout/tax setup remains incomplete; the eProfessor dashboard says this is required before earning. Customer signups, commissions and revenue remain at zero.

Validation: build, repeated state-sync/duplicate-prevention tests, malformed referral-path rejection, link integrity (151 tools) and public SEO integrity (386 English pages) passed.