### PR TITLE
COSHUMA: add traffic and revenue operations dashboard

### DIFF
--- a/projects/GlobalSaaSHub/public/ops/traffic-revenue-data.json
+++ b/projects/GlobalSaaSHub/public/ops/traffic-revenue-data.json
@@ -1,0 +1,53 @@
+{
+  "generated_at": "2026-09-08T23:10:00+09:00",
+  "status": "partial",
+  "metrics": {
+    "today_users": null,
+    "today_users_note": "GA4 Data API 미연결 — 추정하지 않음",
+    "sessions_7d": null,
+    "sessions_7d_note": "GA4 Data API 미연결 — 추정하지 않음",
+    "affiliate_clicks_30d": null,
+    "affiliate_clicks_30d_note": "affiliate_click 이벤트는 수집 중이나 이 정적 화면에서 과거 집계 API는 미연결",
+    "verified_revenue": null,
+    "verified_revenue_currency": "USD",
+    "verified_revenue_note": "파트너별 실제 수익 데이터 통합 미연결 — 수익 발생을 추정하지 않음"
+  },
+  "snapshot": [
+    {
+      "label": "GA4 수집 식별자",
+      "value": "G-J7E0J89VCV",
+      "period": "현재",
+      "source": "projects/GlobalSaaSHub/public/affiliate-attribution.js"
+    },
+    {
+      "label": "페이지 유입 이벤트",
+      "value": "page_view",
+      "period": "현재",
+      "source": "affiliate-attribution.js"
+    },
+    {
+      "label": "제휴 클릭 이벤트",
+      "value": "affiliate_click",
+      "period": "현재",
+      "source": "affiliate-attribution.js"
+    },
+    {
+      "label": "캠페인 attribution",
+      "value": "UTM + entry_page + entry_referrer",
+      "period": "현재 세션",
+      "source": "affiliate-attribution.js"
+    },
+    {
+      "label": "과거 방문자/세션 숫자",
+      "value": "미연결",
+      "period": "현재",
+      "source": "GA4 Data API 연결 필요"
+    },
+    {
+      "label": "가입/구매/커미션",
+      "value": "미연결",
+      "period": "현재",
+      "source": "각 제휴 네트워크의 검증된 전환 데이터 연결 필요"
+    }
+  ]
+}

