### PR TITLE
Sync payout readiness and confirmed Framer outreach

### DIFF
--- a/projects/GlobalSaaSHub/data/affiliate-submission-batch-2026-09-08.json
+++ b/projects/GlobalSaaSHub/data/affiliate-submission-batch-2026-09-08.json
@@ -132,19 +132,20 @@
     },
     {
       "id": "framer",
-      "status": "browser_required_application_form",
+      "status": "outreach_sent",
       "application_state": "not_submitted",
       "affiliate_url": null,
       "workflow_url": "https://www.framer.com/community/creator/?settings=open&settingsTab=links",
       "official_program_url": "https://www.framer.com/creators",
       "portal_enrollment_confirmed": false,
       "account_created": true,
-      "evidence": "Official Creator Program advertises manual application from Community settings Links tab. Pre-action company Gmail in:anywhere search had no prior Framer messages. Email authentication was completed using the newly received verified team@framer.com activation message, and free account creation was completed as Sangkwon An under support@coshuma.com. Optional newsletter was unchecked. Official creator Links route redirected to /@sangkwon-an/?settings=open&settingsTab=links and displayed Page not found. Marketplace Account menu exposed Settings but no application form became available after activation. Account exists; affiliate submission, approval and tracking URL are not confirmed. No paid plan or marketplace product was created.",
-      "next_action": "Reuse the existing support@coshuma.com Framer account. Recover Community Settings > Links when the vendor route works; submit the manual creator application once. Do not recreate the account or publish a generic profile/dashboard URL as a referral link.",
+      "evidence": "Official Creator Program advertises manual application from Community settings Links tab. Pre-action company Gmail in:anywhere search had no prior Framer messages. Email authentication was completed using the newly received verified team@framer.com activation message, and free account creation was completed as Sangkwon An under support@coshuma.com. Optional newsletter was unchecked. Official creator Links route redirected to /@sangkwon-an/?settings=open&settingsTab=links and displayed Page not found. Marketplace Account menu exposed Settings but no application form became available after activation. Account exists; affiliate submission, approval and tracking URL are not confirmed. No paid plan or marketplace product was created. Newer main commit 02e5ba2 records Framer Creator Team outreach. Verified in the authenticated company Gmail UI: COSHUMA <support@coshuma.com> sent COSHUMA — Framer Creator Program / affiliate enrollment to creators@framer.com at 06:25 KST on 2026-09-08, requesting the current manual application path or activation of the Links application. Gmail message 1a07dc29ac469c2d; data/framer-creator-program-outreach-2026-09-08.md. This request is not an application submission or approval. No duplicate outreach sent in this task.",
+      "next_action": "Await the existing Framer Creator Team reply to the 06:25 KST company email. Do not send another request or recreate the account. If the vendor enables the Links application, resume the existing account and submit once; no tracking URL until issued and verified.",
       "blockers": [
         "Official Community Links route returns Page not found; Settings does not expose an application form"
       ],
-      "checked_at": "2026-09-07T21:21:56.008052+00:00"
+      "checked_at": "2026-09-07T21:21:56.008052+00:00",
+      "outreach_sent": true
     }
   ]
 }

