### PR TITLE
Support Work browser login with signed CSRF cookies

### DIFF
--- a/projects/GlobalSaaSHub/scripts/generate_live_dashboard_data.mjs
+++ b/projects/GlobalSaaSHub/scripts/generate_live_dashboard_data.mjs
@@ -1,10 +1,11 @@
 import fs from 'node:fs';
 import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
 
 import path from 'node:path';
 const outPath = process.env.DASHBOARD_OUTPUT_PATH;
 if (!outPath || !path.isAbsolute(outPath)) throw new Error('An absolute private DASHBOARD_OUTPUT_PATH is required');
-const publicRoot = path.resolve(new URL('../public', import.meta.url).pathname.replace(/^\/(?:([A-Za-z]:))/, '$1'));
+const publicRoot = path.resolve(fileURLToPath(new URL('../public', import.meta.url)));
 if (path.resolve(outPath).startsWith(publicRoot + path.sep)) throw new Error('Public output is forbidden');
 const serviceRaw = process.env.GOOGLE_SERVICE_ACCOUNT_JSON || '';
 const propertyId = String(process.env.GA_PROPERTY_ID || '552119661').trim();

--- a/projects/GlobalSaaSHub/worker/PRIVATE_OPS.md
+++ b/projects/GlobalSaaSHub/worker/PRIVATE_OPS.md
@@ -2,7 +2,7 @@
 
 Owner entry: `https://globalsaashub-payments.qmfforfhem.workers.dev/ops/traffic-revenue.html`.
 
-The `/ops` route authenticates `support@coshuma.com` against the `OPS_PASSWORD_SHA256` Worker secret. The existing admin credentials and payment routes are independent. Neither passwords nor secret values belong in Git. Login attempts are limited to ten per client IP per ten-minute bucket; client IPs are stored only as hashes. Sessions expire on the server after eight hours and use Secure, HttpOnly, SameSite=Strict cookies. Basic authentication and unverified Access identity headers cannot bypass this route.
+The `/ops` route authenticates `support@coshuma.com` against the `OPS_PASSWORD_SHA256` Worker secret. The existing admin credentials and payment routes are independent. Neither passwords nor secret values belong in Git. Login forms use a signed ten-minute CSRF cookie plus a matching hidden nonce; this supports the existing Work browser without trusting a mismatched Origin. Login attempts are limited to ten per client IP per ten-minute bucket; client IPs are stored only as hashes. Sessions expire on the server after eight hours and use Secure, HttpOnly, SameSite=Strict cookies. Basic authentication and unverified Access identity headers cannot bypass this route.
 
 HTML and internal JSON live in the existing ORDERS D1 binding's `private_ops_documents` table, outside both GitHub Pages and repository source. Every read requires authentication, including HEAD and direct JSON requests. Responses use no-store/private. Apply `migrations/0002_private_ops.sql` before first deployment; importing documents requires existing authorized Cloudflare administration access. Do not commit document contents or upload them as public Actions artifacts.
 

--- a/projects/GlobalSaaSHub/worker/src/admin.js
+++ b/projects/GlobalSaaSHub/worker/src/admin.js
@@ -149,9 +149,9 @@ export async function handleAdminRequest(request, env) {
   return new Response(body, { status: 200, headers: PRIVATE_HEADERS });
 }
 
-export async function privateLogin(request, env, destination) {
+export async function privateLogin(request, env, destination, csrfValidated = false) {
     const origin = request.headers.get('origin');
-    if (origin && origin !== new URL(request.url).origin) return new Response('Forbidden', { status: 403, headers: PRIVATE_HEADERS });
+    if (!csrfValidated && origin && origin !== new URL(request.url).origin) return new Response('Forbidden', { status: 403, headers: PRIVATE_HEADERS });
     const form = await request.formData().catch(() => new FormData());
     const username = String(form.get('username') || '');
     const passwordHash = await sha256(String(form.get('password') || ''));

--- a/projects/GlobalSaaSHub/worker/src/private-ops.js
+++ b/projects/GlobalSaaSHub/worker/src/private-ops.js
@@ -37,6 +37,30 @@ const response = (body, status, type = 'application/json; charset=utf-8') => new
   status, headers: { ...PRIVATE_HEADERS, 'content-type': type, 'content-security-policy': "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'; img-src data:; base-uri 'none'; form-action 'self'; frame-ancestors 'none'" },
 });
 
