### PR TITLE
Revenue: refresh ElevenLabs vs Murf buyer comparison

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/elevenlabs-vs-murf-ai.html
+++ b/projects/GlobalSaaSHub/public/compare/elevenlabs-vs-murf-ai.html
@@ -3,103 +3,154 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>ElevenLabs vs Murf AI (2026): Voice AI Comparison | GlobalSaaSHub</title>
-  <meta name="description" content="Compare ElevenLabs and Murf AI for AI voice generation, voice cloning, text-to-speech, and production workflows. Use verified partner links when you are ready to try either tool." />
+  <title>ElevenLabs vs Murf AI 2026: $6 Starter vs $19 Creator | COSHUMA</title>
+  <meta name="description" content="ElevenLabs vs Murf AI in 2026: compare free plans, $6 ElevenLabs Starter, Murf Creator from $19/mo billed annually, commercial rights, cloning, studio workflow and verified COSHUMA partner links." />
   <link rel="canonical" href="https://coshuma.com/compare/elevenlabs-vs-murf-ai.html" />
   <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="COSHUMA" />
   <meta property="og:url" content="https://coshuma.com/compare/elevenlabs-vs-murf-ai.html" />
-  <meta property="og:title" content="ElevenLabs vs Murf AI (2026) | GlobalSaaSHub" />
-  <meta property="og:description" content="A practical buyer-intent comparison of ElevenLabs and Murf AI with verified partner CTAs." />
+  <meta property="og:title" content="ElevenLabs vs Murf AI 2026: Pricing, Voice Cloning & Commercial Use" />
+  <meta property="og:description" content="Choose ElevenLabs for a broad creative voice stack or Murf for a studio-oriented business voiceover workflow. Current pricing checked Sep 8, 2026." />
   <script type="application/ld+json">
   {
     "@context":"https://schema.org",
-    "@type":"WebPage",
-    "name":"ElevenLabs vs Murf AI Comparison",
-    "url":"https://coshuma.com/compare/elevenlabs-vs-murf-ai.html",
+    "@type":"Article",
+    "headline":"ElevenLabs vs Murf AI 2026: Pricing, Voice Cloning & Commercial Use",
+    "dateModified":"2026-09-08",
+    "publisher":{"@type":"Organization","name":"COSHUMA","url":"https://coshuma.com/"},
+    "mainEntityOfPage":"https://coshuma.com/compare/elevenlabs-vs-murf-ai.html",
     "about":[
-      {"@type":"SoftwareApplication","name":"ElevenLabs","url":"https://coshuma.com/tool/elevenlabs.html"},
-      {"@type":"SoftwareApplication","name":"Murf AI","url":"https://coshuma.com/tool/murf-ai.html"}
+      {"@type":"SoftwareApplication","name":"ElevenLabs","url":"https://elevenlabs.io/"},
+      {"@type":"SoftwareApplication","name":"Murf AI","url":"https://murf.ai/"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"Which is cheaper, ElevenLabs or Murf AI?","acceptedAnswer":{"@type":"Answer","text":"Both currently offer a free starting point. ElevenLabs lists Starter at $6 per month and Creator at $22 per month, with the first Creator month currently shown at $11. Murf lists Creator from $19 per month when billed annually and Business from $66 per month when billed annually."}},
+      {"@type":"Question","name":"Which is better for commercial voiceovers?","acceptedAnswer":{"@type":"Answer","text":"ElevenLabs includes a commercial license from its Starter plan. Murf states that paid Studio plans include commercial rights. The better choice depends on whether you value ElevenLabs' broader generative voice stack or Murf's studio-oriented production workflow."}},
+      {"@type":"Question","name":"Can I test both before paying?","acceptedAnswer":{"@type":"Answer","text":"Yes. ElevenLabs currently offers a $0 Free plan with 10,000 monthly credits. Murf currently offers a $0 Free tier with 10 minutes of voice generation, two projects and one editor, with no credit card required."}}
     ]
   }
   </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="/affiliate-attribution.js"></script>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <style>
