### PR TITLE
Trigger corrected Claap production build

### DIFF
--- a/projects/GlobalSaaSHub/package.json
+++ b/projects/GlobalSaaSHub/package.json
@@ -18,7 +18,7 @@
     "check:docsbot-partner": "python scripts/apply_docsbot_partner_guidance.py && echo docsbot-partner-v2",
     "check:omnisend-revenue": "python scripts/apply_search_console_ctr_patches.py && python scripts/apply_omnisend_revenue_patch.py && echo omnisend-search-monetization-v5",
     "check:gravity-approval": "node scripts/reconcile_gravity_approval_state.mjs && echo gravity-approved-link-pending-v1",
-    "check:claap-partner": "python scripts/apply_claap_partner_feedback.py && echo claap-approved-link-pending-v2",
+    "check:claap-partner": "python scripts/apply_claap_partner_feedback.py && echo claap-approved-link-pending-v3",
     "check:unbounce-revenue": "python scripts/apply_search_console_ctr_patches.py && python scripts/apply_unbounce_search_revenue_patch.py && echo unbounce-search-revenue-v1",
     "check:databox-ctr": "python scripts/apply_databox_ctr_patch.py && echo databox-search-ctr-v3",
     "test:links": "python scripts/tests/test_link_integrity.py",


### PR DESCRIPTION
The domain-normalization fix is now on main, but that script-only commit did not match the deployment workflow's path filter. Bump the Claap check marker in package.json so the corrected build runs through the full production verification and gh-pages publish path.