### PR TITLE
Revenue: refresh Synthesia pricing and buyer conversion guide

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/synthesia.html
+++ b/projects/GlobalSaaSHub/public/tool/synthesia.html
@@ -3,13 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Synthesia Pricing, Free Plan & AI Avatar Review (2026) | GlobalSaaSHub</title>
-  <meta name="description" content="Synthesia pricing, free plan, AI avatars, dubbing and buyer-fit guidance. Compare Basic, Starter, Creator and Enterprise before choosing Synthesia." />
+  <title>Synthesia Pricing 2026: Free, Starter $29, Creator $89 | COSHUMA</title>
+  <meta name="description" content="Synthesia pricing starts free. Compare Basic, Starter $29/mo, Creator $89/mo, annual prices, AI avatar limits, credits, video minutes and COSHUMA's verified partner route." />
   <link rel="canonical" href="https://coshuma.com/tool/synthesia.html" />
-  <meta property="og:type" content="website" />
+  <meta property="og:type" content="article" />
   <meta property="og:url" content="https://coshuma.com/tool/synthesia.html" />
-  <meta property="og:title" content="Synthesia Pricing, Free Plan & AI Avatar Review (2026)" />
-  <meta property="og:description" content="Current Synthesia pricing, free-plan limits, AI avatars, dubbing and buyer guidance." />
+  <meta property="og:site_name" content="COSHUMA" />
+  <meta property="og:title" content="Synthesia Pricing 2026: Free, Starter $29, Creator $89" />
+  <meta property="og:description" content="Current Synthesia pricing, credits, video limits, AI avatars and a practical free-vs-paid buying decision." />
   <script type="application/ld+json">
   {
     "@context":"https://schema.org",
@@ -17,8 +18,25 @@
     "name":"Synthesia",
     "operatingSystem":"Web",
     "applicationCategory":"VideoApplication",
-    "url":"https://coshuma.com/tool/synthesia.html",
-    "description":"AI video platform for creating videos with avatars, voices, translation and dubbing."
+    "url":"https://www.synthesia.io/",
+    "description":"AI video platform for creating videos with avatars, voiceovers, translation, dubbing and interactive video features.",
+    "offers": {
+      "@type":"AggregateOffer",
+      "lowPrice":"0",
+      "priceCurrency":"USD"
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"How much does Synthesia cost in 2026?","acceptedAnswer":{"@type":"Answer","text":"Synthesia currently lists Basic at $0 per month, Starter at $29 per month or $264 per year, Creator at $89 per month or $804 per year, and Enterprise with custom pricing."}},
+      {"@type":"Question","name":"Can I use Synthesia for free?","acceptedAnswer":{"@type":"Answer","text":"Yes. Synthesia's Basic plan is free and does not require a credit card. It includes 1,200 credits per month and is intended for testing AI video creation, avatars and voices before upgrading."}},
+      {"@type":"Question","name":"What is the difference between Synthesia Starter and Creator?","acceptedAnswer":{"@type":"Answer","text":"Starter is aimed at regular individual video creation and includes downloads, AI Video Assistant, dubbing, logo removal, one editor and three guests. Creator raises the monthly credit allowance, adds five Personal Avatars, API access, interactive videos, branded video pages, multiple avatars per scene, one editor and five guests."}},
+      {"@type":"Question","name":"Does Synthesia offer annual billing?","acceptedAnswer":{"@type":"Answer","text":"Yes. Synthesia currently lists Starter at $264 per year and Creator at $804 per year. Final checkout pricing and taxes can vary by location."}}
+    ]
   }
   </script>
   <script src="https://cdn.tailwindcss.com"></script>
@@ -28,55 +46,125 @@
   <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
 </head>
 <body class="min-h-screen flex flex-col justify-between">
-<header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-  <div class="max-w-5xl mx-auto flex items-center justify-between">
-    <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold">G</div><span class="font-extrabold text-lg">GlobalSaaSHub</span></a>
-    <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">← All Tools</a>
+<header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+  <div class="max-w-6xl mx-auto flex items-center justify-between gap-4">
+    <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold">C</div><span class="font-extrabold text-lg">COSHUMA</span></a>
+    <a href="/best/ai-video-generators.html" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">Compare AI video tools</a>
   </div>
 </header>