--- a/projects/GlobalSaaSHub/data/affiliate_outreach_state.json
+++ b/projects/GlobalSaaSHub/data/affiliate_outreach_state.json
@@ -408,20 +408,22 @@
       "earning_setup_complete": false
     },
     "framer": {
-      "status": "browser_required_application_form",
+      "status": "outreach_sent",
       "tracking_url": null,
       "account": "support@coshuma.com",
       "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
-      "note": "Official Creator Program advertises manual application from Community settings Links tab. Pre-action company Gmail in:anywhere search had no prior Framer messages. Email authentication was completed using the newly received verified team@framer.com activation message, and free account creation was completed as Sangkwon An under support@coshuma.com. Optional newsletter was unchecked. Official creator Links route redirected to /@sangkwon-an/?settings=open&settingsTab=links and displayed Page not found. Marketplace Account menu exposed Settings but no application form became available after activation. Account exists; affiliate submission, approval and tracking URL are not confirmed. No paid plan or marketplace product was created.",
-      "next_action": "Reuse the existing support@coshuma.com Framer account. Recover Community Settings > Links when the vendor route works; submit the manual creator application once. Do not recreate the account or publish a generic profile/dashboard URL as a referral link.",
+      "note": "Official Creator Program advertises manual application from Community settings Links tab. Pre-action company Gmail in:anywhere search had no prior Framer messages. Email authentication was completed using the newly received verified team@framer.com activation message, and free account creation was completed as Sangkwon An under support@coshuma.com. Optional newsletter was unchecked. Official creator Links route redirected to /@sangkwon-an/?settings=open&settingsTab=links and displayed Page not found. Marketplace Account menu exposed Settings but no application form became available after activation. Account exists; affiliate submission, approval and tracking URL are not confirmed. No paid plan or marketplace product was created. Newer main commit 02e5ba2 records Framer Creator Team outreach. Verified in the authenticated company Gmail UI: COSHUMA <support@coshuma.com> sent COSHUMA — Framer Creator Program / affiliate enrollment to creators@framer.com at 06:25 KST on 2026-09-08, requesting the current manual application path or activation of the Links application. Gmail message 1a07dc29ac469c2d; data/framer-creator-program-outreach-2026-09-08.md. This request is not an application submission or approval. No duplicate outreach sent in this task.",
+      "next_action": "Await the existing Framer Creator Team reply to the 06:25 KST company email. Do not send another request or recreate the account. If the vendor enables the Links application, resume the existing account and submit once; no tracking URL until issued and verified.",
       "checked_date_kst": "2026-09-08",
       "application_state": "not_submitted",
       "portal_enrollment_confirmed": false,
-      "do_not_reapply": false,
+      "do_not_reapply": true,
       "workflow_url": "https://www.framer.com/community/creator/?settings=open&settingsTab=links",
       "blockers": [
         "Official Community Links route returns Page not found; Settings does not expose an application form"
-      ]
+      ],
+      "gmail_message_id": "1a07dc29ac469c2d",
+      "sender": "support@coshuma.com"
     }
   }
 }

--- a/projects/GlobalSaaSHub/data/browser_required_queue.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.json
@@ -629,13 +629,13 @@
     "id": "framer-affiliate-batch-20260908",
     "tool_id": "framer",
     "priority": "high",
-    "status": "browser_required_application_form",
-    "affiliate_status": "browser_required_application_form",
+    "status": "waiting_vendor_response",
+    "affiliate_status": "outreach_sent",
     "exact_tracking_url": null,
     "cost": "0",
     "verified_at": "2026-09-07T21:21:56.008052+00:00",
-    "reason": "Official Creator Program advertises manual application from Community settings Links tab. Pre-action company Gmail in:anywhere search had no prior Framer messages. Email authentication was completed using the newly received verified team@framer.com activation message, and free account creation was completed as Sangkwon An under support@coshuma.com. Optional newsletter was unchecked. Official creator Links route redirected to /@sangkwon-an/?settings=open&settingsTab=links and displayed Page not found. Marketplace Account menu exposed Settings but no application form became available after activation. Account exists; affiliate submission, approval and tracking URL are not confirmed. No paid plan or marketplace product was created.",
-    "next_action": "Reuse the existing support@coshuma.com Framer account. Recover Community Settings > Links when the vendor route works; submit the manual creator application once. Do not recreate the account or publish a generic profile/dashboard URL as a referral link.",
+    "reason": "Official Creator Program advertises manual application from Community settings Links tab. Pre-action company Gmail in:anywhere search had no prior Framer messages. Email authentication was completed using the newly received verified team@framer.com activation message, and free account creation was completed as Sangkwon An under support@coshuma.com. Optional newsletter was unchecked. Official creator Links route redirected to /@sangkwon-an/?settings=open&settingsTab=links and displayed Page not found. Marketplace Account menu exposed Settings but no application form became available after activation. Account exists; affiliate submission, approval and tracking URL are not confirmed. No paid plan or marketplace product was created. Newer main commit 02e5ba2 records Framer Creator Team outreach. Verified in the authenticated company Gmail UI: COSHUMA <support@coshuma.com> sent COSHUMA — Framer Creator Program / affiliate enrollment to creators@framer.com at 06:25 KST on 2026-09-08, requesting the current manual application path or activation of the Links application. Gmail message 1a07dc29ac469c2d; data/framer-creator-program-outreach-2026-09-08.md. This request is not an application submission or approval. No duplicate outreach sent in this task.",
+    "next_action": "Await the existing Framer Creator Team reply to the 06:25 KST company email. Do not send another request or recreate the account. If the vendor enables the Links application, resume the existing account and submit once; no tracking URL until issued and verified.",
     "evidence_file": "data/affiliate-submission-batch-2026-09-08.json"
   }
 ]