-    body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}
-  </style>
+  <style>body{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}</style>
 </head>
-<body class="min-h-screen bg-[#0b0c10] text-slate-100">
-  <header class="border-b border-[#222538] bg-[#07080c]/90 sticky top-0 z-50 py-4 px-6 backdrop-blur-md">
-    <div class="max-w-5xl mx-auto flex items-center justify-between">
-      <a href="/" class="font-extrabold text-white">GlobalSaaSHub</a>
-      <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">← All Tools</a>
+<body class="bg-[#08090d] text-slate-100 antialiased">
+  <header class="sticky top-0 z-50 border-b border-white/10 bg-[#08090d]/90 backdrop-blur">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-5 py-4">
+      <a href="/" class="text-xl font-black tracking-tight text-white">COSHUMA</a>
+      <a href="/" class="text-sm font-bold text-slate-400 hover:text-white">← Browse AI & SaaS tools</a>
     </div>
   </header>
 
-  <main class="max-w-5xl mx-auto px-4 py-10 space-y-8">
-    <section class="text-center space-y-4">
-      <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Voice AI buyer comparison</div>
-      <h1 class="text-4xl md:text-5xl font-black tracking-tight">ElevenLabs vs Murf AI</h1>
-      <p class="max-w-3xl mx-auto text-slate-300">Both products cover AI voice creation. The useful decision is which workflow fits your job: ElevenLabs is positioned here for voice cloning, text-to-speech and sound-generation workflows, while Murf AI is positioned for studio-style voice production with cloning, editing and background-audio capabilities.</p>
+  <main class="mx-auto max-w-6xl px-5 py-12 sm:py-16">
+    <nav class="mb-7 text-sm text-slate-500"><a class="hover:text-white" href="/">Home</a> <span class="px-2">/</span> <a class="hover:text-white" href="/compare/index.html">Comparisons</a> <span class="px-2">/</span> ElevenLabs vs Murf AI</nav>
+
+    <section class="grid gap-8 lg:grid-cols-[1.25fr_.75fr] lg:items-start">
+      <div>
+        <div class="inline-flex rounded-full border border-violet-400/20 bg-violet-400/10 px-3 py-1 text-xs font-black text-violet-200">Pricing & product facts checked Sep 8, 2026</div>
+        <h1 class="mt-5 text-4xl font-black tracking-[-0.04em] text-white sm:text-6xl">ElevenLabs vs Murf AI: which voice platform should you pay for?</h1>
+        <p class="mt-5 max-w-3xl text-lg leading-8 text-slate-300">Choose <strong class="text-white">ElevenLabs</strong> when you want a broad creative voice stack spanning text-to-speech, voice cloning, sound effects, music and multiple production surfaces. Choose <strong class="text-white">Murf AI</strong> when your priority is a more studio-oriented business voiceover workflow with clear paid-plan commercial rights and a simple path from testing to production.</p>
+        <div class="mt-7 grid gap-3 sm:grid-cols-2">
+          <a data-cta="affiliate" data-tool-id="elevenlabs" data-cta-source="elevenlabs-vs-murf-hero-elevenlabs" href="https://try.elevenlabs.io/ldc2xmh2x2t5" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-violet-600 px-6 py-4 text-center font-black text-white hover:bg-violet-500">Try ElevenLabs →</a>
+          <a data-cta="affiliate" data-tool-id="murf-ai" data-cta-source="elevenlabs-vs-murf-hero-murf" href="https://get.murf.ai/fqac0vixj0qs" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-cyan-600 px-6 py-4 text-center font-black text-white hover:bg-cyan-500">Try Murf AI →</a>
+        </div>
+        <p class="mt-3 text-xs leading-5 text-slate-500">Affiliate disclosure: COSHUMA may earn a commission from an eligible signup or purchase through either sponsored link, at no extra cost to you.</p>
+      </div>
+
+      <aside class="rounded-3xl border border-white/10 bg-[#11131a] p-6">
+        <div class="text-xs font-black uppercase tracking-widest text-emerald-300">Fast verdict</div>
+        <div class="mt-3 space-y-4 text-sm leading-6 text-slate-300">
+          <p><strong class="text-white">Best low-cost paid entry:</strong> ElevenLabs Starter at $6/month.</p>
+          <p><strong class="text-white">Best for studio-style business voiceover:</strong> Murf Creator, from $19/month when billed annually.</p>
+          <p><strong class="text-white">Safest first move:</strong> test the same 60–90 second script on both free tiers before subscribing.</p>
+        </div>
+      </aside>
     </section>
 