-<main class="max-w-5xl mx-auto px-4 py-10 w-full space-y-6">
-  <section class="p-7 md:p-9 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-6">
-    <div class="flex flex-col md:flex-row md:items-center justify-between gap-6">
-      <div class="flex items-center gap-5">
-        <img src="https://www.google.com/s2/favicons?domain=synthesia.io&sz=128" alt="Synthesia logo" class="h-16 w-16 rounded-2xl border border-[#222538] bg-slate-900 object-contain p-2" />
-        <div><div class="text-xs font-bold text-purple-300 mb-2">AI Video & Avatars</div><h1 class="text-4xl md:text-5xl font-black">Synthesia</h1><p class="text-slate-400 mt-2">Pricing, free plan and buyer guide — verified Sep 1, 2026</p></div>
+
+<main class="max-w-6xl mx-auto px-4 py-10 w-full space-y-7">
+  <section class="p-7 md:p-10 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl">
+    <div class="grid lg:grid-cols-[1fr_310px] gap-8 items-start">
+      <div>
+        <div class="text-xs font-extrabold uppercase tracking-[0.18em] text-purple-300">Verified Sep 8, 2026 · AI video buyer guide</div>
+        <h1 class="text-4xl md:text-5xl font-black tracking-tight mt-3">Synthesia pricing: start free, pay when downloads and production features matter</h1>
+        <p class="text-slate-300 mt-5 leading-relaxed max-w-3xl">Synthesia's current self-serve lineup is straightforward: <strong class="text-white">Basic $0</strong>, <strong class="text-white">Starter $29/month</strong>, and <strong class="text-white">Creator $89/month</strong>. For most buyers, the real decision is not whether the free editor works — it is whether downloads, dubbing, more avatars, API access and higher production capacity justify moving to a paid plan.</p>
+        <div class="flex flex-col sm:flex-row gap-3 mt-7">
+          <a data-cta="affiliate" data-tool-id="synthesia" data-cta-source="synthesia_hero" href="https://www.synthesia.io?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold bg-purple-600 hover:bg-purple-500 text-white text-center">Start Synthesia free →</a>
+          <a data-cta="official" data-tool-id="synthesia" data-cta-source="synthesia_hero_pricing" href="https://www.synthesia.io/pricing" target="_blank" rel="noopener noreferrer" class="px-6 py-4 rounded-xl font-bold bg-slate-800 border border-slate-600 text-white text-center">Verify live pricing</a>
+        </div>
+        <p class="text-[11px] text-slate-500 mt-3">Affiliate disclosure: COSHUMA may earn a commission if you purchase through the verified Synthesia partner link. This does not change COSHUMA's pricing or plan analysis.</p>
       </div>
-      <a data-cta="affiliate" data-tool-id="synthesia" href="https://www.synthesia.io?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-4 rounded-xl font-extrabold text-sm bg-purple-600 hover:bg-purple-500 text-white text-center">Start Synthesia free →</a>
-    </div>
-    <div class="p-4 rounded-xl bg-amber-500/5 border border-amber-500/20 text-xs text-slate-300">
-      Affiliate disclosure: GlobalSaaSHub may earn a commission if you purchase through the Synthesia link on this page, at no extra cost to you. Editorial information is kept separate from affiliate status.
+      <aside class="rounded-2xl border border-emerald-500/25 bg-emerald-500/5 p-6">
+        <div class="text-xs uppercase tracking-[0.15em] font-black text-emerald-300">Fast decision</div>
+        <p class="text-sm text-slate-300 mt-3"><strong class="text-white">Stay on Basic</strong> while you are validating video quality and workflow.</p>
+        <p class="text-sm text-slate-300 mt-3"><strong class="text-white">Choose Starter</strong> when downloads, dubbing, logo removal and regular production become necessary.</p>
+        <p class="text-sm text-slate-300 mt-3"><strong class="text-white">Choose Creator</strong> when you need more monthly production, Personal Avatars, API access or interactive video.</p>
+      </aside>
     </div>
   </section>
 