--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -3239,18 +3239,18 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://framer.com/",
-    "affiliate_status": "browser_required_application_form",
+    "affiliate_status": "outreach_sent",
     "affiliate_verified": false,
     "affiliate_final_url": null,
     "affiliate_evidence_markers": [
-      "Official Creator Program advertises manual application from Community settings Links tab. Pre-action company Gmail in:anywhere search had no prior Framer messages. Email authentication was completed using the newly received verified team@framer.com activation message, and free account creation was completed as Sangkwon An under support@coshuma.com. Optional newsletter was unchecked. Official creator Links route redirected to /@sangkwon-an/?settings=open&settingsTab=links and displayed Page not found. Marketplace Account menu exposed Settings but no application form became available after activation. Account exists; affiliate submission, approval and tracking URL are not confirmed. No paid plan or marketplace product was created.",
-      "Reuse the existing support@coshuma.com Framer account. Recover Community Settings > Links when the vendor route works; submit the manual creator application once. Do not recreate the account or publish a generic profile/dashboard URL as a referral link.",
+      "Official Creator Program advertises manual application from Community settings Links tab. Pre-action company Gmail in:anywhere search had no prior Framer messages. Email authentication was completed using the newly received verified team@framer.com activation message, and free account creation was completed as Sangkwon An under support@coshuma.com. Optional newsletter was unchecked. Official creator Links route redirected to /@sangkwon-an/?settings=open&settingsTab=links and displayed Page not found. Marketplace Account menu exposed Settings but no application form became available after activation. Account exists; affiliate submission, approval and tracking URL are not confirmed. No paid plan or marketplace product was created. Newer main commit 02e5ba2 records Framer Creator Team outreach. Verified in the authenticated company Gmail UI: COSHUMA <support@coshuma.com> sent COSHUMA — Framer Creator Program / affiliate enrollment to creators@framer.com at 06:25 KST on 2026-09-08, requesting the current manual application path or activation of the Links application. Gmail message 1a07dc29ac469c2d; data/framer-creator-program-outreach-2026-09-08.md. This request is not an application submission or approval. No duplicate outreach sent in this task.",
+      "Await the existing Framer Creator Team reply to the 06:25 KST company email. Do not send another request or recreate the account. If the vendor enables the Links application, resume the existing account and submit once; no tracking URL until issued and verified.",
       "data/affiliate-submission-batch-2026-09-08.json"
     ],
     "affiliate_status_checked_at": "2026-09-07T21:21:56.008052+00:00",
     "affiliate_status_evidence_url": "https://www.framer.com/creators",
     "affiliate_workflow_url": "https://www.framer.com/community/creator/?settings=open&settingsTab=links",
