### PR TITLE
Revenue: add verified software trials and partner offers hub

### DIFF
--- a/projects/GlobalSaaSHub/public/best/verified-software-free-trials-deals.html
+++ b/projects/GlobalSaaSHub/public/best/verified-software-free-trials-deals.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Verified SaaS Free Trials & Partner Offers (2026) | COSHUMA</title>
+  <meta name="description" content="Compare currently verified SaaS free trials and partner offers from Unbounce, Pictory, Brand24 and Bookyourdata. COSHUMA checks customer-facing links separately from product claims." />
+  <link rel="canonical" href="https://coshuma.com/best/verified-software-free-trials-deals.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/best/verified-software-free-trials-deals.html" />
+  <meta property="og:title" content="Verified SaaS Free Trials & Partner Offers (2026) | COSHUMA" />
+  <meta property="og:description" content="Low-risk software tests and verified COSHUMA partner paths, checked against current vendor information before you subscribe." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"ItemList",
+    "name":"Verified SaaS Free Trials & Partner Offers",
+    "url":"https://coshuma.com/best/verified-software-free-trials-deals.html",
+    "itemListElement":[
+      {"@type":"ListItem","position":1,"name":"Unbounce","url":"https://coshuma.com/tool/unbounce.html"},
+      {"@type":"ListItem","position":2,"name":"Pictory","url":"https://coshuma.com/best/pictory-free-trial-pricing.html"},
+      {"@type":"ListItem","position":3,"name":"Bookyourdata","url":"https://coshuma.com/best/bookyourdata-free-trial.html"},
+      {"@type":"ListItem","position":4,"name":"Brand24","url":"https://coshuma.com/best/brand24-free-trial.html"}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>body{font-family:Inter,system-ui,sans-serif;background:#08090d;color:#f1f5f9}</style>
+</head>
+<body class="min-h-screen bg-[#08090d] text-slate-100">
+  <header class="border-b border-white/10 bg-[#08090d]/90 backdrop-blur sticky top-0 z-40">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-5 py-4">
+      <a href="/" class="font-black tracking-tight text-white">COSHUMA</a>
+      <a href="/best/index.html" class="rounded-full border border-violet-400/30 bg-violet-500/10 px-4 py-2 text-xs font-bold text-violet-200">All buyer guides</a>
+    </div>
+  </header>
+
+  <main class="mx-auto max-w-6xl px-5 py-12 space-y-8">
+    <section class="rounded-3xl border border-violet-400/25 bg-gradient-to-br from-violet-500/10 to-cyan-500/5 p-7 md:p-11">
+      <div class="text-xs font-black uppercase tracking-[0.18em] text-violet-300">Checked September 8, 2026</div>
+      <h1 class="mt-3 max-w-4xl text-4xl font-black tracking-[-0.04em] text-white md:text-6xl">Software free trials and partner offers worth testing before you pay</h1>
+      <p class="mt-5 max-w-3xl text-base leading-7 text-slate-300 md:text-lg">This page prioritizes offers with a low-risk first step and a customer-facing path COSHUMA has actually verified. A dashboard, onboarding page or generic homepage is never treated as an affiliate link unless the program issued it for customer referrals.</p>
+      <div class="mt-6 flex flex-wrap gap-2 text-xs font-bold">
+        <span class="rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1.5 text-emerald-200">No invented discounts</span>
+        <span class="rounded-full border border-cyan-400/20 bg-cyan-400/10 px-3 py-1.5 text-cyan-200">Verified customer links</span>
+        <span class="rounded-full border border-amber-400/20 bg-amber-400/10 px-3 py-1.5 text-amber-100">Final terms controlled by vendor</span>
+      </div>
+    </section>
+
+    <section class="grid gap-5 lg:grid-cols-2">
+      <article class="rounded-3xl border border-violet-400/30 bg-[#11131a] p-7 space-y-5">
+        <div class="flex items-start justify-between gap-4">
+          <div><div class="text-xs font-black uppercase tracking-wider text-violet-300">Best partner discount</div><h2 class="mt-1 text-3xl font-black text-white">Unbounce</h2></div>
+          <span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">14-day trial</span>
+        </div>
+        <p class="text-sm leading-6 text-slate-300">Unbounce currently offers a 14-day free trial with no credit card required. COSHUMA's issued partner route also carries the verified customer offer described in our Unbounce guide: 20% off the first 3 months or 35% off the first annual subscription. Confirm the invitation and final checkout before relying on the discount.</p>
+        <div class="rounded-2xl border border-white/10 bg-white/[0.03] p-4 text-sm text-slate-300"><strong class="text-white">Good fit:</strong> marketers and agencies that need landing pages, A/B testing and conversion optimization rather than a broad website builder.</div>
+        <div class="grid gap-3 sm:grid-cols-2">
+          <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="verified_offers_unbounce" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-violet-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-violet-500">Start Unbounce trial + offer →</a>
+          <a href="/tool/unbounce.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Read exact offer details</a>
+        </div>
+        <p class="text-[11px] leading-5 text-slate-500">Official trial source: Unbounce pricing. Partner tracking cookie is 90 days according to Unbounce's current partner-program page.</p>
+      </article>
+
+      <article class="rounded-3xl border border-fuchsia-400/25 bg-[#11131a] p-7 space-y-5">
+        <div class="flex items-start justify-between gap-4">
+          <div><div class="text-xs font-black uppercase tracking-wider text-fuchsia-300">AI video trial + active code</div><h2 class="mt-1 text-3xl font-black text-white">Pictory</h2></div>
+          <span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">14 days free</span>
+        </div>
+        <p class="text-sm leading-6 text-slate-300">Pictory's current pricing page lists a 14-day free trial and annual pricing that can save up to 40%. Pictory's affiliate manager separately reconfirmed to COSHUMA that the existing affiliate link and promo code <strong class="text-white">COSHUMA20</strong> remain active. The affiliate link remains the primary attribution method.</p>
+        <div class="rounded-2xl border border-amber-400/20 bg-amber-400/[0.06] p-4 text-sm text-amber-100"><strong>Use code:</strong> COSHUMA20 · Verify the code and final price at checkout because vendor promotions can change.</div>
+        <div class="grid gap-3 sm:grid-cols-2">
+          <a data-cta="affiliate" data-tool-id="pictory" data-cta-source="verified_offers_pictory" href="https://pictory.ai?fpr=sangkwon-an23" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-fuchsia-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-fuchsia-500">Try Pictory via verified link →</a>
+          <a href="/best/pictory-discount-code.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Check Pictory offer guide</a>
+        </div>
+        <p class="text-[11px] leading-5 text-slate-500">Payout setup status is separate from referral tracking. COSHUMA does not claim a commission unless the affiliate system confirms it.</p>
+      </article>
+
+      <article class="rounded-3xl border border-cyan-400/25 bg-[#11131a] p-7 space-y-5">
+        <div class="flex items-start justify-between gap-4">
+          <div><div class="text-xs font-black uppercase tracking-wider text-cyan-300">Best zero-cost B2B data test</div><h2 class="mt-1 text-3xl font-black text-white">Bookyourdata</h2></div>
+          <span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">10 free leads</span>
+        </div>
+        <p class="text-sm leading-6 text-slate-300">Bookyourdata's current official pricing page offers 10 free credits with no subscription and no credit card required. Its paid model is pay-as-you-go rather than a mandatory recurring subscription.</p>
+        <div class="rounded-2xl border border-white/10 bg-white/[0.03] p-4 text-sm text-slate-300"><strong class="text-white">Lowest-risk test:</strong> define one narrow ICP, export the free sample, then check CRM fit and deliverability before buying a larger pack.</div>
+        <div class="grid gap-3 sm:grid-cols-2">
+          <a data-cta="affiliate" data-tool-id="bookyourdata" data-cta-source="verified_offers_bookyourdata" href="https://join.bookyourdata.com/swcyqmumr3s5" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-cyan-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-cyan-500">Get 10 free leads →</a>
+          <a href="/best/bookyourdata-free-trial.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Read free-lead guide</a>
+        </div>
+        <p class="text-[11px] leading-5 text-slate-500">Official source checked September 8, 2026: Bookyourdata pricing page.</p>
+      </article>
+
+      <article class="rounded-3xl border border-emerald-400/25 bg-[#11131a] p-7 space-y-5">
+        <div class="flex items-start justify-between gap-4">
+          <div><div class="text-xs font-black uppercase tracking-wider text-emerald-300">Brand monitoring trial</div><h2 class="mt-1 text-3xl font-black text-white">Brand24</h2></div>
+          <span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">No card</span>
+        </div>
+        <p class="text-sm leading-6 text-slate-300">Brand24's current pricing page says the first 14 days are free and no credit card is required. That makes the trial the safer first step before committing to its relatively high paid entry price.</p>
+        <div class="rounded-2xl border border-white/10 bg-white/[0.03] p-4 text-sm text-slate-300"><strong class="text-white">Good fit:</strong> teams that need social listening, reputation monitoring, competitor intelligence or AI-visibility signals and can validate real keyword volume during the trial.</div>
+        <div class="grid gap-3 sm:grid-cols-2">
+          <a data-cta="affiliate" data-tool-id="brand24" data-cta-source="verified_offers_brand24" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-emerald-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-emerald-500">Start Brand24 free trial →</a>
+          <a href="/best/brand24-free-trial.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Read Brand24 trial guide</a>
+        </div>
+        <p class="text-[11px] leading-5 text-slate-500">Official source checked September 8, 2026: Brand24 pricing page.</p>
+      </article>
+    </section>
+
+    <section class="rounded-3xl border border-white/10 bg-[#11131a] p-7 md:p-9">
+      <h2 class="text-2xl font-black text-white">How this list is gated</h2>
+      <div class="mt-5 grid gap-4 md:grid-cols-3 text-sm leading-6 text-slate-300">
+        <div class="rounded-2xl border border-white/10 p-5"><strong class="text-white">1. Public product claim</strong><br/>Trial, pricing or offer facts are checked against current vendor information where possible.</div>
+        <div class="rounded-2xl border border-white/10 p-5"><strong class="text-white">2. Customer-facing route</strong><br/>The affiliate URL must be specifically issued or otherwise verified as a referral path. Admin and dashboard URLs are excluded.</div>
+        <div class="rounded-2xl border border-white/10 p-5"><strong class="text-white">3. Revenue is separate</strong><br/>A valid link is not proof of a signup, sale or commission. COSHUMA reports revenue only when a partner system confirms it.</div>
+      </div>
+      <p class="mt-6 text-xs leading-5 text-slate-500">Affiliate disclosure: COSHUMA may earn a commission from eligible purchases attributed through some links on this page, at no extra cost to the buyer. This does not change editorial inclusion or ranking.</p>
+    </section>
+  </main>
+
+  <footer class="border-t border-white/10 py-8 text-center text-xs text-slate-500">© 2026 COSHUMA · Independent AI & SaaS buyer guides</footer>
+  <script defer src="/affiliate-attribution.js"></script>
+</body>
+</html>


### PR DESCRIPTION
COSHUMA revenue-focused, zero-cost change.

- Adds `/best/verified-software-free-trials-deals.html`
- Aggregates only currently verified customer-facing revenue paths for Unbounce, Pictory, Bookyourdata and Brand24
- Uses current low-risk trial/offer facts; does not treat dashboards/onboarding URLs as affiliate links
- Adds `data-cta="affiliate"`, tool IDs, CTA sources, sponsored attributes and existing attribution script
- Explicitly separates link validity from signup/sale/commission claims
- No paid service or subscription

The existing build already indexes all `/public/best/*.html` pages into the sitemap via `ensure_best_pages_in_sitemap.py`.