### PR TITLE
Confirm Fillout and Krater enrollment and issued COSHUMA tracking links

### DIFF
--- a/projects/GlobalSaaSHub/data/browser_required_queue.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.json
@@ -188,15 +188,15 @@
   {
     "id": "fillout-browser-followup-20260908",
     "priority": "medium",
-    "status": "application_submitted",
+    "status": "approved_tracking",
     "cost": "0",
-    "verified_at": "2026-09-07T17:19:00Z",
-    "reason": "User explicitly authorized acceptance of the prepared Fillout Program Terms. Existing form preserved, checkbox selected and Continue clicked once. Step 2 of 2 shows Application submitted / submitted for review. Notification address shown by existing Dub account is qmfforfhem@gmail.com. Application ID pga_1M1YE0ANQP8BPWPGEW2BENNGR. Promotional dashboard illustration is not actual earnings or a personal referral link.",
-    "next_action": "Await decision; do not reapply.",
-    "exact_tracking_url": null,
+    "verified_at": "2026-09-08T14:00:00+09:00",
+    "reason": "User explicitly authorized acceptance of the prepared Fillout Program Terms. Existing form preserved, checkbox selected and Continue clicked once. Step 2 of 2 shows Application submitted / submitted for review. Notification address shown by existing Dub account is qmfforfhem@gmail.com. Application ID pga_1M1YE0ANQP8BPWPGEW2BENNGR. Promotional dashboard illustration is not actual earnings or a personal referral link. Follow-up: authenticated Dub partner dashboard at partners.dub.co/programs/fillout now shows Approved/Enrolled with issued exact customer-facing tracking link try.fillout.com/sang-kwon-an-hxwn.",
+    "next_action": "Preserve the issued exact customer-facing link; do not reapply.",
+    "exact_tracking_url": "https://try.fillout.com/sang-kwon-an-hxwn",
     "blocker": null,
-    "execution_evidence": "affiliate-browser-results-2026-09-08.json",
-    "affiliate_status": "application_submitted"
+    "execution_evidence": "data/fillout-affiliate-enrollment-evidence-2026-09-08.md",
+    "affiliate_status": "approved_tracking"
   },
   {
     "id": "time2book-browser-followup-20260908",
@@ -602,13 +602,13 @@
     "tool_id": "krater",
     "priority": "high",
     "status": "resolved",
-    "affiliate_status": "application_submitted",
-    "exact_tracking_url": null,
+    "affiliate_status": "approved_tracking",
+    "exact_tracking_url": "https://go.krater.ai/sang-kwon-an",
     "cost": "0",
-    "verified_at": "2026-09-07T21:21:56.008052+00:00",
-    "reason": "Authenticated Chrome: after a pre-application company Gmail in:anywhere search found no matching messages, the Dub application was submitted once with COSHUMA, support@coshuma.com, https://coshuma.com and factual buyer-guide promotion text. Program terms accepted under explicit user authorization. Step 2 of 2 displayed Application submitted and stated the review update will be sent to support@coshuma.com. The decorative dashboard illustration on this success page is not real account revenue or an issued referral link. No approval or exact tracking URL was issued.",
-    "next_action": "Await the existing Krater application review in Dub; do not reapply. Only publish an issued exact customer-facing link after approval evidence.",
-    "evidence_file": "data/affiliate-submission-batch-2026-09-08.json"
+    "verified_at": "2026-09-08T14:00:00+09:00",
+    "reason": "Authenticated Chrome: after a pre-application company Gmail in:anywhere search found no matching messages, the Dub application was submitted once with COSHUMA, support@coshuma.com, https://coshuma.com and factual buyer-guide promotion text. Program terms accepted under explicit user authorization. Step 2 of 2 displayed Application submitted and stated the review update will be sent to support@coshuma.com. The decorative dashboard illustration on this success page is not real account revenue or an issued referral link. No approval or exact tracking URL was issued. Follow-up: authenticated Dub partner dashboard at partners.dub.co/programs/kraterai now shows Approved/Enrolled with issued exact customer-facing tracking link go.krater.ai/sang-kwon-an.",
+    "next_action": "Preserve the issued exact customer-facing link; do not reapply.",
+    "evidence_file": "data/krater-affiliate-enrollment-evidence-2026-09-08.md"
   },
   {
     "id": "eprofessor-affiliate-batch-20260908",

--- a/projects/GlobalSaaSHub/data/fillout-affiliate-enrollment-evidence-2026-09-08.md
+++ b/projects/GlobalSaaSHub/data/fillout-affiliate-enrollment-evidence-2026-09-08.md
@@ -1,0 +1,10 @@
+# Fillout affiliate enrollment confirmation — 2026-09-08
+
+- Program: Fillout Partner Program, managed via Dub (`partners.dub.co`).
+- Existing application (submitted 2026-09-07, application ID `pga_1M1YE0ANQP8BPWPGEW2BENNGR`) was previously recorded as `application_submitted` with no issued tracking URL. No reapplication was made.
+- Follow-up browser check on 2026-09-08 in the authenticated Dub partner dashboard at `https://partners.dub.co/programs/fillout` now shows the program as **Approved / Enrolled**.
+- The program Overview page issues the exact customer-facing tracking link: `https://try.fillout.com/sang-kwon-an-hxwn`.
+- This is a personal referral/tracking link, not the generic Fillout homepage, login, or partner-application URL.
+- Current state: `approved_tracking`.
+- Revenue state: no Fillout referral, click, or commission has been verified; enrollment confirmation is not evidence of customer activity.
+- Guardrail: preserve this exact link; do not reapply or resubmit the program application.

--- a/projects/GlobalSaaSHub/data/krater-affiliate-enrollment-evidence-2026-09-08.md
+++ b/projects/GlobalSaaSHub/data/krater-affiliate-enrollment-evidence-2026-09-08.md
@@ -1,0 +1,10 @@
+# Krater affiliate enrollment confirmation — 2026-09-08
+
+- Program: Krater AI Partner Program, managed via Dub (`partners.dub.co`).
+- Existing application (submitted 2026-09-07 with COSHUMA / support@coshuma.com / https://coshuma.com) was previously recorded as `application_submitted` with no issued tracking URL. No reapplication was made.
+- Follow-up browser check on 2026-09-08 in the authenticated Dub partner dashboard at `https://partners.dub.co/programs/kraterai` now shows the program as **Approved / Enrolled**.
+- The program Overview page issues the exact customer-facing tracking link: `https://go.krater.ai/sang-kwon-an`.
+- This is distinct from the partner-application/referral-signup URL `https://partners.dub.co/kraterai/apply?via=sang-kwon-an-dgki`, which is a Dub portal URL for recruiting new partners, not a customer-facing purchase link, and was not recorded as the tracking URL.
+- Current state: `approved_tracking`.
+- Revenue state: no Krater referral, click, or commission has been verified; enrollment confirmation is not evidence of customer activity.
+- Guardrail: preserve this exact link; do not reapply or resubmit the program application.

--- a/projects/GlobalSaaSHub/data/tools.json
+++ b/projects/GlobalSaaSHub/data/tools.json
@@ -4805,7 +4805,7 @@
     "category": "creator",
     "category_display": "Creator Tools",
     "description": "All-in-one AI content creation suite featuring text, voiceover, image, and code generation for creators.",
-    "affiliate_url": null,
+    "affiliate_url": "https://go.krater.ai/sang-kwon-an",
     "pricing": "Pro plan starting at $200/year (billed annually)",
     "key_features": [
       "AI Text Generation",
@@ -4835,18 +4835,18 @@
     "official_verification_status": "verified",
     "official_verified_at": "2026-08-04T03:23:28.664870+00:00",
     "official_evidence_url": "https://krater.ai/",
-    "affiliate_status": "application_submitted",
-    "affiliate_verified": false,
-    "affiliate_final_url": null,
+    "affiliate_status": "approved_tracking",
+    "affiliate_verified": true,
+    "affiliate_final_url": "https://go.krater.ai/sang-kwon-an",
     "affiliate_evidence_markers": [
-      "Authenticated Chrome: after a pre-application company Gmail in:anywhere search found no matching messages, the Dub application was submitted once with COSHUMA, support@coshuma.com, https://coshuma.com and factual buyer-guide promotion text. Program terms accepted under explicit user authorization. Step 2 of 2 displayed Application submitted and stated the review update will be sent to support@coshuma.com. The decorative dashboard illustration on this success page is not real account revenue or an issued referral link. No approval or exact tracking URL was issued.",
-      "Await the existing Krater application review in Dub; do not reapply. Only publish an issued exact customer-facing link after approval evidence.",
-      "data/affiliate-submission-batch-2026-09-08.json"
+      "Authenticated Dub partner dashboard at partners.dub.co/programs/kraterai now shows the Krater program as Approved/Enrolled (previously application_submitted). The program Overview surfaces the issued exact customer-facing tracking link go.krater.ai/sang-kwon-an, distinct from the generic partner-application URL partners.dub.co/kraterai/apply?via=sang-kwon-an-dgki which is not a customer-facing link and was not recorded as one.",
+      "Preserve the issued exact customer-facing link; do not reapply. Keep customer signups, commissions and revenue at 0 without new evidence; a dashboard/portal visit is not customer activity.",
+      "data/krater-affiliate-enrollment-evidence-2026-09-08.md"
     ],
-    "affiliate_status_checked_at": "2026-09-07T21:21:56.008052+00:00",
-    "affiliate_status_evidence_url": "https://partners.dub.co/kraterai/apply",
-    "affiliate_workflow_url": "https://partners.dub.co/kraterai/apply",
-    "affiliate_next_action": "Await the existing Krater application review in Dub; do not reapply. Only publish an issued exact customer-facing link after approval evidence."
+    "affiliate_status_checked_at": "2026-09-08T14:00:00+09:00",
+    "affiliate_status_evidence_url": "https://partners.dub.co/programs/kraterai",
+    "affiliate_workflow_url": "https://partners.dub.co/programs/kraterai",
+    "affiliate_next_action": "Preserve the issued exact customer-facing link; do not reapply. Keep customer signups, commissions and revenue at 0 without new evidence; a dashboard/portal visit is not customer activity."
   },
   {
     "id": "expandi",


### PR DESCRIPTION
Browser follow-up in the authenticated Dub partner dashboard shows both programs moved from application_submitted to Approved/Enrolled, with exact customer-facing tracking links issued:

- Fillout: https://try.fillout.com/sang-kwon-an-hxwn
- - Krater: https://go.krater.ai/sang-kwon-an (distinct from the generic partner-application URL, which is not the tracking link)
No reapplication was made for either program. Pipedrive remains pending per PartnerStack (unchanged, not touched here).