-  <section class="grid md:grid-cols-3 gap-4">
-    <div class="p-5 rounded-2xl bg-[#131520] border border-[#222538]"><div class="text-xs text-slate-400 font-bold">BASIC</div><div class="text-2xl font-black text-emerald-400 mt-1">Free</div><div class="text-xs text-slate-400 mt-1">No credit card required</div><p class="text-sm text-slate-300 mt-3">Up to 10 minutes of video per month and 25 AI-generated video assets.</p></div>
-    <div class="p-5 rounded-2xl bg-[#131520] border border-purple-500/40"><div class="text-xs text-purple-300 font-bold">STARTER</div><div class="text-2xl font-black text-emerald-400 mt-1">$29/mo</div><div class="text-xs text-slate-400 mt-1">Monthly billing · annual option available</div><p class="text-sm text-slate-300 mt-3">Downloads, AI Video Assistant, dubbing, logo removal, 1 editor and 3 guests.</p></div>
-    <div class="p-5 rounded-2xl bg-[#131520] border border-[#222538]"><div class="text-xs text-slate-400 font-bold">CREATOR</div><div class="text-2xl font-black text-emerald-400 mt-1">$89/mo</div><div class="text-xs text-slate-400 mt-1">Monthly billing · annual option available</div><p class="text-sm text-slate-300 mt-3">Up to 30 video minutes/month, 5 Personal Avatars, API access and interactive video features.</p></div>
+  <section class="rounded-3xl bg-[#131520] border border-[#222538] p-7 md:p-9">
+    <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-3">
+      <div>
+        <h2 class="text-2xl font-black">Current Synthesia plan snapshot</h2>
+        <p class="text-sm text-slate-400 mt-2">Official pricing and help-center information checked Sep 8, 2026. Credits are the shared usage currency across self-serve AI features.</p>
+      </div>
+      <a href="https://www.synthesia.io/pricing" target="_blank" rel="noopener noreferrer" class="text-sm font-bold text-purple-300">Official pricing ↗</a>
+    </div>
+    <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4 mt-6">
+      <div class="p-5 rounded-2xl bg-[#181a29] border border-emerald-500/25">
+        <div class="text-xs text-emerald-300 font-bold">BASIC</div><div class="text-3xl font-black mt-2">$0</div><div class="text-xs text-slate-500">per month · no card required</div>
+        <ul class="mt-4 text-sm text-slate-300 space-y-2"><li>✓ 1,200 credits/month</li><li>✓ Up to 10 video minutes/month</li><li>✓ Test avatars and voices</li><li>✓ 1 editor</li></ul>
+      </div>
+      <div class="p-5 rounded-2xl bg-purple-500/5 border border-purple-500/40">
+        <div class="text-xs text-purple-300 font-bold">STARTER</div><div class="text-3xl font-black mt-2">$29<span class="text-sm text-slate-400">/mo</span></div><div class="text-xs text-slate-500">or $264/year (~$22/mo)</div>
+        <ul class="mt-4 text-sm text-slate-300 space-y-2"><li>✓ 1,200 credits/month</li><li>✓ Downloads + logo removal</li><li>✓ AI Dubbing + Video Assistant</li><li>✓ 125+ AI avatars</li><li>✓ 1 editor + 3 guests</li></ul>
+      </div>
+      <div class="p-5 rounded-2xl bg-[#181a29] border border-fuchsia-500/35">
+        <div class="text-xs text-fuchsia-300 font-bold">CREATOR · MOST POPULAR</div><div class="text-3xl font-black mt-2">$89<span class="text-sm text-slate-400">/mo</span></div><div class="text-xs text-slate-500">or $804/year (~$67/mo)</div>
+        <ul class="mt-4 text-sm text-slate-300 space-y-2"><li>✓ 3,600 credits/month</li><li>✓ Up to 30 video minutes/month</li><li>✓ 5 Personal Avatars</li><li>✓ API + interactive videos</li><li>✓ 180+ AI avatars</li></ul>
+      </div>
+      <div class="p-5 rounded-2xl bg-[#181a29] border border-[#2d3146]">
+        <div class="text-xs text-slate-400 font-bold">ENTERPRISE</div><div class="text-2xl font-black mt-2">Custom</div><div class="text-xs text-slate-500">sales-assisted pricing</div>
+        <ul class="mt-4 text-sm text-slate-300 space-y-2"><li>✓ Unlimited video minutes</li><li>✓ Full avatar library</li><li>✓ SSO + shared workspaces</li><li>✓ Brand kits + higher API limits</li></ul>
+      </div>
+    </div>
+    <div class="mt-5 p-4 rounded-xl bg-amber-500/5 border border-amber-500/20 text-sm text-slate-300"><strong class="text-white">Credit note:</strong> Synthesia's help center says each second of generated video uses 2 credits. Unused allowances and feature-specific credit usage can vary by billing setup, so check the live dashboard before a high-volume project.</div>
+  </section>
+
+  <section class="grid lg:grid-cols-3 gap-5">
+    <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538]">
+      <div class="text-xs font-bold uppercase tracking-[0.14em] text-emerald-300">Basic</div>
+      <h2 class="text-xl font-black mt-2">Use free first</h2>
+      <p class="text-sm text-slate-300 mt-3 leading-relaxed">Basic is the lowest-risk test. Build one real training, sales or support video and judge avatar quality, pronunciation, editing speed and brand fit before paying.</p>
+    </div>
+    <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30">
+      <div class="text-xs font-bold uppercase tracking-[0.14em] text-purple-300">Starter</div>
+      <h2 class="text-xl font-black mt-2">Pay for production basics</h2>
+      <p class="text-sm text-slate-300 mt-3 leading-relaxed">Starter makes sense when the free workflow proves useful and you need to download finished videos, remove Synthesia branding, dub content or collaborate with a few guests.</p>
+    </div>
+    <div class="p-6 rounded-3xl bg-[#131520] border border-fuchsia-500/30">
+      <div class="text-xs font-bold uppercase tracking-[0.14em] text-fuchsia-300">Creator</div>
+      <h2 class="text-xl font-black mt-2">Upgrade for scale or integrations</h2>
+      <p class="text-sm text-slate-300 mt-3 leading-relaxed">Creator is the stronger fit when 30 minutes of monthly video capacity, Personal Avatars, API access, interactive video or extra guest seats are central to your workflow.</p>
+    </div>
+  </section>
+
+  <section class="rounded-3xl bg-gradient-to-br from-purple-500/10 to-cyan-500/5 border border-purple-500/30 p-7 md:p-9">
+    <div class="grid lg:grid-cols-[1fr_auto] gap-6 items-center">
+      <div>
+        <div class="text-xs font-black uppercase tracking-[0.16em] text-purple-300">Lowest-risk next step</div>
+        <h2 class="text-2xl md:text-3xl font-black mt-2">Create one real video before choosing a paid plan</h2>
+        <p class="text-slate-300 mt-3 max-w-3xl">Use a script you would actually publish. If Basic handles the quality test, keep it free. Upgrade only when a specific production limit — downloads, branding, capacity, API or collaboration — blocks the next real deliverable.</p>
+      </div>
+      <a data-cta="affiliate" data-tool-id="synthesia" data-cta-source="synthesia_decision_box" href="https://www.synthesia.io?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-7 py-4 rounded-xl font-extrabold bg-purple-600 hover:bg-purple-500 text-white text-center whitespace-nowrap">Test Synthesia free →</a>
+    </div>
+  </section>
+
+  <section class="grid lg:grid-cols-2 gap-5">
+    <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538]">
+      <h2 class="text-2xl font-black">Synthesia is a strong fit when…</h2>
+      <ul class="mt-5 text-sm text-slate-300 space-y-3"><li>✓ Training and onboarding videos need repeatable presenter-style production.</li><li>✓ Global teams need translation or dubbing across many languages.</li><li>✓ Marketing, sales or support teams want video without recurring camera shoots.</li><li>✓ Brand consistency and collaboration matter more than cinematic editing freedom.</li></ul>
+    </div>
+    <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538]">
+      <h2 class="text-2xl font-black">Compare another tool when…</h2>
+      <ul class="mt-5 text-sm text-slate-300 space-y-3"><li>• You mainly need script-to-stock-footage repurposing rather than avatar-led video.</li><li>• You need deep timeline editing, complex motion graphics or traditional post-production.</li><li>• Your production is mostly audio-first and avatar presentation is unnecessary.</li><li>• A cheaper tool already covers the exact video volume you publish each month.</li></ul>
+    </div>
   </section>
 
   <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-4">
