### PR TITLE
Record Koala and Speechify applications and Supademo form blocker

### DIFF
--- a/projects/GlobalSaaSHub/data/affiliate-batch-scan-2026-09-08-0633.json
+++ b/projects/GlobalSaaSHub/data/affiliate-batch-scan-2026-09-08-0633.json
@@ -1898,5 +1898,16 @@
       "prior_evidence": null,
       "queue_ids": []
     }
-  ]
+  ],
+  "pre_merge_queue_reconciliation": {
+    "main_sha": "7fbd1935ec547ae56fa141c1e8eb541d4e836a1a",
+    "note": "New sidecar queue entries arrived during the batch. ActiveCampaign remains protected by existing rejection evidence; eProfessor recovery marked resolved against already issued exact link. No candidate membership change."
+  },
+  "validation": {
+    "build": "passed",
+    "repeat_sync_and_duplicate_prevention": "passed",
+    "link_integrity": "151/151 tools and 152 pages passed",
+    "target_seo": "9 detail/comparison pages passed canonical, title, description, OG, schema, sitemap, no unissued affiliate CTA",
+    "existing_seo_regression": "public and dist passed"
+  }
 }

--- a/projects/GlobalSaaSHub/data/affiliate-batch-scan-2026-09-08-0633.json
+++ b/projects/GlobalSaaSHub/data/affiliate-batch-scan-2026-09-08-0633.json
@@ -1,0 +1,1902 @@
+{
+  "checked_at": "2026-09-07T21:35:04.579403+00:00",
+  "main_sha": "cf9ca081b0368d1c30a9bef91c5e9ee64e07b273",
+  "tool_count": 151,
+  "sources": [
+    "data/tools.json",
+    "data/tools.next.json",
+    "data/affiliate_outreach_state.json",
+    "data/browser_required_queue.json",
+    "scripts/sync_verified_affiliates.mjs",
+    "scripts/sync_latest_affiliate_states.mjs",
+    "data/affiliate-submission-batch-2026-09-08.json",
+    "data/affiliate-browser-followup-wave3-2026-09-08.json",
+    "data/approved-tracking-2026-09-08.json",
+    "data/activecampaign-affiliate-rejection-evidence-2026-08-28.md",
+    "data/affiliate-outreach-2026-09-07-1829.md"
+  ],
+  "method": "Rescanned all 151 current main records against deploy-effective sync results, prior full cross-source scan, authoritative outreach state, browser queue, and existing evidence documents. Status in tools.next alone is not eligibility. Existing rejection/enrollment evidence is protected even when a public route is available. Ranking is qualitative audience fit and official reward opportunity, not measured revenue.",
+  "selected_order": [
+    "koala-ai",
+    "speechify",
+    "supademo"
+  ],
+  "ranking_rationale": {
+    "koala-ai": "AI writing/SEO buyer-guide fit; current official email application replaces unavailable campaign registration; 30% lifetime recurring advertised.",
+    "speechify": "AI voice/productivity buyer-guide fit; current official plural /affiliates/ form works; 30% per eligible sale advertised.",
+    "supademo": "Direct B2B SaaS buyer-guide fit; explicitly free without product subscription; 30% recurring advertised, but current official form connection blocks submission."
+  },
+  "pre_application_mail_check": {
+    "account": "support@coshuma.com",
+    "queries": [
+      "in:anywhere {supademo speechify \"workspace referral\" \"Workspace 추천\"}",
+      "in:anywhere koala"
+    ],
+    "result": "No matching messages before actions. in:anywhere includes Spam and Trash."
+  },
+  "excluded_conflicts": {
+    "activecampaign": "Existing rejection evidence message 1a049ba49a81c468 conflicts with a newer public-route-only note. Public availability does not reverse account rejection. No reapplication.",
+    "manychat": "Existing official-path request to PartnerStack is recorded in affiliate-outreach-2026-09-07-1829.md; no duplicate.",
+    "google-workspace": "Official affiliate program targets 100+ users per year; that qualification is not established. Referral program country list does not establish South Korea eligibility. Not selected."
+  },
+  "paid_actions": 0,
+  "customer_signups": 0,
+  "commissions": 0,
+  "revenue": 0,
+  "tools": [
+    {
+      "id": "gohighlevel",
+      "name": "GoHighLevel",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "notion-ai",
+      "name": "Notion AI",
+      "source_status": "program_closed_to_new_applicants",
+      "deploy_effective_status": "program_closed_to_new_applicants",
+      "cross_checked_statuses": [
+        "program_closed_to_new_applicants"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "make-com",
+      "name": "Make.com",
+      "source_status": "blocked_requires_active_wise_account",
+      "deploy_effective_status": "blocked_requires_active_wise_account",
+      "cross_checked_statuses": [
+        "approved_tracking",
+        "blocked_requires_active_wise_account"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "elevenlabs",
+      "name": "ElevenLabs",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "copy-ai",
+      "name": "Copy.ai",
+      "source_status": "no_affiliate_program",
+      "deploy_effective_status": "no_affiliate_program",
+      "cross_checked_statuses": [
+        "no_affiliate_program"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "zenrows",
+      "name": "ZenRows",
+      "source_status": "application_submitted",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "tubebuddy",
+      "name": "TubeBuddy",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "outlierkit",
+      "name": "OutlierKit",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "pictory",
+      "name": "Pictory",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "fliki",
+      "name": "Fliki",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "inkfluence-ai",
+      "name": "Inkfluence AI",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "jasper",
+      "name": "Jasper",
+      "source_status": null,
+      "deploy_effective_status": "enrollment_requested",
+      "cross_checked_statuses": [
+        "enrollment_requested"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "writesonic",
+      "name": "Writesonic",
+      "source_status": "rejected",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking",
+        "rejected"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "sudowrite",
+      "name": "Sudowrite",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "convertkit",
+      "name": "Kit (formerly ConvertKit)",
+      "source_status": "blocked_partnerstack_marketplace_limited",
+      "deploy_effective_status": "blocked_partnerstack_marketplace_limited",
+      "cross_checked_statuses": [
+        "blocked_partnerstack_marketplace_limited"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "quillbot",
+      "name": "QuillBot",
+      "source_status": "blocked_partnerstack_marketplace_limited",
+      "deploy_effective_status": "blocked_partnerstack_marketplace_limited",
+      "cross_checked_statuses": [
+        "blocked_partnerstack_marketplace_limited"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "text-cortex",
+      "name": "Text Cortex",
+      "source_status": "program_inactive",
+      "deploy_effective_status": "program_inactive",
+      "cross_checked_statuses": [
+        "program_inactive"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "vidiq",
+      "name": "VidIQ",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "bolddesk",
+      "name": "BoldDesk",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "brand24",
+      "name": "Brand24",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "socialchamp-io",
+      "name": "Social Champ",
+      "source_status": null,
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "triple-whale",
+      "name": "Triple Whale",
+      "source_status": "application_submitted",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "boldsign",
+      "name": "BoldSign",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "privy",
+      "name": "Privy",
+      "source_status": null,
+      "deploy_effective_status": "outreach_sent",
+      "cross_checked_statuses": [
+        "outreach_sent"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "aweber",
+      "name": "AWeber",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "unbounce",
+      "name": "Unbounce",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "moosend",
+      "name": "Moosend",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "reply-io",
+      "name": "Reply.io",
+      "source_status": null,
+      "deploy_effective_status": "enrollment_requested",
+      "cross_checked_statuses": [
+        "enrollment_requested"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "omnisend",
+      "name": "Omnisend",
+      "source_status": null,
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "time2book",
+      "name": "Time2book",
+      "source_status": null,
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "semrush",
+      "name": "Semrush",
+      "source_status": "rejected",
+      "deploy_effective_status": "rejected",
+      "cross_checked_statuses": [
+        "rejected"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "hubspot",
+      "name": "HubSpot",
+      "source_status": null,
+      "deploy_effective_status": "rejected",
+      "cross_checked_statuses": [
+        "rejected"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "kinsta",
+      "name": "Kinsta",
+      "source_status": null,
+      "deploy_effective_status": null,
+      "cross_checked_statuses": [
+        "rejected"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "shopify",
+      "name": "Shopify",
+      "source_status": "excluded_user_request",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking",
+        "excluded_user_request"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "systeme-io",
+      "name": "Systeme.io",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "jotform",
+      "name": "Jotform",
+      "source_status": null,
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_account",
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "webflow",
+      "name": "Webflow",
+      "source_status": "application_submitted",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": [
+        "webflow-affiliate-browser-followup"
+      ]
+    },
+    {
+      "id": "reactin",
+      "name": "ReactIn",
+      "source_status": null,
+      "deploy_effective_status": "outreach_sent",
+      "cross_checked_statuses": [
+        "outreach_sent"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "synthesia",
+      "name": "Synthesia",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "octo-browser",
+      "name": "Octo Browser",
+      "source_status": null,
+      "deploy_effective_status": "outreach_sent",
+      "cross_checked_statuses": [
+        "outreach_sent"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "carv",
+      "name": "Carv",
+      "source_status": null,
+      "deploy_effective_status": null,
+      "cross_checked_statuses": [
+        "program_mismatch"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": "data/affiliate-candidate-triage-2026-09-08-0220.json",
+      "queue_ids": []
+    },
+    {
+      "id": "jobhire",
+      "name": "JobHire",
+      "source_status": null,
+      "deploy_effective_status": "outreach_sent",
+      "cross_checked_statuses": [
+        "outreach_sent"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "aitable-ai",
+      "name": "AITable.ai",
+      "source_status": "program_inactive",
+      "deploy_effective_status": "program_inactive",
+      "cross_checked_statuses": [
+        "program_inactive"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "liftmycv",
+      "name": "LiftmyCV",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "blaze",
+      "name": "Blaze",
+      "source_status": null,
+      "deploy_effective_status": "outreach_sent",
+      "cross_checked_statuses": [
+        "outreach_sent"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "aiassistworks",
+      "name": "AiAssistWorks",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": [
+        "aiassistworks-affiliate-browser-followup"
+      ]
+    },
+    {
+      "id": "vista-social",
+      "name": "Vista Social",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "gravity-forms",
+      "name": "Gravity Forms",
+      "source_status": "application_session_conflict",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_session_conflict",
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "sendcloud",
+      "name": "Sendcloud",
+      "source_status": "application_available_partnerstack",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_available_partnerstack",
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "alidropship",
+      "name": "AliDropship",
+      "source_status": "application_pending",
+      "deploy_effective_status": "application_pending",
+      "cross_checked_statuses": [
+        "application_pending"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "nudgera",
+      "name": "Nudgera",
+      "source_status": null,
+      "deploy_effective_status": null,
+      "cross_checked_statuses": [],
+      "decision": "not_selected_program_or_fit_unverified",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "questmate",
+      "name": "Questmate",
+      "source_status": null,
+      "deploy_effective_status": "outreach_sent",
+      "cross_checked_statuses": [
+        "outreach_sent"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "merlin",
+      "name": "Merlin",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "decktopus",
+      "name": "Decktopus",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "dorik",
+      "name": "Dorik",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "rytr",
+      "name": "Rytr",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "frase",
+      "name": "Frase",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "heygen",
+      "name": "HeyGen",
+      "source_status": null,
+      "deploy_effective_status": "outreach_sent",
+      "cross_checked_statuses": [
+        "outreach_sent"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "veed",
+      "name": "VEED",
+      "source_status": "application_available_impact",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_available_impact",
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "reclaim-ai",
+      "name": "Reclaim AI",
+      "source_status": "application_page_unavailable",
+      "deploy_effective_status": "enrollment_requested",
+      "cross_checked_statuses": [
+        "application_page_unavailable",
+        "enrollment_requested"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "descript",
+      "name": "Descript",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "synder",
+      "name": "Synder",
+      "source_status": "application_page_unavailable",
+      "deploy_effective_status": "outreach_sent",
+      "cross_checked_statuses": [
+        "application_page_unavailable",
+        "outreach_sent"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "gallabox",
+      "name": "Gallabox",
+      "source_status": "application_blocked_tax_id_captcha",
+      "deploy_effective_status": "application_blocked_tax_id_captcha",
+      "cross_checked_statuses": [
+        "application_blocked_tax_id_captcha"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "panda-video",
+      "name": "Panda Video",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "surfer-seo",
+      "name": "Surfer SEO",
+      "source_status": "application_submitted",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "murf-ai",
+      "name": "Murf AI",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "scalenut",
+      "name": "Scalenut",
+      "source_status": "application_submitted",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "castmagic",
+      "name": "Castmagic",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "loopcv",
+      "name": "LoopCV",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "clickfunnels",
+      "name": "ClickFunnels",
+      "source_status": null,
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "tapfiliate",
+      "name": "Tapfiliate",
+      "source_status": "application_blocked_captcha",
+      "deploy_effective_status": "outreach_sent",
+      "cross_checked_statuses": [
+        "application_blocked_captcha",
+        "outreach_sent"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "getresponse",
+      "name": "GetResponse",
+      "source_status": "rejected",
+      "deploy_effective_status": "rejected",
+      "cross_checked_statuses": [
+        "rejected"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "kit",
+      "name": "Kit",
+      "source_status": "application_page_unavailable",
+      "deploy_effective_status": "application_page_unavailable",
+      "cross_checked_statuses": [
+        "application_page_unavailable"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "teachable",
+      "name": "Teachable",
+      "source_status": "corporate_affiliate_program_not_found",
+      "deploy_effective_status": "outreach_sent",
+      "cross_checked_statuses": [
+        "corporate_affiliate_program_not_found",
+        "outreach_sent"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "livechat",
+      "name": "LiveChat",
+      "source_status": null,
+      "deploy_effective_status": null,
+      "cross_checked_statuses": [
+        "existing_text_partner_account"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": "data/browser_required_queue.json",
+      "queue_ids": []
+    },
+    {
+      "id": "kittl",
+      "name": "Kittl",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "koala-ai",
+      "name": "Koala AI",
+      "source_status": "campaign_registration_unavailable",
+      "deploy_effective_status": "campaign_registration_unavailable",
+      "cross_checked_statuses": [
+        "application_submitted",
+        "campaign_registration_unavailable"
+      ],
+      "decision": "selected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "lovo",
+      "name": "Lovo",
+      "source_status": "application_blocked_vendor_site_paused",
+      "deploy_effective_status": "application_blocked_vendor_site_paused",
+      "cross_checked_statuses": [
+        "application_blocked_vendor_site_paused"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "n8n",
+      "name": "n8n",
+      "source_status": "application_submitted",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": [
+        "n8n-affiliate-browser-followup"
+      ]
+    },
+    {
+      "id": "novita-ai",
+      "name": "Novita AI",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": [
+        "novita-ai-affiliate-browser-followup"
+      ]
+    },
+    {
+      "id": "followr",
+      "name": "Followr",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": [
+        "followr-affiliate-browser-followup"
+      ]
+    },
+    {
+      "id": "10web",
+      "name": "10Web",
+      "source_status": "application_submitted",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "supademo",
+      "name": "Supademo",
+      "source_status": "application_embed_unavailable",
+      "deploy_effective_status": "application_embed_unavailable",
+      "cross_checked_statuses": [
+        "application_embed_unavailable"
+      ],
+      "decision": "selected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "colossyan",
+      "name": "Colossyan",
+      "source_status": "program_inactive",
+      "deploy_effective_status": "program_inactive",
+      "cross_checked_statuses": [
+        "program_inactive"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "beefree",
+      "name": "Beefree",
+      "source_status": "application_page_unavailable",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_page_unavailable",
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "apollo",
+      "name": "Apollo",
+      "source_status": "application_page_unavailable",
+      "deploy_effective_status": "rejected",
+      "cross_checked_statuses": [
+        "application_page_unavailable",
+        "rejected"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "getgenie",
+      "name": "GetGenie",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "activecampaign",
+      "name": "ActiveCampaign",
+      "source_status": "application_page_unavailable",
+      "deploy_effective_status": "application_page_unavailable",
+      "cross_checked_statuses": [
+        "application_page_unavailable",
+        "rejected"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "sanebox",
+      "name": "Sanebox",
+      "source_status": "application_page_unavailable",
+      "deploy_effective_status": "application_page_unavailable",
+      "cross_checked_statuses": [
+        "application_page_unavailable",
+        "outreach_sent"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "pipedrive",
+      "name": "Pipedrive",
+      "source_status": null,
+      "deploy_effective_status": "pending",
+      "cross_checked_statuses": [
+        "pending"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "framer",
+      "name": "Framer",
+      "source_status": "outreach_sent",
+      "deploy_effective_status": "outreach_sent",
+      "cross_checked_statuses": [
+        "outreach_sent"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "monday-com",
+      "name": "Monday.com",
+      "source_status": null,
+      "deploy_effective_status": "pending",
+      "cross_checked_statuses": [
+        "pending"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "cartstack",
+      "name": "CartStack",
+      "source_status": "application_available",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "application_available",
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "cloudways",
+      "name": "Cloudways",
+      "source_status": null,
+      "deploy_effective_status": "pending",
+      "cross_checked_statuses": [
+        "pending"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "featureshark",
+      "name": "FeatureShark",
+      "source_status": null,
+      "deploy_effective_status": null,
+      "cross_checked_statuses": [],
+      "decision": "not_selected_program_or_fit_unverified",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "clickup",
+      "name": "ClickUp",
+      "source_status": null,
+      "deploy_effective_status": null,
+      "cross_checked_statuses": [
+        "rejected"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": "data/clickup-affiliate-rejection-evidence-2026-08-25.md",
+      "queue_ids": []
+    },
+    {
+      "id": "getgabs",
+      "name": "Getgabs",
+      "source_status": "application_available_instant",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_available_instant",
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "eprofessor",
+      "name": "eProfessor",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "docsbot",
+      "name": "DocsBot",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "surfeo",
+      "name": "Surfeo",
+      "source_status": null,
+      "deploy_effective_status": null,
+      "cross_checked_statuses": [],
+      "decision": "not_selected_program_or_fit_unverified",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "dub",
+      "name": "Dub",
+      "source_status": "application_not_submitted",
+      "deploy_effective_status": "application_not_submitted",
+      "cross_checked_statuses": [
+        "application_not_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "helpdesk",
+      "name": "HelpDesk",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "happyscribe",
+      "name": "HappyScribe",
+      "source_status": "beta_application_available",
+      "deploy_effective_status": "beta_application_available",
+      "cross_checked_statuses": [
+        "beta_application_available"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "pickaxe",
+      "name": "Pickaxe",
+      "source_status": "application_available",
+      "deploy_effective_status": "excluded_user_request",
+      "cross_checked_statuses": [
+        "application_available",
+        "excluded_user_request"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "ai-video-cut",
+      "name": "AI Video Cut",
+      "source_status": "application_available_auto_approval",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_available_auto_approval",
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "tagshop-ai",
+      "name": "Tagshop AI",
+      "source_status": "application_submitted",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": [
+        "tagshop-ai-affiliate-followup"
+      ]
+    },
+    {
+      "id": "text",
+      "name": "Text",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "typedesk",
+      "name": "Typedesk",
+      "source_status": "application_submitted",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": [
+        "typedesk-affiliate-browser-followup"
+      ]
+    },
+    {
+      "id": "chatbot",
+      "name": "ChatBot",
+      "source_status": null,
+      "deploy_effective_status": null,
+      "cross_checked_statuses": [
+        "existing_text_partner_account"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": "data/browser_required_queue.json",
+      "queue_ids": []
+    },
+    {
+      "id": "gojiberry",
+      "name": "Gojiberry",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": [
+        "gojiberry-affiliate-browser-followup"
+      ]
+    },
+    {
+      "id": "bidx",
+      "name": "BidX",
+      "source_status": "application_submitted",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "tidio",
+      "name": "Tidio",
+      "source_status": "application_available",
+      "deploy_effective_status": "application_available",
+      "cross_checked_statuses": [
+        "application_available",
+        "rejected"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": "data/tidio-affiliate-rejection-evidence-2026-08-25.md",
+      "queue_ids": []
+    },
+    {
+      "id": "catalister",
+      "name": "Catalister",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": [
+        "catalister-affiliate-followup"
+      ]
+    },
+    {
+      "id": "bookyourdata",
+      "name": "Bookyourdata",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "mindstudio",
+      "name": "MindStudio",
+      "source_status": "application_available_partnerstack",
+      "deploy_effective_status": "application_available_partnerstack",
+      "cross_checked_statuses": [
+        "application_available_partnerstack"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "manychat",
+      "name": "Manychat",
+      "source_status": "application_available_partnerstack",
+      "deploy_effective_status": "application_available_partnerstack",
+      "cross_checked_statuses": [
+        "application_available_partnerstack",
+        "direct_enrollment_path_requested"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "synthflow-ai",
+      "name": "Synthflow AI",
+      "source_status": "application_submitted",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "customgpt-ai",
+      "name": "CustomGPT.ai",
+      "source_status": "account_active_payout_setup_required",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "account_active_payout_setup_required",
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "databox",
+      "name": "Databox",
+      "source_status": "application_pending",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "application_pending",
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "fathom",
+      "name": "Fathom",
+      "source_status": "solution_partner_application_available",
+      "deploy_effective_status": "solution_partner_application_available",
+      "cross_checked_statuses": [
+        "solution_partner_application_available"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "taskip",
+      "name": "Taskip",
+      "source_status": "program_unavailable_ssl_error",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking",
+        "program_unavailable_ssl_error"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "gumloop",
+      "name": "Gumloop",
+      "source_status": "application_submitted",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "teknikforce",
+      "name": "Teknikforce",
+      "source_status": null,
+      "deploy_effective_status": "enrollment_requested",
+      "cross_checked_statuses": [
+        "enrollment_requested"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "hide-me",
+      "name": "hide.me",
+      "source_status": "application_available",
+      "deploy_effective_status": "application_available",
+      "cross_checked_statuses": [
+        "application_available",
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": "data/hideme-affiliate-application-evidence-2026-09-07.md",
+      "queue_ids": []
+    },
+    {
+      "id": "snov-io",
+      "name": "Snov.io",
+      "source_status": "application_available",
+      "deploy_effective_status": "application_available",
+      "cross_checked_statuses": [
+        "application_available",
+        "enrollment_requested"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": "data/snov-affiliate-enrollment-evidence-2026-09-07.md",
+      "queue_ids": []
+    },
+    {
+      "id": "claap",
+      "name": "Claap",
+      "source_status": "application_not_submitted",
+      "deploy_effective_status": "application_not_submitted",
+      "cross_checked_statuses": [
+        "application_not_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "cloudtalk",
+      "name": "CloudTalk",
+      "source_status": "application_available_partnerstack",
+      "deploy_effective_status": "application_available_partnerstack",
+      "cross_checked_statuses": [
+        "application_available_partnerstack"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "seamless",
+      "name": "Seamless",
+      "source_status": "application_blocked_region",
+      "deploy_effective_status": "application_blocked_region",
+      "cross_checked_statuses": [
+        "application_blocked_region"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "flowgent-ai",
+      "name": "FlowGent AI",
+      "source_status": null,
+      "deploy_effective_status": null,
+      "cross_checked_statuses": [
+        "existing_enrollment_conflict"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": "data/flowgent-affiliate-conflict-evidence-2026-09-07.md",
+      "queue_ids": []
+    },
+    {
+      "id": "activepieces",
+      "name": "Activepieces",
+      "source_status": null,
+      "deploy_effective_status": null,
+      "cross_checked_statuses": [],
+      "decision": "not_selected_program_or_fit_unverified",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "marketingblocks",
+      "name": "MarketingBlocks",
+      "source_status": null,
+      "deploy_effective_status": "enrollment_requested",
+      "cross_checked_statuses": [
+        "enrollment_requested"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "google-workspace",
+      "name": "Google Workspace",
+      "source_status": null,
+      "deploy_effective_status": null,
+      "cross_checked_statuses": [],
+      "decision": "not_selected_program_or_fit_unverified",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "chatbase",
+      "name": "Chatbase",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "krater",
+      "name": "Krater",
+      "source_status": "application_submitted",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "expandi",
+      "name": "Expandi",
+      "source_status": null,
+      "deploy_effective_status": null,
+      "cross_checked_statuses": [
+        "eligibility_unverified"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": "https://expandi.io/affiliate-program/",
+      "queue_ids": []
+    },
+    {
+      "id": "reditus",
+      "name": "Reditus",
+      "source_status": null,
+      "deploy_effective_status": "enrollment_requested",
+      "cross_checked_statuses": [
+        "enrollment_requested"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "joiin",
+      "name": "Joiin",
+      "source_status": "application_submitted",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": [
+        "joiin-affiliate-browser-followup"
+      ]
+    },
+    {
+      "id": "agentworks",
+      "name": "AgentWorks",
+      "source_status": "referral_link_requested",
+      "deploy_effective_status": "referral_link_requested",
+      "cross_checked_statuses": [
+        "referral_link_requested"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "airia",
+      "name": "Airia",
+      "source_status": "application_submitted",
+      "deploy_effective_status": "application_submitted",
+      "cross_checked_statuses": [
+        "application_submitted"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": [
+        "airia-affiliate-browser-followup"
+      ]
+    },
+    {
+      "id": "omi-ai",
+      "name": "Omi AI",
+      "source_status": "approved_email_verification_required",
+      "deploy_effective_status": "approved_email_verification_required",
+      "cross_checked_statuses": [
+        "approved_email_verification_required",
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "fireflies-ai",
+      "name": "Fireflies.ai",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "gamma",
+      "name": "Gamma",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "gobii",
+      "name": "Gobii",
+      "source_status": "program_unavailable_company_winding_down",
+      "deploy_effective_status": "program_unavailable_company_winding_down",
+      "cross_checked_statuses": [
+        "program_unavailable_company_winding_down"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "voibe",
+      "name": "Voibe",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "merlin-ai",
+      "name": "Merlin AI",
+      "source_status": "duplicate_do_not_apply",
+      "deploy_effective_status": "duplicate_do_not_apply",
+      "cross_checked_statuses": [
+        "duplicate_do_not_apply"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "speechify",
+      "name": "Speechify",
+      "source_status": "application_blocked_official_page_not_found",
+      "deploy_effective_status": "application_blocked_official_page_not_found",
+      "cross_checked_statuses": [
+        "application_blocked_official_page_not_found",
+        "application_submitted"
+      ],
+      "decision": "selected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "babylovegrowth-ai",
+      "name": "BabyLoveGrowth.ai",
+      "source_status": "application_blocked_existing_reditus_onboarding",
+      "deploy_effective_status": "application_blocked_existing_reditus_onboarding",
+      "cross_checked_statuses": [
+        "application_blocked_existing_reditus_onboarding"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "ai-agent-store",
+      "name": "AI Agent Store",
+      "source_status": "application_blocked_affiliate_domain_ssl_error",
+      "deploy_effective_status": "application_blocked_affiliate_domain_ssl_error",
+      "cross_checked_statuses": [
+        "application_blocked_affiliate_domain_ssl_error"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "marblism",
+      "name": "Marblism",
+      "source_status": "account_active_payout_setup_required",
+      "deploy_effective_status": "rejected",
+      "cross_checked_statuses": [
+        "account_active_payout_setup_required",
+        "rejected"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "taskade",
+      "name": "Taskade",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    },
+    {
+      "id": "relevance-ai",
+      "name": "Relevance AI",
+      "source_status": "approved_tracking",
+      "deploy_effective_status": "approved_tracking",
+      "cross_checked_statuses": [
+        "approved_tracking"
+      ],
+      "decision": "excluded_existing_or_protected",
+      "prior_evidence": null,
+      "queue_ids": []
+    }
+  ]
+}

--- a/projects/GlobalSaaSHub/data/affiliate-submission-batch-2026-09-08.json
+++ b/projects/GlobalSaaSHub/data/affiliate-submission-batch-2026-09-08.json
@@ -146,6 +146,66 @@
       ],
       "checked_at": "2026-09-07T21:21:56.008052+00:00",
       "outreach_sent": true
+    },
+    {
+      "id": "koala-ai",
+      "status": "application_submitted",
+      "application_state": "submitted",
+      "review_state": "awaiting_vendor_response",
+      "affiliate_url": null,
+      "workflow_url": "https://koala.sh/pages/affiliate",
+      "official_program_url": "https://koala.sh/pages/affiliate",
+      "portal_enrollment_confirmed": false,
+      "application_channel": "official_email_application",
+      "evidence": "2026-09-08 06:33 KST: official Koala page instructs applicants to email hello@koala.sh with audience details and links. Company Gmail in:anywhere koala returned no messages before applying. Sent one application with factual COSHUMA buyer-guide description and website/product links, without invented traffic or customer usage. Gmail displayed Message sent; Sent message subject COSHUMA — Koala AI Affiliate Program Application, sender COSHUMA <support@coshuma.com>, recipient hello@koala.sh. Sent URL https://mail.google.com/mail/u/1/#sent/QgrcJHsHsHNwknQNnbrBrVCglRWGxCQHpKQ. This verifies dispatch of the official email application, not vendor receipt, approval or enrollment. No tracking URL issued.",
+      "next_action": "Await the existing email application response. Do not reapply or send duplicate outreach. Record only an exact customer-facing link issued by the vendor after approval.",
+      "blockers": [],
+      "checked_at": "2026-09-07T21:35:04.579403+00:00",
+      "paid_actions": 0,
+      "customer_signups": 0,
+      "commissions": 0,
+      "revenue": 0
+    },
+    {
+      "id": "speechify",
+      "status": "application_submitted",
+      "application_state": "interest_form_submitted",
+      "review_state": "awaiting_vendor_response",
+      "affiliate_url": null,
+      "workflow_url": "https://speechify.com/affiliates/",
+      "official_program_url": "https://speechify.com/affiliates/",
+      "portal_enrollment_confirmed": false,
+      "application_channel": "official_affiliate_interest_form",
+      "evidence": "2026-09-08 authenticated Chrome: company Gmail in:anywhere search including speechify returned no messages before submission. Current /affiliates/ page exposes a free Submit Interest form, replacing the old singular /affiliate Page Not Found route. Submitted once with Sangkwon An, support@coshuma.com, https://coshuma.com, and traffic stated as Not yet verified; early-stage SaaS/AI buyer-guide website. No invented traffic number. After Processing your submission the page displayed Thanks for getting in touch! and A member of our team will reach out to you shortly. This is affiliate-interest submission, not an approved partner account. No customer tracking URL issued.",
+      "next_action": "Await the vendor response to the existing affiliate-interest submission. Do not resubmit. Recover only an issued customer-facing referral link after approval.",
+      "blockers": [],
+      "checked_at": "2026-09-07T21:35:04.579403+00:00",
+      "paid_actions": 0,
+      "customer_signups": 0,
+      "commissions": 0,
+      "revenue": 0,
+      "supersedes_unavailable_route": true
+    },
+    {
+      "id": "supademo",
+      "status": "application_embed_unavailable",
+      "application_state": "not_submitted",
+      "review_state": "not_applicable",
+      "affiliate_url": null,
+      "workflow_url": "https://eu.makeforms.io/k1ibmll/",
+      "official_program_url": "https://supademo.com/affiliates",
+      "portal_enrollment_confirmed": false,
+      "application_channel": "official_embedded_form",
+      "evidence": "2026-09-08: company Gmail in:anywhere search including supademo returned no existing messages. Official Supademo page explicitly states affiliate signup is completely free, no customer subscription or sales minimum is required, and advertises 30% recurring commission. Join the affiliate program exposed an eu.makeforms.io frame with connection reset. Its exact official form https://eu.makeforms.io/k1ibmll/ also returned net::ERR_CONNECTION_RESET when opened directly in Chrome and the in-app browser. No form fields or submission confirmation were available. Technical connectivity failure, not CAPTCHA or a user-consent blocker. No account, application, payment or referral link created.",
+      "next_action": "Resume this exact official form when its connection recovers. Recheck mailbox before a first submission. No user action currently required; do not publish the form or homepage as an affiliate URL.",
+      "blockers": [
+        "official_application_form_connection_reset"
+      ],
+      "checked_at": "2026-09-07T21:35:04.579403+00:00",
+      "paid_actions": 0,
+      "customer_signups": 0,
+      "commissions": 0,
+      "revenue": 0
     }
   ]
 }

--- a/projects/GlobalSaaSHub/data/affiliate_outreach_state.json
+++ b/projects/GlobalSaaSHub/data/affiliate_outreach_state.json
@@ -424,6 +424,53 @@
       ],
       "gmail_message_id": "1a07dc29ac469c2d",
       "sender": "support@coshuma.com"
+    },
+    "koala-ai": {
+      "status": "application_submitted",
+      "tracking_url": null,
+      "account": "support@coshuma.com",
+      "sender": "support@coshuma.com",
+      "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+      "note": "2026-09-08 06:33 KST: official Koala page instructs applicants to email hello@koala.sh with audience details and links. Company Gmail in:anywhere koala returned no messages before applying. Sent one application with factual COSHUMA buyer-guide description and website/product links, without invented traffic or customer usage. Gmail displayed Message sent; Sent message subject COSHUMA — Koala AI Affiliate Program Application, sender COSHUMA <support@coshuma.com>, recipient hello@koala.sh. Sent URL https://mail.google.com/mail/u/1/#sent/QgrcJHsHsHNwknQNnbrBrVCglRWGxCQHpKQ. This verifies dispatch of the official email application, not vendor receipt, approval or enrollment. No tracking URL issued.",
+      "next_action": "Await the existing email application response. Do not reapply or send duplicate outreach. Record only an exact customer-facing link issued by the vendor after approval.",
+      "checked_date_kst": "2026-09-08",
+      "application_state": "submitted",
+      "portal_enrollment_confirmed": false,
+      "do_not_reapply": true,
+      "workflow_url": "https://koala.sh/pages/affiliate",
+      "blockers": []
+    },
+    "speechify": {
+      "status": "application_submitted",
+      "tracking_url": null,
+      "account": "support@coshuma.com",
+      "sender": null,
+      "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+      "note": "2026-09-08 authenticated Chrome: company Gmail in:anywhere search including speechify returned no messages before submission. Current /affiliates/ page exposes a free Submit Interest form, replacing the old singular /affiliate Page Not Found route. Submitted once with Sangkwon An, support@coshuma.com, https://coshuma.com, and traffic stated as Not yet verified; early-stage SaaS/AI buyer-guide website. No invented traffic number. After Processing your submission the page displayed Thanks for getting in touch! and A member of our team will reach out to you shortly. This is affiliate-interest submission, not an approved partner account. No customer tracking URL issued.",
+      "next_action": "Await the vendor response to the existing affiliate-interest submission. Do not resubmit. Recover only an issued customer-facing referral link after approval.",
+      "checked_date_kst": "2026-09-08",
+      "application_state": "interest_form_submitted",
+      "portal_enrollment_confirmed": false,
+      "do_not_reapply": true,
+      "workflow_url": "https://speechify.com/affiliates/",
+      "blockers": []
+    },
+    "supademo": {
+      "status": "application_embed_unavailable",
+      "tracking_url": null,
+      "account": "support@coshuma.com",
+      "sender": null,
+      "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+      "note": "2026-09-08: company Gmail in:anywhere search including supademo returned no existing messages. Official Supademo page explicitly states affiliate signup is completely free, no customer subscription or sales minimum is required, and advertises 30% recurring commission. Join the affiliate program exposed an eu.makeforms.io frame with connection reset. Its exact official form https://eu.makeforms.io/k1ibmll/ also returned net::ERR_CONNECTION_RESET when opened directly in Chrome and the in-app browser. No form fields or submission confirmation were available. Technical connectivity failure, not CAPTCHA or a user-consent blocker. No account, application, payment or referral link created.",
+      "next_action": "Resume this exact official form when its connection recovers. Recheck mailbox before a first submission. No user action currently required; do not publish the form or homepage as an affiliate URL.",
+      "checked_date_kst": "2026-09-08",
+      "application_state": "not_submitted",
+      "portal_enrollment_confirmed": false,
+      "do_not_reapply": false,
+      "workflow_url": "https://eu.makeforms.io/k1ibmll/",
+      "blockers": [
+        "official_application_form_connection_reset"
+      ]
     }
   }
 }

--- a/projects/GlobalSaaSHub/data/browser_required_queue.d/activecampaign-affiliate-2026-09-08.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.d/activecampaign-affiliate-2026-09-08.json
@@ -2,20 +2,21 @@
   "id": "activecampaign-affiliate-partnerstack-application",
   "tool_id": "activecampaign",
   "priority": "high",
-  "status": "browser_required_partnerstack_application",
-  "affiliate_status": "browser_required_partnerstack_application",
+  "status": "blocked_existing_rejection_evidence",
+  "affiliate_status": "rejected",
   "cost": "0",
   "verified_at": "2026-09-08T06:23:15+09:00",
   "exact_tracking_url": null,
   "official_program_url": "https://www.activecampaign.com/partners/affiliate",
   "workflow_url": "https://activecampaign.partnerstack.com/?group=affiliatepartners",
-  "reason": "ActiveCampaign's current official affiliate page exposes a live Apply Now route to its PartnerStack application. The company mailbox support@coshuma.com has no ActiveCampaign application/outreach evidence in the prior year, so the prior application_page_unavailable state is stale and there is no known duplicate submission.",
-  "next_action": "Open the exact PartnerStack application route, reuse the existing COSHUMA PartnerStack identity where possible, and submit once with factual COSHUMA information. After approval, recover and independently verify the exact customer-facing referral URL before publishing any revenue CTA.",
+  "reason": "Existing repository evidence data/activecampaign-affiliate-rejection-evidence-2026-08-28.md records a submitted application followed by an explicit decline (Gmail message 1a049ba49a81c468). A later public application route and an empty search in the newer company mailbox do not establish that the prior rejection was reversed. Current eligibility is unconfirmed; keep this application protected.",
+  "next_action": "Do not reapply. Only reopen after account-specific vendor evidence explicitly reverses the rejection or establishes eligibility. Public program availability alone is insufficient.",
   "do_not": [
     "Do not use the ActiveCampaign homepage, application URL, PartnerStack dashboard, login page, or onboarding URL as an affiliate/revenue link.",
     "Do not submit a second application if the PartnerStack UI reveals an existing pending/approved/declined application.",
     "Do not pay for ActiveCampaign or any PartnerStack service to qualify for the affiliate program; ActiveCampaign states applicants do not need to be customers.",
     "Do not infer clicks, sign-ups, commissions, or revenue from application availability or submission."
   ],
-  "evidence_file": "data/activecampaign-affiliate-route-2026-09-08.md"
+  "evidence_file": "data/activecampaign-affiliate-rejection-evidence-2026-08-28.md",
+  "do_not_reapply": true
 }

--- a/projects/GlobalSaaSHub/data/browser_required_queue.d/eprofessor-referral-link-2026-09-08.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.d/eprofessor-referral-link-2026-09-08.json
@@ -2,14 +2,14 @@
   "id": "eprofessor-referral-link-recovery",
   "tool_id": "eprofessor",
   "priority": "medium",
-  "status": "browser_required_account_activation",
-  "affiliate_status": "browser_required_account_activation",
+  "status": "resolved",
+  "affiliate_status": "approved_tracking",
   "cost": "0",
   "verified_at": "2026-09-08T06:23:15+09:00",
-  "exact_tracking_url": null,
-  "workflow_url": "https://examprofessor.com/",
-  "reason": "The company mailbox received an eProfessor account verification email for COSHUMA (Gmail message 1a07dc143f8f79c2). eProfessor's official help documents an account-level Referral Program that issues a unique /invite/ referral URL and tracks paying-subscriber conversions. The account must be verified and authenticated before any exact COSHUMA referral URL can be recovered.",
-  "next_action": "Verify the existing COSHUMA account once, sign in, open the account-menu Referral Program, and copy the exact unique referral URL. Independently verify the customer destination before adding eProfessor to revenue CTAs or tool data. Payment/tax setup is not required to validate the referral URL and should remain separate.",
+  "exact_tracking_url": "https://eprofessor.com/invite/coshuma173",
+  "workflow_url": "https://admin.eprofessor.com/referrals/",
+  "reason": "Superseded by confirmed referral issuance and published main evidence in data/affiliate-submission-batch-2026-09-08.json. The exact issued customer referral URL is https://eprofessor.com/invite/coshuma173. Account/link recovery is complete; do not follow the stale activation route or create another account.",
+  "next_action": "Preserve the verified referral URL. No further account or link recovery. PayPal and tax setup remain incomplete as separately recorded; no earning or revenue claim.",
   "do_not": [
     "Do not create another eProfessor account because support@coshuma.com already has a verification email for an existing COSHUMA signup.",
     "Do not construct or guess the /invite/ slug from the account name.",
@@ -18,5 +18,7 @@
     "Do not infer sign-ups, active subscribers, commissions, or revenue until dashboard evidence exists."
   ],
   "gmail_message_id": "1a07dc143f8f79c2",
-  "official_program_evidence_url": "https://examprofessor.com/page/help/settings-1/referral-program-1"
+  "official_program_evidence_url": "https://examprofessor.com/page/help/settings-1/referral-program-1",
+  "do_not_reapply": true,
+  "evidence_file": "data/affiliate-submission-batch-2026-09-08.json"
 }

--- a/projects/GlobalSaaSHub/data/browser_required_queue.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.json
@@ -637,5 +637,47 @@
     "reason": "Official Creator Program advertises manual application from Community settings Links tab. Pre-action company Gmail in:anywhere search had no prior Framer messages. Email authentication was completed using the newly received verified team@framer.com activation message, and free account creation was completed as Sangkwon An under support@coshuma.com. Optional newsletter was unchecked. Official creator Links route redirected to /@sangkwon-an/?settings=open&settingsTab=links and displayed Page not found. Marketplace Account menu exposed Settings but no application form became available after activation. Account exists; affiliate submission, approval and tracking URL are not confirmed. No paid plan or marketplace product was created. Newer main commit 02e5ba2 records Framer Creator Team outreach. Verified in the authenticated company Gmail UI: COSHUMA <support@coshuma.com> sent COSHUMA — Framer Creator Program / affiliate enrollment to creators@framer.com at 06:25 KST on 2026-09-08, requesting the current manual application path or activation of the Links application. Gmail message 1a07dc29ac469c2d; data/framer-creator-program-outreach-2026-09-08.md. This request is not an application submission or approval. No duplicate outreach sent in this task.",
     "next_action": "Await the existing Framer Creator Team reply to the 06:25 KST company email. Do not send another request or recreate the account. If the vendor enables the Links application, resume the existing account and submit once; no tracking URL until issued and verified.",
     "evidence_file": "data/affiliate-submission-batch-2026-09-08.json"
+  },
+  {
+    "id": "koala-ai-affiliate-batch-20260908-0633",
+    "tool_id": "koala-ai",
+    "priority": "high",
+    "status": "resolved",
+    "affiliate_status": "application_submitted",
+    "exact_tracking_url": null,
+    "cost": "0",
+    "verified_at": "2026-09-07T21:35:04.579403+00:00",
+    "reason": "2026-09-08 06:33 KST: official Koala page instructs applicants to email hello@koala.sh with audience details and links. Company Gmail in:anywhere koala returned no messages before applying. Sent one application with factual COSHUMA buyer-guide description and website/product links, without invented traffic or customer usage. Gmail displayed Message sent; Sent message subject COSHUMA — Koala AI Affiliate Program Application, sender COSHUMA <support@coshuma.com>, recipient hello@koala.sh. Sent URL https://mail.google.com/mail/u/1/#sent/QgrcJHsHsHNwknQNnbrBrVCglRWGxCQHpKQ. This verifies dispatch of the official email application, not vendor receipt, approval or enrollment. No tracking URL issued.",
+    "next_action": "Await the existing email application response. Do not reapply or send duplicate outreach. Record only an exact customer-facing link issued by the vendor after approval.",
+    "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+    "user_action_required": false
+  },
+  {
+    "id": "speechify-affiliate-batch-20260908-0633",
+    "tool_id": "speechify",
+    "priority": "high",
+    "status": "resolved",
+    "affiliate_status": "application_submitted",
+    "exact_tracking_url": null,
+    "cost": "0",
+    "verified_at": "2026-09-07T21:35:04.579403+00:00",
+    "reason": "2026-09-08 authenticated Chrome: company Gmail in:anywhere search including speechify returned no messages before submission. Current /affiliates/ page exposes a free Submit Interest form, replacing the old singular /affiliate Page Not Found route. Submitted once with Sangkwon An, support@coshuma.com, https://coshuma.com, and traffic stated as Not yet verified; early-stage SaaS/AI buyer-guide website. No invented traffic number. After Processing your submission the page displayed Thanks for getting in touch! and A member of our team will reach out to you shortly. This is affiliate-interest submission, not an approved partner account. No customer tracking URL issued.",
+    "next_action": "Await the vendor response to the existing affiliate-interest submission. Do not resubmit. Recover only an issued customer-facing referral link after approval.",
+    "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+    "user_action_required": false
+  },
+  {
+    "id": "supademo-affiliate-batch-20260908-0633",
+    "tool_id": "supademo",
+    "priority": "high",
+    "status": "technical_failure",
+    "affiliate_status": "application_embed_unavailable",
+    "exact_tracking_url": null,
+    "cost": "0",
+    "verified_at": "2026-09-07T21:35:04.579403+00:00",
+    "reason": "2026-09-08: company Gmail in:anywhere search including supademo returned no existing messages. Official Supademo page explicitly states affiliate signup is completely free, no customer subscription or sales minimum is required, and advertises 30% recurring commission. Join the affiliate program exposed an eu.makeforms.io frame with connection reset. Its exact official form https://eu.makeforms.io/k1ibmll/ also returned net::ERR_CONNECTION_RESET when opened directly in Chrome and the in-app browser. No form fields or submission confirmation were available. Technical connectivity failure, not CAPTCHA or a user-consent blocker. No account, application, payment or referral link created.",
+    "next_action": "Resume this exact official form when its connection recovers. Recheck mailbox before a first submission. No user action currently required; do not publish the form or homepage as an affiliate URL.",
+    "evidence_file": "data/affiliate-submission-batch-2026-09-08.json",
+    "user_action_required": false
   }
 ]

--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -2738,8 +2738,18 @@
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://friends.koala.sh/signup",
     "affiliate_verified": false,
-    "affiliate_status": "campaign_registration_unavailable",
-    "affiliate_verified_at": "2026-09-01T00:00:00+09:00"
+    "affiliate_status": "application_submitted",
+    "affiliate_verified_at": "2026-09-01T00:00:00+09:00",
+    "affiliate_final_url": null,
+    "affiliate_evidence_markers": [
+      "2026-09-08 06:33 KST: official Koala page instructs applicants to email hello@koala.sh with audience details and links. Company Gmail in:anywhere koala returned no messages before applying. Sent one application with factual COSHUMA buyer-guide description and website/product links, without invented traffic or customer usage. Gmail displayed Message sent; Sent message subject COSHUMA — Koala AI Affiliate Program Application, sender COSHUMA <support@coshuma.com>, recipient hello@koala.sh. Sent URL https://mail.google.com/mail/u/1/#sent/QgrcJHsHsHNwknQNnbrBrVCglRWGxCQHpKQ. This verifies dispatch of the official email application, not vendor receipt, approval or enrollment. No tracking URL issued.",
+      "Await the existing email application response. Do not reapply or send duplicate outreach. Record only an exact customer-facing link issued by the vendor after approval.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
+    "affiliate_status_checked_at": "2026-09-07T21:35:04.579403+00:00",
+    "affiliate_status_evidence_url": "https://koala.sh/pages/affiliate",
+    "affiliate_workflow_url": "https://koala.sh/pages/affiliate",
+    "affiliate_next_action": "Await the existing email application response. Do not reapply or send duplicate outreach. Record only an exact customer-facing link issued by the vendor after approval."
   },
   {
     "id": "lovo",
@@ -2979,7 +2989,17 @@
     "official_evidence_url": "https://supademo.com/affiliates",
     "affiliate_verified": false,
     "affiliate_status": "application_embed_unavailable",
-    "affiliate_verified_at": "2026-09-01T00:00:00+09:00"
+    "affiliate_verified_at": "2026-09-01T00:00:00+09:00",
+    "affiliate_final_url": null,
+    "affiliate_evidence_markers": [
+      "2026-09-08: company Gmail in:anywhere search including supademo returned no existing messages. Official Supademo page explicitly states affiliate signup is completely free, no customer subscription or sales minimum is required, and advertises 30% recurring commission. Join the affiliate program exposed an eu.makeforms.io frame with connection reset. Its exact official form https://eu.makeforms.io/k1ibmll/ also returned net::ERR_CONNECTION_RESET when opened directly in Chrome and the in-app browser. No form fields or submission confirmation were available. Technical connectivity failure, not CAPTCHA or a user-consent blocker. No account, application, payment or referral link created.",
+      "Resume this exact official form when its connection recovers. Recheck mailbox before a first submission. No user action currently required; do not publish the form or homepage as an affiliate URL.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
+    "affiliate_status_checked_at": "2026-09-07T21:35:04.579403+00:00",
+    "affiliate_status_evidence_url": "https://supademo.com/affiliates",
+    "affiliate_workflow_url": "https://eu.makeforms.io/k1ibmll/",
+    "affiliate_next_action": "Resume this exact official form when its connection recovers. Recheck mailbox before a first submission. No user action currently required; do not publish the form or homepage as an affiliate URL."
   },
   {
     "id": "colossyan",
@@ -5253,18 +5273,25 @@
     "is_manual_override": false,
     "http_verification_status": null,
     "affiliate_verified": false,
-    "affiliate_source_url": "https://speechify.com/affiliate",
+    "affiliate_source_url": "https://speechify.com/affiliates/",
     "affiliate_final_url": null,
     "affiliate_http_status": 308,
-    "affiliate_evidence_markers": [],
+    "affiliate_evidence_markers": [
+      "2026-09-08 authenticated Chrome: company Gmail in:anywhere search including speechify returned no messages before submission. Current /affiliates/ page exposes a free Submit Interest form, replacing the old singular /affiliate Page Not Found route. Submitted once with Sangkwon An, support@coshuma.com, https://coshuma.com, and traffic stated as Not yet verified; early-stage SaaS/AI buyer-guide website. No invented traffic number. After Processing your submission the page displayed Thanks for getting in touch! and A member of our team will reach out to you shortly. This is affiliate-interest submission, not an approved partner account. No customer tracking URL issued.",
+      "Await the vendor response to the existing affiliate-interest submission. Do not resubmit. Recover only an issued customer-facing referral link after approval.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
     "affiliate_verified_at": null,
-    "affiliate_rejection_reason": "Official affiliate URL displays Page Not Found",
     "primary_category": "voice_cloning",
     "comparison_group": "voice_generation",
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://speechify.com/",
-    "affiliate_status": "application_blocked_official_page_not_found"
+    "affiliate_status": "application_submitted",
+    "affiliate_status_checked_at": "2026-09-07T21:35:04.579403+00:00",
+    "affiliate_status_evidence_url": "https://speechify.com/affiliates/",
+    "affiliate_workflow_url": "https://speechify.com/affiliates/",
+    "affiliate_next_action": "Await the vendor response to the existing affiliate-interest submission. Do not resubmit. Recover only an issued customer-facing referral link after approval."
   },
   {
     "id": "babylovegrowth-ai",

--- a/projects/GlobalSaaSHub/data/tools.next.json
+++ b/projects/GlobalSaaSHub/data/tools.next.json
@@ -2700,8 +2700,18 @@
     "official_evidence_url": "https://friends.koala.sh/signup",
     "affiliate_url": null,
     "affiliate_verified": false,
-    "affiliate_status": "campaign_registration_unavailable",
-    "affiliate_verified_at": "2026-09-01T00:00:00+09:00"
+    "affiliate_status": "application_submitted",
+    "affiliate_verified_at": "2026-09-01T00:00:00+09:00",
+    "affiliate_final_url": null,
+    "affiliate_evidence_markers": [
+      "2026-09-08 06:33 KST: official Koala page instructs applicants to email hello@koala.sh with audience details and links. Company Gmail in:anywhere koala returned no messages before applying. Sent one application with factual COSHUMA buyer-guide description and website/product links, without invented traffic or customer usage. Gmail displayed Message sent; Sent message subject COSHUMA — Koala AI Affiliate Program Application, sender COSHUMA <support@coshuma.com>, recipient hello@koala.sh. Sent URL https://mail.google.com/mail/u/1/#sent/QgrcJHsHsHNwknQNnbrBrVCglRWGxCQHpKQ. This verifies dispatch of the official email application, not vendor receipt, approval or enrollment. No tracking URL issued.",
+      "Await the existing email application response. Do not reapply or send duplicate outreach. Record only an exact customer-facing link issued by the vendor after approval.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
+    "affiliate_status_checked_at": "2026-09-07T21:35:04.579403+00:00",
+    "affiliate_status_evidence_url": "https://koala.sh/pages/affiliate",
+    "affiliate_workflow_url": "https://koala.sh/pages/affiliate",
+    "affiliate_next_action": "Await the existing email application response. Do not reapply or send duplicate outreach. Record only an exact customer-facing link issued by the vendor after approval."
   },
   {
     "id": "lovo",
@@ -2938,7 +2948,17 @@
     "affiliate_url": null,
     "affiliate_verified": false,
     "affiliate_status": "application_embed_unavailable",
-    "affiliate_verified_at": "2026-09-01T00:00:00+09:00"
+    "affiliate_verified_at": "2026-09-01T00:00:00+09:00",
+    "affiliate_final_url": null,
+    "affiliate_evidence_markers": [
+      "2026-09-08: company Gmail in:anywhere search including supademo returned no existing messages. Official Supademo page explicitly states affiliate signup is completely free, no customer subscription or sales minimum is required, and advertises 30% recurring commission. Join the affiliate program exposed an eu.makeforms.io frame with connection reset. Its exact official form https://eu.makeforms.io/k1ibmll/ also returned net::ERR_CONNECTION_RESET when opened directly in Chrome and the in-app browser. No form fields or submission confirmation were available. Technical connectivity failure, not CAPTCHA or a user-consent blocker. No account, application, payment or referral link created.",
+      "Resume this exact official form when its connection recovers. Recheck mailbox before a first submission. No user action currently required; do not publish the form or homepage as an affiliate URL.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
+    "affiliate_status_checked_at": "2026-09-07T21:35:04.579403+00:00",
+    "affiliate_status_evidence_url": "https://supademo.com/affiliates",
+    "affiliate_workflow_url": "https://eu.makeforms.io/k1ibmll/",
+    "affiliate_next_action": "Resume this exact official form when its connection recovers. Recheck mailbox before a first submission. No user action currently required; do not publish the form or homepage as an affiliate URL."
   },
   {
     "id": "colossyan",
@@ -5202,13 +5222,20 @@
     "official_evidence_url": "https://speechify.com/",
     "affiliate_url": null,
     "affiliate_verified": false,
-    "affiliate_source_url": "https://speechify.com/affiliate",
+    "affiliate_source_url": "https://speechify.com/affiliates/",
     "affiliate_final_url": null,
     "affiliate_http_status": 308,
-    "affiliate_evidence_markers": [],
+    "affiliate_evidence_markers": [
+      "2026-09-08 authenticated Chrome: company Gmail in:anywhere search including speechify returned no messages before submission. Current /affiliates/ page exposes a free Submit Interest form, replacing the old singular /affiliate Page Not Found route. Submitted once with Sangkwon An, support@coshuma.com, https://coshuma.com, and traffic stated as Not yet verified; early-stage SaaS/AI buyer-guide website. No invented traffic number. After Processing your submission the page displayed Thanks for getting in touch! and A member of our team will reach out to you shortly. This is affiliate-interest submission, not an approved partner account. No customer tracking URL issued.",
+      "Await the vendor response to the existing affiliate-interest submission. Do not resubmit. Recover only an issued customer-facing referral link after approval.",
+      "data/affiliate-submission-batch-2026-09-08.json"
+    ],
     "affiliate_verified_at": null,
-    "affiliate_rejection_reason": "Official affiliate URL displays Page Not Found",
-    "affiliate_status": "application_blocked_official_page_not_found"
+    "affiliate_status": "application_submitted",
+    "affiliate_status_checked_at": "2026-09-07T21:35:04.579403+00:00",
+    "affiliate_status_evidence_url": "https://speechify.com/affiliates/",
+    "affiliate_workflow_url": "https://speechify.com/affiliates/",
+    "affiliate_next_action": "Await the vendor response to the existing affiliate-interest submission. Do not resubmit. Recover only an issued customer-facing referral link after approval."
   },
   {
     "id": "babylovegrowth-ai",

--- a/projects/GlobalSaaSHub/scripts/browser_followup_evidence.mjs
+++ b/projects/GlobalSaaSHub/scripts/browser_followup_evidence.mjs
@@ -48,6 +48,10 @@ export function applyBrowserFollowup(tool) {
     affiliate_next_action: item.next_action,
   });
   if (approved && item.checked_at) tool.affiliate_verified_at = item.checked_at;
+  if (item.supersedes_unavailable_route === true) {
+    tool.affiliate_source_url = item.official_program_url;
+    delete tool.affiliate_rejection_reason;
+  }
   if (typeof item.payout_setup_complete === 'boolean') {
     tool.payout_setup_status = item.payout_setup_complete ? 'complete' : 'incomplete';
   }


### PR DESCRIPTION
Rescanned all 151 tools against deployed state, outreach records, browser queue and prior evidence. Records the official Koala email application sent from support@coshuma.com, Speechify's successful affiliate-interest form submission, and Supademo's confirmed application-form connection reset. No approval or customer tracking URL was issued; all three URLs remain null and no revenue is claimed.

Updates authoritative evidence, both tool datasets and the browser queue. Sync now clears Speechify's superseded missing-route reason. Existing ActiveCampaign rejection and Manychat outreach were excluded from reapplication.

Validation: production build, repeat-sync/duplicate-prevention tests, full link integrity (151 tools), existing SEO regressions, and nine target detail/comparison pages checked for canonical, title, description, OG, schema, sitemap and absence of unissued affiliate CTAs. No payments.