-    <section class="grid md:grid-cols-2 gap-5">
-      <article class="rounded-3xl bg-[#131520] border border-purple-500/30 p-6 space-y-5">
-        <div>
-          <div class="text-xs font-bold text-purple-300 uppercase tracking-wider">Choose ElevenLabs when</div>
-          <h2 class="text-2xl font-black mt-1">Voice generation flexibility matters most</h2>
-        </div>
-        <ul class="space-y-2 text-sm text-slate-300">
-          <li>✓ AI voice cloning</li>
-          <li>✓ Text-to-speech</li>
-          <li>✓ Sound effects generation</li>
-          <li>✓ Multi-lingual support</li>
+    <section class="mt-14">
+      <div class="text-xs font-black uppercase tracking-[0.2em] text-violet-300">Current pricing</div>
+      <h2 class="mt-2 text-3xl font-black">ElevenLabs vs Murf AI pricing in 2026</h2>
+      <p class="mt-3 max-w-4xl text-sm leading-7 text-slate-400">ElevenLabs publishes monthly Creative-plan pricing. Murf's public product pages currently summarize Creator and Business from annual-billing prices. Taxes, billing cadence, add-ons and product surfaces can change the checkout total.</p>
+      <div class="mt-6 overflow-x-auto rounded-2xl border border-white/10">
+        <table class="w-full min-w-[820px] text-left text-sm">
+          <thead class="bg-white/[0.04] text-slate-300"><tr><th class="p-4">Product</th><th class="p-4">Free</th><th class="p-4">Entry paid</th><th class="p-4">Next useful tier</th><th class="p-4">Buyer signal</th></tr></thead>
+          <tbody class="divide-y divide-white/10 text-slate-300">
+            <tr><td class="p-4 font-black text-white">ElevenLabs</td><td class="p-4">$0 · 10k credits/mo</td><td class="p-4">Starter $6/mo</td><td class="p-4">Creator $22/mo; first month currently $11</td><td class="p-4">Commercial license + instant cloning start at Starter; professional cloning at Creator</td></tr>
+            <tr><td class="p-4 font-black text-white">Murf AI</td><td class="p-4">$0 · 10 min voice generation · 2 projects</td><td class="p-4">Creator from $19/mo billed annually</td><td class="p-4">Business from $66/mo billed annually</td><td class="p-4">Paid Studio plans include commercial rights; higher tiers add capacity and business features</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="mt-4 grid gap-3 sm:grid-cols-2">
+        <a href="https://elevenlabs.io/pricing" target="_blank" rel="noopener noreferrer" class="rounded-xl border border-violet-400/20 bg-violet-400/[0.06] px-5 py-3 text-center font-bold text-violet-200 hover:bg-violet-400/10">Verify ElevenLabs live pricing →</a>
+        <a href="https://murf.ai/pricing" target="_blank" rel="noopener noreferrer" class="rounded-xl border border-cyan-400/20 bg-cyan-400/[0.06] px-5 py-3 text-center font-bold text-cyan-200 hover:bg-cyan-400/10">Verify Murf live pricing →</a>
+      </div>
+    </section>
+
+    <section class="mt-14 grid gap-5 lg:grid-cols-2">
+      <article class="rounded-3xl border border-violet-400/25 bg-violet-400/[0.06] p-6 sm:p-8">
+        <div class="text-xs font-black uppercase tracking-widest text-violet-300">Choose ElevenLabs when</div>
+        <h2 class="mt-2 text-2xl font-black">You want the broader creative voice stack</h2>
+        <ul class="mt-5 space-y-3 text-sm leading-6 text-slate-300">
+          <li>✓ You want text-to-speech plus speech-to-text, sound effects, voice design and music in one credit system.</li>
+          <li>✓ Instant voice cloning matters at a low paid entry point.</li>
+          <li>✓ Professional voice cloning is important enough to justify Creator or above.</li>
+          <li>✓ You may later need higher-end API audio quality, team seats or large credit pools.</li>
         </ul>