-    <h2 class="text-2xl font-black">What you can do on the free plan</h2>
-    <p class="text-slate-300 leading-relaxed">Synthesia's current Basic plan is free and does not require a credit card. It lets you test the editor, stock and customizable avatars, voices and video generation before moving to a paid plan.</p>
-    <a data-cta="affiliate" data-tool-id="synthesia" href="https://www.synthesia.io?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex px-5 py-3 rounded-xl bg-emerald-600 hover:bg-emerald-500 text-white font-extrabold text-sm">Create a free Synthesia video →</a>
-  </section>
-
-  <section class="grid md:grid-cols-2 gap-4">
-    <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-3"><h2 class="text-xl font-black">Best fit</h2><ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>Training and onboarding teams that need repeatable video production</li><li>Global teams translating or dubbing content into many languages</li><li>Marketing and sales teams that want presenter-style videos without filming</li><li>Organizations that need branded workspaces, collaboration or enterprise controls</li></ul></div>
-    <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-3"><h2 class="text-xl font-black">Key capabilities</h2><ul class="text-sm text-slate-300 space-y-2 list-disc list-inside"><li>240+ stock AI avatars on Enterprise and a large avatar library on self-serve plans</li><li>Video creation and translation across 160+ languages</li><li>AI dubbing and lip-synced localization</li><li>Personal and customizable avatars</li><li>Interactive video and API capabilities on higher plans</li></ul></div>
+    <h2 class="text-xl font-black">Compare Synthesia with other AI video tools</h2>
+    <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-3">
+      <a href="/tool/pictory.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40"><div class="font-bold">Pictory</div><div class="text-xs text-slate-400 mt-1">Script and long-form content repurposing</div></a>
+      <a href="/compare/outlierkit-vs-pictory.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40"><div class="font-bold">AI video buyer comparisons</div><div class="text-xs text-slate-400 mt-1">Explore alternative creation workflows</div></a>
+      <a href="/best/ai-video-generators.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40"><div class="font-bold">Best AI video generators</div><div class="text-xs text-slate-400 mt-1">Shortlist tools by use case</div></a>
+      <a href="/tool/elevenlabs.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40"><div class="font-bold">ElevenLabs</div><div class="text-xs text-slate-400 mt-1">Voice-first AI production</div></a>
+    </div>
   </section>
 
   <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-4">
