### PR TITLE
Make Claap approval supersede stale submission evidence

### DIFF
--- a/projects/GlobalSaaSHub/data/affiliate-status-hotfix-2026-09-08.json
+++ b/projects/GlobalSaaSHub/data/affiliate-status-hotfix-2026-09-08.json
@@ -28,7 +28,25 @@
       "checked_at": "2026-09-09T14:44:42+09:00",
       "evidence": "Omnisend Affiliate Team / Impact sent Gmail message 1a084b27a331668b to support@coshuma.com with subject 'Welcome to the Omnisend Affiliate Program!' and explicitly welcomed Sangkwon An as part of the Omnisend Affiliate program. This is newer than the September 1 application-submitted state. The email contains program/help links but no account-specific customer tracking URL, so no homepage, Impact dashboard URL, or email redirect is treated as a revenue link.",
       "next_action": "Do not reapply. Retrieve the exact account-issued customer tracking link from the existing Impact account under Content > Assets, as Omnisend's official affiliate page instructs. Keep affiliate_url null and do not publish an Omnisend affiliate CTA until that exact tracking URL is copied and verified. No paid action.",
-      "blockers": ["Authenticated Impact dashboard required only to retrieve the issued tracking link if Omnisend does not send it directly."],
+      "blockers": [
+        "Authenticated Impact dashboard required only to retrieve the issued tracking link if Omnisend does not send it directly."
+      ],
+      "supersedes_pending_submission": true
+    },
+    {
+      "id": "claap",
+      "status": "approved",
+      "application_state": "submitted",
+      "review_state": "approved",
+      "affiliate_url": null,
+      "workflow_url": "https://dash.partnerstack.com/home",
+      "official_program_url": "https://www.claap.io/",
+      "checked_at": "2026-09-09T17:31:35+09:00",
+      "evidence": "Claap's PartnerStack welcome email to support@coshuma.com (Gmail message 1a08009379826dfd) confirms COSHUMA is in the affiliate program. Newer human manager feedback from Lamia Karmaly (Gmail message 1a0854b42ac1cc9a) reviewed the live COSHUMA Claap page and explicitly said the current claap.io buttons are not affiliate-tracked or commissionable yet, instructing COSHUMA to recover the issued link from the existing PartnerStack account. This supersedes the older application-submitted snapshot but does not establish an exact customer-facing tracking URL.",
+      "next_action": "Do not reapply or send duplicate outreach. Reuse the existing approved Claap PartnerStack partnership, open Claap > Links, and copy only the exact customer-facing affiliate URL issued to COSHUMA. Keep affiliate_url null and keep current official Claap links non-affiliate until that exact URL is verified; then replace revenue CTAs and validate attribution.",
+      "blockers": [
+        "Exact customer-facing tracking URL requires the existing authenticated PartnerStack Claap Links view."
+      ],
       "supersedes_pending_submission": true
     }
   ]

--- a/projects/GlobalSaaSHub/package.json
+++ b/projects/GlobalSaaSHub/package.json
@@ -18,7 +18,7 @@
     "check:docsbot-partner": "python scripts/apply_docsbot_partner_guidance.py && echo docsbot-partner-v2",
     "check:omnisend-revenue": "python scripts/apply_search_console_ctr_patches.py && python scripts/apply_omnisend_revenue_patch.py && echo omnisend-search-monetization-v5",
     "check:gravity-approval": "node scripts/reconcile_gravity_approval_state.mjs && echo gravity-approved-link-pending-v1",
-    "check:claap-partner": "python scripts/apply_claap_partner_feedback.py && echo claap-approved-link-pending-v3",
+    "check:claap-partner": "python scripts/apply_claap_partner_feedback.py && echo claap-approved-link-pending-v4",
     "check:unbounce-revenue": "python scripts/apply_search_console_ctr_patches.py && python scripts/apply_unbounce_search_revenue_patch.py && echo unbounce-search-revenue-v1",
     "check:databox-ctr": "python scripts/apply_databox_ctr_patch.py && echo databox-search-ctr-v3",
     "test:links": "python scripts/tests/test_link_integrity.py",


### PR DESCRIPTION
Run #319 built successfully but the browser-followup validator still treated Claap's older application-submitted snapshot as authoritative. Add the newer Gmail/manager approval as a status hotfix so it supersedes the submission record while keeping the exact tracking URL null. This reuses the existing generic approved-without-link recovery logic and prevents duplicate reapplication.