### PR TITLE
Make dashboard landing page entries clickable

### DIFF
--- a/projects/GlobalSaaSHub/worker/src/ops-dashboard-view.js
+++ b/projects/GlobalSaaSHub/worker/src/ops-dashboard-view.js
@@ -7,8 +7,18 @@ export function dashboardClient() {
   const show = (id, v) => { $(id).textContent = v === null || v === undefined ? '—' : String(v); };
   const money = (v, currency = 'USD') => v === null ? '—' : `${currency} ${v.toFixed(2)}`;
   function connected() { return snapshot?.status === 'live_google_connected' && snapshot?.measurement_status === 'live_connected'; }
+  function pageLabel(value) {
+    const label = esc(value);
+    try {
+      const path = String(value || '').trim();
+      if (!path.startsWith('/') && !path.startsWith('https://')) return label;
+      const url = new URL(path, 'https://coshuma.com');
+      if (url.origin !== 'https://coshuma.com' || url.username || url.password) return label;
+      return `<a href="${esc(url.href)}" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:underline;text-underline-offset:3px" title="새 탭에서 페이지 열기">${label}</a>`;
+    } catch { return label; }
+  }
   function list(id, items, label = 'name', value = 'value', suffix = '') {
-    $(id).innerHTML = items?.length ? items.slice(0, 8).map(x => `<div class="row"><div><strong>${esc(x[label])}</strong>${x.note ? `<small>${esc(x.note)}</small>` : ''}</div><span>${esc(x[value])}${suffix}</span></div>`).join('')
+    $(id).innerHTML = items?.length ? items.slice(0, 8).map(x => `<div class="row"><div><strong>${id === 'pages' ? pageLabel(x[label]) : esc(x[label])}</strong>${x.note ? `<small>${esc(x.note)}</small>` : ''}</div><span>${esc(x[value])}${suffix}</span></div>`).join('')
       : `<div class="row"><strong>${connected() ? '조회 기간에 기록 없음' : '데이터 확인 필요'}</strong><span>—</span></div>`;
   }
   function opportunities() {
@@ -69,4 +79,3 @@ export function decorateOpsHtml(html) {
   return html.replace(pattern, () => `<script>(()=>{const __name=fn=>fn;(${dashboardClient.toString()})();})();</script>`)
     .replace(/<tbody id="opportunities">[\s\S]*?<\/tbody>/, '<tbody id="opportunities"><tr><td colspan="5">실데이터 확인 중</td></tr></tbody>');
 }
-

--- a/projects/GlobalSaaSHub/worker/test/ops-dashboard-view.test.js
+++ b/projects/GlobalSaaSHub/worker/test/ops-dashboard-view.test.js
@@ -9,9 +9,10 @@ test('connected Google snapshot replaces placeholder rows and renders actual que
   const data = { status: 'live_google_connected', measurement_status: 'live_connected', generated_at: 'fixture',
     connections: { ga4: '연결됨 · property fixture', search_console: '연결됨 · site fixture' },
     metrics: { affiliate_clicks_30d: 3 }, ranges: { today: { users: 2, sessions: 2, affiliate_clicks: 0, verified_revenue: null } },
+    top_pages: [{ name: '/tool/example.html?source=a&b=2', value: 4 }, { name: '//other.example/path', value: 1 }],
     top_queries: [{ name: 'fixture search query', value: 21 }], search_pages: [{ name: '/fixture-page', value: 21, note: 'CTR 1%' }],
     affiliate_links: [{ name: 'https://fixture.example/', value: 3 }], snapshot: [] };
-  vm.runInNewContext(`(${dashboardClient.toString()})();`, { document: { getElementById: get, querySelectorAll: () => [] }, fetch: async url => ({ ok: true, json: async () => url.includes('partnerstack') ? { connected: true, rewardCount: 0, partnershipCount: 2 } : data }) });
+  vm.runInNewContext(`(${dashboardClient.toString()})();`, { URL, document: { getElementById: get, querySelectorAll: () => [] }, fetch: async url => ({ ok: true, json: async () => url.includes('partnerstack') ? { connected: true, rewardCount: 0, partnershipCount: 2 } : data }) });
   await new Promise(resolve => setImmediate(resolve));
   assert.match(get('opportunities').innerHTML, /실데이터 연결됨/);
   assert.doesNotMatch(get('opportunities').innerHTML, /실데이터 집계 미연결/);
@@ -22,6 +23,8 @@ test('connected Google snapshot replaces placeholder rows and renders actual que
   assert.equal(get('gaApiDot').className, 'ok');
   assert.match(get('partnerState').textContent, /PartnerStack 연결됨/);
   assert.equal(get('revenue').textContent, '—');
+  assert.match(get('pages').innerHTML, /href="https:\/\/coshuma.com\/tool\/example.html\?source=a&amp;b=2" target="_blank" rel="noopener noreferrer"/);
+  assert.doesNotMatch(get('pages').innerHTML, /href="[^"]*other.example/);
 });
 
 test('dashboard transformation replaces obsolete initial instructions, and fails closed on incompatible HTML', () => {


### PR DESCRIPTION
Turn the Top landing/pages paths into underlined links to their corresponding HTTPS COSHUMA pages, opening a new tab so the dashboard stays available. Resolve paths against coshuma.com rather than the Worker host, escape labels/URLs, and leave non-COSHUMA or invalid values as text.

Validation: existing dashboard rendering tests pass, including absolute destination, escaped query string, new-tab attributes and off-site rejection. Worker version 3127e83f-473c-4cc9-998c-44ec031150e0 deployed.