-    <h2 class="text-xl font-black">Compare Synthesia alternatives</h2>
-    <div class="grid sm:grid-cols-3 gap-3"><a href="/tool/pictory.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 font-bold">Pictory →</a><a href="/tool/tubebuddy.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 font-bold">TubeBuddy →</a><a href="/tool/outlierkit.html" class="p-4 rounded-xl bg-[#181a29] border border-[#222538] hover:border-purple-500/40 font-bold">OutlierKit →</a></div>
-  </section>
-
-  <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-3">
     <h2 class="text-xl font-black">Pricing source & freshness</h2>
-    <p class="text-sm text-slate-300">Pricing and plan limits were checked against Synthesia's official pricing page and July 2026 help-center guidance on September 1, 2026. Vendor pricing can change, so confirm the final amount at checkout.</p>
-    <a data-cta="official" href="https://www.synthesia.io/pricing" target="_blank" rel="noopener noreferrer" class="text-sm font-bold text-purple-300 hover:text-purple-200">View official Synthesia pricing →</a>
+    <p class="text-sm text-slate-300">COSHUMA checked Synthesia's official pricing page and current help-center documentation on Sep 8, 2026. The official sources list Basic at $0, Starter at $29/month or $264/year, Creator at $89/month or $804/year, and Enterprise as custom pricing. Vendor pricing, credits and feature limits can change, so verify the final checkout and account limits before purchasing.</p>
+    <div class="flex flex-col sm:flex-row gap-3">
+      <a data-cta="official" href="https://www.synthesia.io/pricing" target="_blank" rel="noopener noreferrer" class="px-5 py-3 rounded-xl bg-slate-800 border border-slate-600 text-white font-bold text-center">Open official pricing →</a>
+      <a data-cta="affiliate" data-tool-id="synthesia" data-cta-source="synthesia_footer" href="https://www.synthesia.io?via=sangkwon" target="_blank" rel="sponsored noopener noreferrer" class="px-5 py-3 rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-extrabold text-center">Start with COSHUMA partner link →</a>
+    </div>
   </section>
 </main>
-<footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">© 2026 GlobalSaaSHub · Global AI SaaS Decision Platform</footer>
+
+<footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">© 2026 COSHUMA · Independent AI & SaaS buyer guides</footer>
 <script defer src="/affiliate-attribution.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Revenue-priority, no-cost conversion refresh for the existing verified Synthesia partner route.

Verified before editing:
- customer-facing tracking URL remains exactly `https://www.synthesia.io?via=sangkwon` in repository affiliate evidence
- Synthesia official pricing checked 2026-09-08: Basic $0, Starter $29/mo or $264/year, Creator $89/mo or $804/year, Enterprise custom
- current help center confirms Basic/Starter/Creator plan structure and current credit model

Changes:
- remove legacy GlobalSaaSHub branding from Synthesia tool page
- strengthen title/meta for pricing purchase intent
- add current annual pricing and credit/plan decision context
- add FAQ structured data
- use verified Synthesia affiliate route in hero, buyer-decision and footer CTAs with attribution metadata
- retain official pricing fallback and clear affiliate disclosure

No new subscription, purchase, application, or unverified revenue claim.