-    "affiliate_next_action": "Reuse the existing support@coshuma.com Framer account. Recover Community Settings > Links when the vendor route works; submit the manual creator application once. Do not recreate the account or publish a generic profile/dashboard URL as a referral link."
+    "affiliate_next_action": "Await the existing Framer Creator Team reply to the 06:25 KST company email. Do not send another request or recreate the account. If the vendor enables the Links application, resume the existing account and submit once; no tracking URL until issued and verified."
   },
   {
     "id": "monday-com",

--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -3478,7 +3478,8 @@
     "affiliate_status_evidence_url": "https://admin.eprofessor.com/referrals/",
     "affiliate_workflow_url": "https://admin.eprofessor.com/referrals/",
     "affiliate_next_action": "Preserve the existing account and exact issued referral link; do not reapply. PayPal and tax-document setup remain incomplete and require a separate user action before earnings can start, as stated by the dashboard. Keep real signups, commissions and revenue at 0 without evidence.",
-    "affiliate_verified_at": "2026-09-07T21:24:29.148094+00:00"
+    "affiliate_verified_at": "2026-09-07T21:24:29.148094+00:00",
+    "payout_setup_status": "incomplete"
   },
   {
     "id": "docsbot",

--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -1679,7 +1679,8 @@
     "affiliate_status_evidence_url": "https://aiassistworks.affonso.io/",
     "affiliate_workflow_url": "https://aiassistworks.affonso.io/",
     "affiliate_next_action": "Preserve the issued exact link and existing account; do not reapply. Payout setup remains incomplete and is separate from enrollment. Keep real customer signups, commissions and revenue at 0 without new evidence; verification visits are not customer activity.",
-    "affiliate_verified_at": "2026-09-08T05:29:50+09:00"
+    "affiliate_verified_at": "2026-09-08T05:29:50+09:00",
+    "payout_setup_status": "incomplete"
   },
   {
     "id": "vista-social",

--- a/projects/GlobalSaaSHub/data/tools.next.json
+++ b/projects/GlobalSaaSHub/data/tools.next.json
@@ -3437,7 +3437,8 @@
     "affiliate_status_evidence_url": "https://admin.eprofessor.com/referrals/",
     "affiliate_workflow_url": "https://admin.eprofessor.com/referrals/",
     "affiliate_next_action": "Preserve the existing account and exact issued referral link; do not reapply. PayPal and tax-document setup remain incomplete and require a separate user action before earnings can start, as stated by the dashboard. Keep real signups, commissions and revenue at 0 without evidence.",
-    "affiliate_verified_at": "2026-09-07T21:24:29.148094+00:00"
+    "affiliate_verified_at": "2026-09-07T21:24:29.148094+00:00",
+    "payout_setup_status": "incomplete"
   },
   {
     "id": "docsbot",

--- a/projects/GlobalSaaSHub/data/tools.next.json
+++ b/projects/GlobalSaaSHub/data/tools.next.json
@@ -1641,7 +1641,8 @@
     "affiliate_status_evidence_url": "https://aiassistworks.affonso.io/",
     "affiliate_workflow_url": "https://aiassistworks.affonso.io/",
     "affiliate_next_action": "Preserve the issued exact link and existing account; do not reapply. Payout setup remains incomplete and is separate from enrollment. Keep real customer signups, commissions and revenue at 0 without new evidence; verification visits are not customer activity.",
-    "affiliate_verified_at": "2026-09-08T05:29:50+09:00"
+    "affiliate_verified_at": "2026-09-08T05:29:50+09:00",
+    "payout_setup_status": "incomplete"
   },
   {
     "id": "vista-social",

--- a/projects/GlobalSaaSHub/data/tools.next.json
+++ b/projects/GlobalSaaSHub/data/tools.next.json
@@ -3198,18 +3198,18 @@
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://framer.com/",
     "affiliate_url": null,
-    "affiliate_status": "browser_required_application_form",
+    "affiliate_status": "outreach_sent",
     "affiliate_verified": false,
     "affiliate_final_url": null,
     "affiliate_evidence_markers": [
-      "Official Creator Program advertises manual application from Community settings Links tab. Pre-action company Gmail in:anywhere search had no prior Framer messages. Email authentication was completed using the newly received verified team@framer.com activation message, and free account creation was completed as Sangkwon An under support@coshuma.com. Optional newsletter was unchecked. Official creator Links route redirected to /@sangkwon-an/?settings=open&settingsTab=links and displayed Page not found. Marketplace Account menu exposed Settings but no application form became available after activation. Account exists; affiliate submission, approval and tracking URL are not confirmed. No paid plan or marketplace product was created.",
-      "Reuse the existing support@coshuma.com Framer account. Recover Community Settings > Links when the vendor route works; submit the manual creator application once. Do not recreate the account or publish a generic profile/dashboard URL as a referral link.",
+      "Official Creator Program advertises manual application from Community settings Links tab. Pre-action company Gmail in:anywhere search had no prior Framer messages. Email authentication was completed using the newly received verified team@framer.com activation message, and free account creation was completed as Sangkwon An under support@coshuma.com. Optional newsletter was unchecked. Official creator Links route redirected to /@sangkwon-an/?settings=open&settingsTab=links and displayed Page not found. Marketplace Account menu exposed Settings but no application form became available after activation. Account exists; affiliate submission, approval and tracking URL are not confirmed. No paid plan or marketplace product was created. Newer main commit 02e5ba2 records Framer Creator Team outreach. Verified in the authenticated company Gmail UI: COSHUMA <support@coshuma.com> sent COSHUMA — Framer Creator Program / affiliate enrollment to creators@framer.com at 06:25 KST on 2026-09-08, requesting the current manual application path or activation of the Links application. Gmail message 1a07dc29ac469c2d; data/framer-creator-program-outreach-2026-09-08.md. This request is not an application submission or approval. No duplicate outreach sent in this task.",
+      "Await the existing Framer Creator Team reply to the 06:25 KST company email. Do not send another request or recreate the account. If the vendor enables the Links application, resume the existing account and submit once; no tracking URL until issued and verified.",
       "data/affiliate-submission-batch-2026-09-08.json"
     ],
     "affiliate_status_checked_at": "2026-09-07T21:21:56.008052+00:00",
     "affiliate_status_evidence_url": "https://www.framer.com/creators",
     "affiliate_workflow_url": "https://www.framer.com/community/creator/?settings=open&settingsTab=links",
-    "affiliate_next_action": "Reuse the existing support@coshuma.com Framer account. Recover Community Settings > Links when the vendor route works; submit the manual creator application once. Do not recreate the account or publish a generic profile/dashboard URL as a referral link."
+    "affiliate_next_action": "Await the existing Framer Creator Team reply to the 06:25 KST company email. Do not send another request or recreate the account. If the vendor enables the Links application, resume the existing account and submit once; no tracking URL until issued and verified."
   },
   {
     "id": "monday-com",

--- a/projects/GlobalSaaSHub/scripts/browser_followup_evidence.mjs
+++ b/projects/GlobalSaaSHub/scripts/browser_followup_evidence.mjs
@@ -48,6 +48,9 @@ export function applyBrowserFollowup(tool) {
     affiliate_next_action: item.next_action,
   });
   if (approved && item.checked_at) tool.affiliate_verified_at = item.checked_at;