--- a/projects/GlobalSaaSHub/public/ops/traffic-revenue.html
+++ b/projects/GlobalSaaSHub/public/ops/traffic-revenue.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="robots" content="noindex,nofollow,noarchive" />
+  <title>COSHUMA 유입·전환 운영 대시보드</title>
+  <style>
+    :root{color-scheme:dark;--bg:#07090d;--panel:#0f131b;--line:#242b38;--muted:#94a3b8;--text:#f8fafc;--ok:#34d399;--warn:#fbbf24;--bad:#fb7185;--accent:#a78bfa}
+    *{box-sizing:border-box}body{margin:0;background:linear-gradient(180deg,#090b12,#050608 55%);color:var(--text);font-family:Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.wrap{max-width:1180px;margin:0 auto;padding:28px 18px 56px}.top{display:flex;gap:18px;justify-content:space-between;align-items:flex-start;flex-wrap:wrap}.eyebrow{font-size:12px;font-weight:800;letter-spacing:.14em;color:#c4b5fd;text-transform:uppercase}.title{font-size:30px;line-height:1.15;margin:7px 0 8px}.sub{max-width:820px;color:var(--muted);line-height:1.7;font-size:14px}.actions{display:flex;gap:8px;flex-wrap:wrap}.btn{display:inline-flex;align-items:center;justify-content:center;padding:10px 13px;border-radius:10px;border:1px solid var(--line);background:#111722;color:#e2e8f0;text-decoration:none;font-weight:800;font-size:13px}.btn:hover{border-color:#475569}.btn.primary{background:#6d28d9;border-color:#7c3aed;color:white}.grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px;margin-top:22px}.card{background:rgba(15,19,27,.92);border:1px solid var(--line);border-radius:16px;padding:17px}.label{font-size:12px;color:var(--muted);font-weight:700}.metric{font-size:27px;font-weight:900;margin:8px 0 4px}.hint{font-size:12px;color:#64748b;line-height:1.55}.section{margin-top:18px}.section h2{font-size:18px;margin:0 0 12px}.two{display:grid;grid-template-columns:1.2fr .8fr;gap:12px}.status{display:flex;align-items:center;gap:9px;padding:10px 0;border-bottom:1px solid #1b2230}.status:last-child{border-bottom:0}.dot{width:9px;height:9px;border-radius:99px;background:#64748b;flex:0 0 auto}.dot.ok{background:var(--ok);box-shadow:0 0 0 4px rgba(52,211,153,.08)}.dot.warn{background:var(--warn);box-shadow:0 0 0 4px rgba(251,191,36,.08)}.status strong{font-size:13px}.status span{font-size:12px;color:var(--muted);margin-left:auto;text-align:right}.tablewrap{overflow:auto;border:1px solid var(--line);border-radius:14px}.table{width:100%;border-collapse:collapse;min-width:760px;background:rgba(15,19,27,.9)}.table th,.table td{padding:11px 12px;text-align:left;border-bottom:1px solid #1d2430;font-size:12px;vertical-align:top}.table th{color:#cbd5e1;background:#111722}.table td{color:#94a3b8}.table tr:last-child td{border-bottom:0}.pill{display:inline-block;padding:4px 7px;border-radius:999px;background:#172033;border:1px solid #28334a;color:#cbd5e1;font-size:11px;font-weight:800}.pill.ok{color:#a7f3d0;border-color:#14532d;background:#052e1e}.pill.warn{color:#fde68a;border-color:#713f12;background:#2d1b05}.note{margin-top:12px;border:1px solid #3730a3;background:rgba(49,46,129,.18);padding:13px 14px;border-radius:12px;color:#c7d2fe;font-size:12px;line-height:1.65}.mono{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;word-break:break-all}.kv{display:grid;grid-template-columns:130px 1fr;gap:7px 10px;font-size:12px}.kv div:nth-child(odd){color:#64748b}.kv div:nth-child(even){color:#cbd5e1;word-break:break-all}.footer{margin-top:24px;color:#64748b;font-size:11px;line-height:1.6}@media(max-width:900px){.grid{grid-template-columns:repeat(2,minmax(0,1fr))}.two{grid-template-columns:1fr}}@media(max-width:520px){.grid{grid-template-columns:1fr}.title{font-size:25px}}
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <div class="top">
+      <div>
+        <div class="eyebrow">COSHUMA OPERATIONS</div>
+        <h1 class="title">유입 → 제휴 클릭 → 수익 연결 상태</h1>
+        <p class="sub">이 페이지는 공개 정적 사이트 안에서 민감한 인증정보를 노출하지 않는 운영용 상태판이다. GA4는 현재 사이트 이벤트를 수집하고 있으며, 과거 방문자·세션·전환 숫자를 이 화면에 직접 표시하려면 서버 측 GA4 Data API 연결이 필요하다. 연결 전 숫자는 추정하지 않고 <b>미연결</b>로 표시한다.</p>
+      </div>
+      <div class="actions">
+        <a class="btn primary" href="https://analytics.google.com/" target="_blank" rel="noopener noreferrer">Google Analytics 열기</a>
+        <a class="btn" href="https://search.google.com/search-console" target="_blank" rel="noopener noreferrer">Search Console 열기</a>
+        <a class="btn" href="/" target="_blank">COSHUMA 열기</a>
+      </div>
+    </div>
+
+    <section class="grid" aria-label="핵심 지표">
+      <div class="card"><div class="label">오늘 방문자</div><div class="metric" id="todayUsers">—</div><div class="hint" id="todayUsersHint">GA4 Data API 미연결</div></div>
+      <div class="card"><div class="label">최근 7일 세션</div><div class="metric" id="sessions7d">—</div><div class="hint" id="sessions7dHint">GA4 Data API 미연결</div></div>
+      <div class="card"><div class="label">최근 30일 제휴 클릭</div><div class="metric" id="affiliateClicks30d">—</div><div class="hint" id="affiliateClicks30dHint">GA4 affiliate_click 이벤트 수집 중</div></div>
+      <div class="card"><div class="label">확인된 수익</div><div class="metric" id="verifiedRevenue">—</div><div class="hint" id="verifiedRevenueHint">파트너 수익 데이터 미연결</div></div>
+    </section>
+
+    <section class="section two">
+      <div class="card">
+        <h2>수집·연결 상태</h2>
+        <div class="status"><i class="dot ok"></i><strong>GA4 기본 수집</strong><span>Measurement ID: <span class="mono">G-J7E0J89VCV</span></span></div>
+        <div class="status"><i class="dot ok"></i><strong>페이지 유입 이벤트</strong><span><span class="mono">page_view</span> + UTM + referrer + landing</span></div>
+        <div class="status"><i class="dot ok"></i><strong>제휴 CTA 클릭 이벤트</strong><span><span class="mono">affiliate_click</span> + tool + outbound domain</span></div>
+        <div class="status"><i class="dot warn"></i><strong>GA4 과거 지표 조회</strong><span>Data API 자격증명 미연결</span></div>
+        <div class="status"><i class="dot warn"></i><strong>Search Console 지표</strong><span>API 미연결</span></div>
+        <div class="status"><i class="dot warn"></i><strong>파트너 전환·커미션</strong><span>네트워크별 API/내보내기 미연결</span></div>
+        <div class="note">중요: Measurement ID는 수집용 공개 식별자라 이 페이지에 표시해도 인증 비밀키가 아니다. 반대로 GA4 서비스 계정 키, OAuth secret, 제휴 네트워크 토큰은 정적 HTML에 넣지 않는다.</div>
+      </div>
+
+      <div class="card">
+        <h2>현재 브라우저 유입 정보</h2>
+        <div class="kv">
+          <div>현재 경로</div><div id="currentPath">—</div>
+          <div>Referrer</div><div id="referrer">—</div>
+          <div>UTM source</div><div id="utmSource">—</div>
+          <div>UTM medium</div><div id="utmMedium">—</div>
+          <div>UTM campaign</div><div id="utmCampaign">—</div>
+          <div>저장 캠페인</div><div id="storedCampaign">—</div>
+        </div>
+        <div class="note">이 박스는 <b>지금 이 페이지를 연 브라우저 세션만</b> 보여준다. 전체 방문자 통계로 오해하면 안 된다.</div>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>수익 추적에 이미 포함된 이벤트·속성</h2>
+      <div class="tablewrap"><table class="table">
+        <thead><tr><th>이벤트</th><th>속성</th><th>용도</th><th>상태</th></tr></thead>
+        <tbody>
+          <tr><td><span class="pill">page_view</span></td><td class="mono">page_path, page_type, content_slug, tool_id</td><td>어떤 랜딩/도구/비교 페이지가 유입을 받는지 판별</td><td><span class="pill ok">수집 중</span></td></tr>
+          <tr><td><span class="pill">page_view</span></td><td class="mono">entry_page, entry_referrer</td><td>세션 최초 유입 페이지와 이전 사이트 확인</td><td><span class="pill ok">수집 중</span></td></tr>
+          <tr><td><span class="pill">page_view / affiliate_click</span></td><td class="mono">utm_source, utm_medium, utm_campaign, utm_content, utm_term</td><td>캠페인별 유입→클릭 attribution 연결</td><td><span class="pill ok">수집 중</span></td></tr>
+          <tr><td><span class="pill">affiliate_click</span></td><td class="mono">tool_id, cta_source, link_url, outbound_domain, link_text</td><td>어떤 제휴 도구와 CTA가 실제 클릭되는지 판별</td><td><span class="pill ok">수집 중</span></td></tr>
+          <tr><td><span class="pill warn">conversion / revenue</span></td><td>파트너 네트워크별 가입·구매·커미션</td><td>클릭 이후 실제 수익 KPI 확인</td><td><span class="pill warn">미연결</span></td></tr>
+        </tbody>
+      </table></div>
+    </section>
+
+    <section class="section">
+      <h2>데이터 스냅샷</h2>
+      <div class="tablewrap"><table class="table">
+        <thead><tr><th>항목</th><th>값</th><th>기간</th><th>근거</th></tr></thead>
+        <tbody id="snapshotRows"><tr><td colspan="4">/ops/traffic-revenue-data.json 확인 중…</td></tr></tbody>
+      </table></div>
+    </section>
+
+    <p class="footer">COSHUMA 내부 운영 참고용 · 검색엔진 색인 차단(noindex) · 이 화면 자체에는 개인정보, OAuth secret, 서비스 계정 키, 제휴 토큰을 저장하지 않는다.</p>
+  </main>
+<script>
+(function(){
+  const $=id=>document.getElementById(id);
+  const params=new URLSearchParams(location.search);
+  $('currentPath').textContent=location.pathname+location.search;
+  $('referrer').textContent=document.referrer||'direct';
+  $('utmSource').textContent=params.get('utm_source')||'없음';
+  $('utmMedium').textContent=params.get('utm_medium')||'없음';
+  $('utmCampaign').textContent=params.get('utm_campaign')||'없음';
+  try{
+    const raw=sessionStorage.getItem('coshuma_affiliate_campaign_v2');
+    $('storedCampaign').textContent=raw||'없음';
+  }catch(e){$('storedCampaign').textContent='브라우저 저장소 접근 불가';}
+
+  const setMetric=(id,value,hintId,hint)=>{if(value!==null&&value!==undefined){$(id).textContent=String(value);if(hint)$(hintId).textContent=hint;}};
+  fetch('/ops/traffic-revenue-data.json',{cache:'no-store'})
+    .then(r=>{if(!r.ok)throw new Error('snapshot unavailable');return r.json();})
+    .then(data=>{
+      setMetric('todayUsers',data.metrics?.today_users,'todayUsersHint',data.metrics?.today_users_note);
+      setMetric('sessions7d',data.metrics?.sessions_7d,'sessions7dHint',data.metrics?.sessions_7d_note);
+      setMetric('affiliateClicks30d',data.metrics?.affiliate_clicks_30d,'affiliateClicks30dHint',data.metrics?.affiliate_clicks_30d_note);
+      if(data.metrics?.verified_revenue!==null&&data.metrics?.verified_revenue!==undefined){$('verifiedRevenue').textContent=data.metrics.verified_revenue_currency+' '+data.metrics.verified_revenue;}
+      if(data.metrics?.verified_revenue_note)$('verifiedRevenueHint').textContent=data.metrics.verified_revenue_note;
+      const rows=[];
+      (data.snapshot||[]).forEach(item=>rows.push('<tr><td>'+esc(item.label)+'</td><td>'+esc(item.value)+'</td><td>'+esc(item.period||'—')+'</td><td>'+esc(item.source||'—')+'</td></tr>'));
+      $('snapshotRows').innerHTML=rows.length?rows.join(''):'<tr><td colspan="4">연결된 운영 스냅샷 없음</td></tr>';
+    })
+    .catch(()=>{$('snapshotRows').innerHTML='<tr><td colspan="4">운영 스냅샷 파일을 불러오지 못함 — 핵심 수치를 추정하지 않음</td></tr>';});
+  function esc(v){return String(v??'—').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[c]));}
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
무비용 운영 대시보드 추가.

- `/ops/traffic-revenue.html`: 유입→제휴 클릭→수익 연결 상태를 한 화면에서 확인
- 현재 실제 코드로 검증된 GA4 measurement ID와 `page_view` / `affiliate_click` 이벤트 계약 표시
- UTM, entry page/referrer, tool/outbound attribution 상태 표시
- 과거 방문자·세션·전환·수익은 API 미연결 상태에서 절대 추정하지 않고 `미연결`로 표시
- OAuth secret, 서비스 계정 키, 제휴 토큰 등 민감정보를 정적 페이지에 저장하지 않음
- `noindex,nofollow,noarchive` 적용
- `/ops/traffic-revenue-data.json` 스냅샷 계약 추가, 추후 서버 측/Actions 데이터 연결 가능

추가 유료 서비스 없음.