-        <a data-cta="affiliate" data-tool-id="elevenlabs" href="https://try.elevenlabs.io/ldc2xmh2x2t5" target="_blank" rel="sponsored noopener noreferrer" class="block w-full py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white text-center shadow-lg">Try ElevenLabs via verified partner link →</a>
-        <a href="/tool/elevenlabs.html" class="block text-center text-xs text-slate-400 hover:text-white">See the ElevenLabs detail page</a>
+        <a data-cta="affiliate" data-tool-id="elevenlabs" data-cta-source="elevenlabs-vs-murf-fit-elevenlabs" href="https://try.elevenlabs.io/ldc2xmh2x2t5" target="_blank" rel="sponsored noopener noreferrer" class="mt-6 block rounded-xl bg-violet-600 px-5 py-3.5 text-center font-black text-white hover:bg-violet-500">Start with ElevenLabs Free →</a>
       </article>
 
-      <article class="rounded-3xl bg-[#131520] border border-blue-500/30 p-6 space-y-5">
-        <div>
-          <div class="text-xs font-bold text-blue-300 uppercase tracking-wider">Choose Murf AI when</div>
-          <h2 class="text-2xl font-black mt-1">A studio-style voice workflow fits better</h2>
-        </div>
-        <ul class="space-y-2 text-sm text-slate-300">
-          <li>✓ Studio-quality AI voices</li>
-          <li>✓ Custom voice cloning</li>
-          <li>✓ Speech-to-text editor</li>
-          <li>✓ Background music and sound</li>
+      <article class="rounded-3xl border border-cyan-400/25 bg-cyan-400/[0.06] p-6 sm:p-8">
+        <div class="text-xs font-black uppercase tracking-widest text-cyan-300">Choose Murf AI when</div>
+        <h2 class="mt-2 text-2xl font-black">You want a business voiceover studio workflow</h2>
+        <ul class="mt-5 space-y-3 text-sm leading-6 text-slate-300">
+          <li>✓ You want a straightforward voiceover workflow for YouTube, training, ads, presentations or client content.</li>
+          <li>✓ Commercial rights on paid Studio plans are a key buying requirement.</li>
+          <li>✓ You want to test pronunciation, pacing and voice fit with a time-based free allowance first.</li>
+          <li>✓ A creator-to-business upgrade path is easier for your team to budget than a broad generative credit stack.</li>
         </ul>
-        <a data-cta="affiliate" data-tool-id="murf-ai" href="https://get.murf.ai/fqac0vixj0qs" target="_blank" rel="sponsored noopener noreferrer" class="block w-full py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white text-center shadow-lg">Try Murf AI via verified partner link →</a>
-        <a href="/tool/murf-ai.html" class="block text-center text-xs text-slate-400 hover:text-white">See the Murf AI detail page</a>
+        <a data-cta="affiliate" data-tool-id="murf-ai" data-cta-source="elevenlabs-vs-murf-fit-murf" href="https://get.murf.ai/fqac0vixj0qs" target="_blank" rel="sponsored noopener noreferrer" class="mt-6 block rounded-xl bg-cyan-600 px-5 py-3.5 text-center font-black text-white hover:bg-cyan-500">Start with Murf Free →</a>
       </article>
     </section>
 