+  if (typeof item.payout_setup_complete === 'boolean') {
+    tool.payout_setup_status = item.payout_setup_complete ? 'complete' : 'incomplete';
+  }
   if (item.current_dashboard_status) {
     tool.affiliate_dashboard_status = item.current_dashboard_status;
     tool.affiliate_tracking_attribution_currently_verified = false;

--- a/projects/GlobalSaaSHub/scripts/tests/browser-followup.test.mjs
+++ b/projects/GlobalSaaSHub/scripts/tests/browser-followup.test.mjs
@@ -50,7 +50,7 @@ try {
 assert.equal(state.typedesk.sender, 'qmfforfhem@gmail.com');
 assert.equal(state.typedesk.portal_enrollment_confirmed, false);
 assert.equal(state.n8n.application_state, 'submitted');
-for (const [id, expected] of [['krater', 'application_submitted'], ['framer', 'browser_required_application_form']]) {
+for (const [id, expected] of [['krater', 'application_submitted'], ['framer', 'outreach_sent']]) {
   assert.equal(state[id].status, expected);
   assert.equal(state[id].tracking_url, null);
   const stale = {id, affiliate_url: 'https://example.com/dashboard', affiliate_verified: true};


### PR DESCRIPTION
Carry recorded payout_setup_complete evidence into the public affiliate audit for eProfessor and AiAssistWorks, so issued referral links do not hide incomplete payout setup.

Reconcile the newer Framer outreach evidence committed to main: the company Gmail UI confirms the 06:25 KST enrollment-path request to creators@framer.com. Preserve the existing account, mark outreach_sent without claiming application submission, and prevent another request while awaiting the reply.

Repeated browser-state sync, duplicate-prevention and exact referral evidence regression checks passed. No new customer, commission or revenue claim.