+async function csrfSignature(value, secret) {
+  const key = await crypto.subtle.importKey('raw', new TextEncoder().encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  return [...new Uint8Array(await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(`login:${value}`)))].map(b => b.toString(16).padStart(2, '0')).join('');
+}
+async function ownerLoginPage(env, error = '') {
+  if (!env.OPS_PASSWORD_SHA256) return response('{"error":"Authentication unavailable"}', 503);
+  const nonce = crypto.randomUUID();
+  const value = `${nonce}.${Math.floor(Date.now()/1000)+600}`;
+  const signed = `${value}.${await csrfSignature(value, env.OPS_PASSWORD_SHA256)}`;
+  const result = response(loginPage(error).replace('<form method="post">', `<form method="post"><input type="hidden" name="csrf" value="${nonce}">`), 401, 'text/html; charset=utf-8');
+  result.headers.append('set-cookie', `__Secure-coshuma_login=${signed}; Path=/ops; Max-Age=600; HttpOnly; Secure; SameSite=Strict`);
+  return result;
+}
+async function validCsrf(request, env) {
+  try {
+    const cookie = (request.headers.get('cookie') || '').split(';').map(s => s.trim()).find(s => s.startsWith('__Secure-coshuma_login='))?.slice('__Secure-coshuma_login='.length);
+    const [nonce, expires, signature] = (cookie || '').split('.');
+    const form = await request.clone().formData();
+    const now = Date.now()/1000;
+    return nonce === form.get('csrf') && Number(expires) > now && Number(expires) <= now+600
+      && signature === await csrfSignature(`${nonce}.${expires}`, env.OPS_PASSWORD_SHA256);
+  } catch { return false; }
+}
+
 export async function handleSnapshotUpload(request, env) {
   if (request.method !== 'PUT') return response('{"error":"Method not allowed"}', 405);
   const token = request.headers.get('authorization')?.replace(/^Bearer /, '');
@@ -70,6 +94,7 @@ export async function handlePrivateOps(request, env) {
   const authEnv = { ...env, ADMIN_PATH: '/ops', ADMIN_USERNAME: 'support@coshuma.com', ADMIN_PASSWORD_SHA256: env.OPS_PASSWORD_SHA256 };
   if (request.method === 'POST' && ['/ops', '/ops/', '/ops/traffic-revenue.html'].includes(path)) {
     if (!env.ORDERS || !env.OPS_PASSWORD_SHA256) return response('{"error":"Authentication unavailable"}', 503);
+    if (!await validCsrf(request, env)) return response('Login session expired. Reload this page and try again.', 403, 'text/plain; charset=utf-8');
     const ip = request.headers.get('cf-connecting-ip') || 'unknown';
     const digest = [...new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(ip)))].map(b => b.toString(16).padStart(2, '0')).join('');
     const bucket = Math.floor(Date.now() / 600000);
@@ -77,11 +102,12 @@ export async function handlePrivateOps(request, env) {
       ON CONFLICT(client) DO UPDATE SET bucket=excluded.bucket, attempts=CASE WHEN bucket=excluded.bucket THEN attempts+1 ELSE 1 END RETURNING attempts`)
       .bind(digest, bucket).first();
     if (!attempt || attempt.attempts > 10) return response('{"error":"Too many login attempts; try again later"}', 429);
-    return privateLogin(request, authEnv, '/ops/traffic-revenue.html');
+    const login = await privateLogin(request, authEnv, '/ops/traffic-revenue.html', true);
+    return login.status === 401 ? ownerLoginPage(env, '아이디 또는 비밀번호가 맞지 않습니다.') : login;
   }
   if (!await authorized(request, authEnv, false)) {
     return path.endsWith('.json') ? response('{"error":"Authentication required"}', 401)
-      : response(loginPage(), 401, 'text/html; charset=utf-8');
+      : ownerLoginPage(env);
   }
   if (!['GET', 'HEAD'].includes(request.method)) return response('{"error":"Method not allowed"}', 405);
   const name = ['/ops', '/ops/'].includes(path) ? 'traffic-revenue.html' : path.slice('/ops/'.length);

--- a/projects/GlobalSaaSHub/worker/test/private-ops.test.js
+++ b/projects/GlobalSaaSHub/worker/test/private-ops.test.js
@@ -23,7 +23,10 @@ test('anonymous HTML and JSON fail closed without reading storage; spoofed heade
 });
 test('only configured owner password permits content; expired and forged sessions are denied', async () => {
   const state = await setup();
-  const login = await worker.fetch(new Request(url, { method: 'POST', body: new URLSearchParams({ username: 'support@coshuma.com', password }) }), state.env);
+  const page = await worker.fetch(new Request(url), state.env);
+  const loginCookie = page.headers.get('set-cookie').split(';')[0];
+  const csrf = (await page.text()).match(/name="csrf" value="([^"]+)"/)[1];
+  const login = await worker.fetch(new Request(url, { method: 'POST', headers: { cookie: loginCookie, origin: 'null' }, body: new URLSearchParams({ username: 'support@coshuma.com', password, csrf }) }), state.env);
   assert.equal(login.status, 303);
   const cookie = login.headers.get('set-cookie').split(';')[0];
   assert.match(login.headers.get('set-cookie'), /HttpOnly; Secure; SameSite=Strict/);
@@ -34,7 +37,7 @@ test('only configured owner password permits content; expired and forged session
   for (const badCookie of [cookie.replace(/=\d+\./, '=1.'), cookie + 'x']) {
     assert.equal((await worker.fetch(new Request(url, { headers: { cookie: badCookie } }), state.env)).status, 401);
   }
-  const wrongUser = await worker.fetch(new Request(url, { method: 'POST', body: new URLSearchParams({ username: 'outsider@example.com', password }) }), state.env);
+  const wrongUser = await worker.fetch(new Request(url, { method: 'POST', headers: { cookie: loginCookie }, body: new URLSearchParams({ username: 'outsider@example.com', password, csrf }) }), state.env);
   assert.equal(wrongUser.status, 401);
   const crossOrigin = await worker.fetch(new Request(url, { method: 'POST', headers: { origin: 'https://evil.example' }, body: new URLSearchParams({ username: 'support@coshuma.com', password }) }), state.env);
   assert.equal(crossOrigin.status, 403);


### PR DESCRIPTION
The existing Work browser could display the owner login page but its form submission was rejected by the Origin check. Validate a signed, expiring login cookie together with the form nonce before checking credentials, allowing that browser without trusting a spoofed Origin. Wrong-password responses issue a fresh form token. Keep eight-hour server session expiry, owner-only credentials, rate limiting and authenticated HTML/JSON reads.

Validation: 15 Worker tests pass, including rejected cross-site login without CSRF and successful signed form login with opaque Origin. Existing Work browser successfully logged in and rendered the latest private Google analytics snapshot (2026-09-09T22:07:42.178Z). Private snapshot Actions run 34410590053 succeeded. Public removals deployed in gh-pages commit b553bd927b74fa8c60885b12554a6d6e72409d8c, Pages run 34410639902 succeeded; public dashboard, JSON, audit and default Pages-origin dashboard return 404. No secret values included.