-    <section class="rounded-3xl bg-[#131520] border border-[#222538] p-6 space-y-5">
-      <h2 class="text-2xl font-black">Fast decision guide</h2>
-      <div class="grid md:grid-cols-3 gap-4 text-sm">
-        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white mb-1">Need cloned or generated voices?</div><p class="text-slate-400">Both are relevant. Compare the actual output and workflow before committing to a paid plan.</p></div>
-        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white mb-1">Need sound effects too?</div><p class="text-slate-400">ElevenLabs lists sound effects generation among the capabilities captured in our current tool data.</p></div>
-        <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="font-bold text-white mb-1">Need a studio-oriented editor?</div><p class="text-slate-400">Murf AI lists speech-to-text editing plus background music and sound among the capabilities captured in our current tool data.</p></div>
+    <section class="mt-14 rounded-3xl border border-white/10 bg-[#11131a] p-6 sm:p-8">
+      <h2 class="text-3xl font-black">The purchase test that matters more than feature count</h2>
+      <p class="mt-4 max-w-4xl leading-7 text-slate-300">Use the <strong class="text-white">same script, same language and same target use case</strong> on both free tiers. Compare pronunciation, emotional fit, edit time, export friction and the exact paid feature that blocks you. If ElevenLabs wins on voice variety but Murf saves meaningful editing time, the cheaper sticker price may not be the cheaper production workflow—and vice versa.</p>
+      <div class="mt-6 grid gap-4 md:grid-cols-3">
+        <div class="rounded-2xl border border-white/10 bg-white/[0.03] p-5"><div class="font-black text-white">1. Same script</div><p class="mt-2 text-sm leading-6 text-slate-400">Use 60–90 seconds of text from a real project, not a demo sentence.</p></div>
+        <div class="rounded-2xl border border-white/10 bg-white/[0.03] p-5"><div class="font-black text-white">2. Same output goal</div><p class="mt-2 text-sm leading-6 text-slate-400">Judge the exact YouTube, ad, eLearning, podcast or product-demo workflow you plan to monetize.</p></div>
+        <div class="rounded-2xl border border-white/10 bg-white/[0.03] p-5"><div class="font-black text-white">3. Pay for the blocker</div><p class="mt-2 text-sm leading-6 text-slate-400">Upgrade only when cloning, commercial rights, quality, credits or collaboration actually prevents delivery.</p></div>
       </div>
-      <p class="text-xs text-slate-500">Pricing and plan limits can change. Check the vendor page reached through the button before purchasing.</p>
     </section>
 
-    <section class="rounded-3xl bg-gradient-to-r from-purple-950/50 to-blue-950/50 border border-purple-500/20 p-6 text-center space-y-4">
-      <h2 class="text-2xl font-black">Ready to test one?</h2>
-      <p class="text-sm text-slate-300">Use the verified partner link for the product you actually want to evaluate. COSHUMA may earn a commission if an eligible signup or purchase is attributed, at no extra cost to you.</p>
-      <div class="grid sm:grid-cols-2 gap-3 max-w-2xl mx-auto">
-        <a data-cta="affiliate" data-tool-id="elevenlabs" href="https://try.elevenlabs.io/ldc2xmh2x2t5" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-sm text-white">Open ElevenLabs →</a>
-        <a data-cta="affiliate" data-tool-id="murf-ai" href="https://get.murf.ai/fqac0vixj0qs" target="_blank" rel="sponsored noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-sm text-white">Open Murf AI →</a>
+    <section class="mt-14">
+      <h2 class="text-3xl font-black">ElevenLabs vs Murf AI FAQ</h2>
+      <div class="mt-6 space-y-4">
+        <details class="rounded-2xl border border-white/10 bg-[#11131a] p-5"><summary class="cursor-pointer font-black">Which one has the cheaper paid starting price?</summary><p class="mt-3 text-sm leading-6 text-slate-400">ElevenLabs currently lists Starter at $6/month. Murf currently lists Creator from $19/month when billed annually. The products meter usage differently, so compare the allowance you actually need rather than price alone.</p></details>
+        <details class="rounded-2xl border border-white/10 bg-[#11131a] p-5"><summary class="cursor-pointer font-black">Which one is better for commercial YouTube or client voiceovers?</summary><p class="mt-3 text-sm leading-6 text-slate-400">Both can support commercial production on paid tiers. ElevenLabs includes a commercial license from Starter. Murf states paid Studio plans include commercial rights. Check the exact vendor terms for your content and platform before publishing.</p></details>
+        <details class="rounded-2xl border border-white/10 bg-[#11131a] p-5"><summary class="cursor-pointer font-black">Which one is better for voice cloning?</summary><p class="mt-3 text-sm leading-6 text-slate-400">ElevenLabs currently makes instant voice cloning available from Starter and professional voice cloning from Creator. Murf offers voice-cloning capabilities within its broader paid platform; test consent, quality and workflow requirements before choosing.</p></details>
       </div>
+    </section>
+
+    <section class="mt-14 rounded-3xl border border-emerald-400/25 bg-gradient-to-br from-emerald-400/10 to-cyan-400/5 p-7 sm:p-9">
+      <div class="max-w-3xl"><div class="text-xs font-black uppercase tracking-widest text-emerald-300">Lowest-risk next step</div><h2 class="mt-2 text-3xl font-black">Run the same real-world voice test on both free tiers</h2><p class="mt-3 leading-7 text-slate-300">Do not subscribe from a feature checklist. Generate the same real script first, then buy the platform that reduces your actual production friction.</p></div>
+      <div class="mt-6 grid gap-3 sm:grid-cols-2">
+        <a data-cta="affiliate" data-tool-id="elevenlabs" data-cta-source="elevenlabs-vs-murf-bottom-elevenlabs" href="https://try.elevenlabs.io/ldc2xmh2x2t5" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-violet-600 px-6 py-4 text-center font-black text-white hover:bg-violet-500">Test ElevenLabs →</a>
+        <a data-cta="affiliate" data-tool-id="murf-ai" data-cta-source="elevenlabs-vs-murf-bottom-murf" href="https://get.murf.ai/fqac0vixj0qs" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-cyan-600 px-6 py-4 text-center font-black text-white hover:bg-cyan-500">Test Murf AI →</a>
+      </div>
+    </section>
+
+    <section class="mt-10 grid gap-4 sm:grid-cols-2">
+      <a href="/tool/elevenlabs.html" class="rounded-2xl border border-white/10 bg-white/[0.03] p-5 hover:bg-white/[0.06]"><div class="font-black text-white">Read the ElevenLabs buyer guide →</div><p class="mt-2 text-sm text-slate-400">Plan details, credits and upgrade fit.</p></a>
+      <a href="/tool/murf-ai.html" class="rounded-2xl border border-white/10 bg-white/[0.03] p-5 hover:bg-white/[0.06]"><div class="font-black text-white">Read the Murf AI buyer guide →</div><p class="mt-2 text-sm text-slate-400">Studio pricing, commercial rights and use cases.</p></a>
     </section>
   </main>
 
-  <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-    <div class="max-w-5xl mx-auto px-4">&copy; 2026 GlobalSaaSHub. Independent comparison and affiliate disclosure included.</div>
-  </footer>
+  <footer class="mt-16 border-t border-white/10 bg-[#07080c] py-8 text-center text-xs text-slate-500">© 2026 COSHUMA. Independent AI & SaaS buyer guides.</footer>
 </body>
 </html>


### PR DESCRIPTION
Refreshes the existing high-intent ElevenLabs vs Murf AI comparison with current official pricing facts checked on 2026-09-08, COSHUMA branding, stronger buyer-decision structure, FAQ schema, and only the already-verified customer-facing affiliate URLs for both vendors. No new affiliate enrollment, paid action, or unverified revenue claim.