### PR TITLE
Keep Claude ops UI and add calendar-aligned private analytics charts

### DIFF
--- a/.github/workflows/coshuma-analytics-snapshot.yml
+++ b/.github/workflows/coshuma-analytics-snapshot.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - '.github/workflows/coshuma-analytics-snapshot.yml'
       - 'projects/GlobalSaaSHub/scripts/generate_live_dashboard_data.mjs'
+      - 'projects/GlobalSaaSHub/scripts/dashboard-series.mjs'
       - 'projects/GlobalSaaSHub/scripts/upload_private_dashboard.mjs'
 
 permissions:

--- a/projects/GlobalSaaSHub/scripts/dashboard-series.mjs
+++ b/projects/GlobalSaaSHub/scripts/dashboard-series.mjs
@@ -1,0 +1,18 @@
+export const RANGE_LENGTHS = { today: 1, '7d': 7, '30d': 30, '90d': 90 };
+export function dateInZone(instant, timeZone) {
+  const parts = Object.fromEntries(new Intl.DateTimeFormat('en-US', { timeZone, year:'numeric', month:'2-digit', day:'2-digit' }).formatToParts(instant).map(p=>[p.type,p.value]));
+  return `${parts.year}-${parts.month}-${parts.day}`;
+}
+export function shiftDate(date, days) {
+  return new Date(Date.parse(`${date}T00:00:00Z`) + days * 86400000).toISOString().slice(0,10);
+}
+export function windowEnding(end, days) { return { start:shiftDate(end, 1-days), end }; }
+export function dateSeries(rows, window, fields, confirmedThrough = window.end) {
+  const byDate = new Map(rows.map(row=>[row.date,row]));
+  const result = [];
+  for(let date=window.start; date<=window.end; date=shiftDate(date,1)) {
+    const found=byDate.get(date);
+    result.push({date,...Object.fromEntries(fields.map(key=>[key, found ? (Number.isFinite(found[key]) ? found[key] : null) : date<=confirmedThrough ? 0 : null]))});
+  }
+  return result;
+}

--- a/projects/GlobalSaaSHub/scripts/generate_live_dashboard_data.mjs
+++ b/projects/GlobalSaaSHub/scripts/generate_live_dashboard_data.mjs
@@ -1,3 +1,4 @@
+import { RANGE_LENGTHS, dateInZone, shiftDate, windowEnding, dateSeries } from './dashboard-series.mjs';
 import fs from 'node:fs';
 import crypto from 'node:crypto';
 import { fileURLToPath } from 'node:url';
@@ -32,6 +33,7 @@ const empty = (status, reason) => ({
   },
   ranges: Object.fromEntries(['today','7d','30d','90d'].map(k => [k, { users:null, sessions:null, views:null, affiliate_clicks:null, search_impressions:null, search_clicks:null, verified_revenue:null }])),
   top_sources: [], top_pages: [], top_queries: [], affiliate_pages: [], affiliate_links: [], search_pages: [],
+  daily: [], affiliate_daily: [], search_daily: [], sources_daily: {},
   snapshot: [
     { label:'GA4 Property ID', value:propertyId || '미설정', period:'현재 실행', source:'GitHub Actions env / fallback' },
     { label:'Search Console site', value:siteUrl || '미설정', period:'현재 실행', source:'GitHub Actions env / fallback' },
@@ -80,59 +82,93 @@ async function post(url, access, body) {
 }
 const metric = (row, i=0) => Number(row?.metricValues?.[i]?.value || 0);
 const dim = (row, i=0) => row?.dimensionValues?.[i]?.value || '알 수 없음';
-const iso = d => d.toISOString().slice(0,10);
-const ago = n => iso(new Date(Date.now()-n*86400000));
-const yesterday = ago(1);
-
+const gaDate = value => `${value.slice(0,4)}-${value.slice(4,6)}-${value.slice(6,8)}`;
 try {
   const access = await token();
   const ga = `https://analyticsdata.googleapis.com/v1beta/properties/${propertyId}`;
   const gsc = `https://searchconsole.googleapis.com/webmasters/v3/sites/${encodeURIComponent(siteUrl)}/searchAnalytics/query`;
-  const rangeReq = start => ({dateRanges:[{startDate:start,endDate:'today'}],metrics:[{name:'activeUsers'},{name:'sessions'},{name:'screenPageViews'}]});
-  const affiliateEventFilter = {filter:{fieldName:'eventName',stringFilter:{matchType:'EXACT',value:'affiliate_click'}}};
-  const [kpis,sources,pages,aff30,affPages,affLinks,gsc90,gscQueries,gscPages,gsc30,gsc7,gscToday] = await Promise.all([
-    post(`${ga}:batchRunReports`,access,{requests:[rangeReq('today'),rangeReq('7daysAgo'),rangeReq('30daysAgo'),rangeReq('90daysAgo')]}),
-    post(`${ga}:runReport`,access,{dateRanges:[{startDate:'30daysAgo',endDate:'today'}],dimensions:[{name:'sessionSource'}],metrics:[{name:'activeUsers'},{name:'sessions'}],orderBys:[{metric:{metricName:'activeUsers'},desc:true}],limit:15}),
-    post(`${ga}:runReport`,access,{dateRanges:[{startDate:'30daysAgo',endDate:'today'}],dimensions:[{name:'pagePath'}],metrics:[{name:'screenPageViews'},{name:'activeUsers'}],orderBys:[{metric:{metricName:'screenPageViews'},desc:true}],limit:20}),
-    post(`${ga}:runReport`,access,{dateRanges:[{startDate:'30daysAgo',endDate:'today'}],dimensions:[{name:'eventName'}],metrics:[{name:'eventCount'}],dimensionFilter:affiliateEventFilter}),
-    post(`${ga}:runReport`,access,{dateRanges:[{startDate:'30daysAgo',endDate:'today'}],dimensions:[{name:'pagePath'}],metrics:[{name:'eventCount'}],dimensionFilter:affiliateEventFilter,orderBys:[{metric:{metricName:'eventCount'},desc:true}],limit:20}),
-    post(`${ga}:runReport`,access,{dateRanges:[{startDate:'30daysAgo',endDate:'today'}],dimensions:[{name:'pagePath'},{name:'linkUrl'},{name:'linkText'},{name:'date'}],metrics:[{name:'eventCount'}],dimensionFilter:affiliateEventFilter,orderBys:[{dimension:{dimensionName:'date'},desc:true},{metric:{metricName:'eventCount'},desc:true}],limit:50}),
-    post(gsc,access,{startDate:ago(89),endDate:yesterday,rowLimit:1}),
-    post(gsc,access,{startDate:ago(89),endDate:yesterday,dimensions:['query'],rowLimit:250}),
-    post(gsc,access,{startDate:ago(89),endDate:yesterday,dimensions:['page'],rowLimit:250}),
-    post(gsc,access,{startDate:ago(29),endDate:yesterday,rowLimit:1}),
-    post(gsc,access,{startDate:ago(6),endDate:yesterday,rowLimit:1}),
-    post(gsc,access,{startDate:yesterday,endDate:yesterday,rowLimit:1})
+  const metadata = await post(`${ga}:runReport`,access,{dateRanges:[{startDate:'today',endDate:'today'}],metrics:[{name:'activeUsers'}]});
+  const gaZone = metadata.metadata?.timeZone;
+  if (!gaZone) throw new Error('GA reporting timezone unavailable');
+  const collected = new Date();
+  const gaToday = dateInZone(collected, gaZone);
+  const searchEnd = shiftDate(dateInZone(collected,'America/Los_Angeles'),-1);
+  const windows = Object.fromEntries(Object.entries(RANGE_LENGTHS).map(([key,days])=>[key,{ga:windowEnding(gaToday,days),search:windowEnding(searchEnd,days)}]));
+  const gaWindow = windows['90d'].ga, sourceWindow = windows['30d'].ga, searchWindow = windows['90d'].search;
+  const dates = window => [{startDate:window.start,endDate:window.end}];
+  const affiliateFilter = {filter:{fieldName:'eventName',stringFilter:{matchType:'EXACT',value:'affiliate_click'}}};
+  const gaRequest = (window, metrics, extra={}) => ({dateRanges:dates(window),metrics:metrics.map(name=>({name})),...extra});
+  const searchRequest = (window, extra={}) => ({startDate:window.start,endDate:window.end,dataState:'final',...extra});
+  const statuses = {};
+  const optional = async (name, request) => {
+    try {
+      const value = await request();
+      if(value.metadata?.dataLossFromOtherRow || (value.rowCount && value.rowCount > (value.rows?.length || 0))) throw new Error('Incomplete series');
+      statuses[name]='ok'; return value;
+    } catch { statuses[name]='unavailable'; return null; }
+  };
+  const keys=Object.keys(RANGE_LENGTHS);
+  const [kpis,affTotals,sources,pages,affPages,affLinks,gscTotalsByRange,gscQueries,gscPages,gaDaily,gaAffiliateDaily,gscDaily] = await Promise.all([
+    post(`${ga}:batchRunReports`,access,{requests:keys.map(key=>gaRequest(windows[key].ga,['activeUsers','sessions','screenPageViews']))}),
+    post(`${ga}:batchRunReports`,access,{requests:keys.map(key=>gaRequest(windows[key].ga,['eventCount'],{dimensionFilter:affiliateFilter}))}),
+    post(`${ga}:runReport`,access,gaRequest(sourceWindow,['activeUsers','sessions'],{dimensions:[{name:'sessionSource'}],orderBys:[{metric:{metricName:'activeUsers'},desc:true}],limit:15})),
+    post(`${ga}:runReport`,access,gaRequest(sourceWindow,['screenPageViews','activeUsers'],{dimensions:[{name:'pagePath'}],orderBys:[{metric:{metricName:'screenPageViews'},desc:true}],limit:20})),
+    post(`${ga}:runReport`,access,gaRequest(sourceWindow,['eventCount'],{dimensionFilter:affiliateFilter,dimensions:[{name:'pagePath'}],orderBys:[{metric:{metricName:'eventCount'},desc:true}],limit:20})),
+    post(`${ga}:runReport`,access,gaRequest(sourceWindow,['eventCount'],{dimensionFilter:affiliateFilter,dimensions:['pagePath','linkUrl','linkText','date'].map(name=>({name})),orderBys:[{metric:{metricName:'eventCount'},desc:true}],limit:30})),
+    Promise.all(keys.map(key=>post(gsc,access,searchRequest(windows[key].search,{rowLimit:1})))),
+    post(gsc,access,searchRequest(searchWindow,{dimensions:['query'],rowLimit:250})),
+    post(gsc,access,searchRequest(searchWindow,{dimensions:['page'],rowLimit:250})),
+    optional('daily',()=>post(`${ga}:runReport`,access,gaRequest(gaWindow,['activeUsers','sessions','screenPageViews'],{dimensions:[{name:'date'}],keepEmptyRows:true,orderBys:[{dimension:{dimensionName:'date'}}]}))),
+    optional('affiliate_daily',()=>post(`${ga}:runReport`,access,gaRequest(gaWindow,['eventCount'],{dimensionFilter:affiliateFilter,dimensions:[{name:'date'}],keepEmptyRows:true,orderBys:[{dimension:{dimensionName:'date'}}]}))),
+    optional('search_daily',()=>post(gsc,access,searchRequest(searchWindow,{dimensions:['date'],rowLimit:100})))
   ]);
-  const reports = kpis.reports || [];
-  const gr = i => ({users:metric(reports[i]?.rows?.[0],0),sessions:metric(reports[i]?.rows?.[0],1),views:metric(reports[i]?.rows?.[0],2)});
-  const gscTotals = x => ({search_impressions:Math.round(x.rows?.[0]?.impressions||0),search_clicks:Math.round(x.rows?.[0]?.clicks||0)});
-  const click30 = metric(aff30.rows?.[0],0);
-  const rToday = {...gr(0),affiliate_clicks:null,...gscTotals(gscToday),verified_revenue:null};
-  const r7 = {...gr(1),affiliate_clicks:null,...gscTotals(gsc7),verified_revenue:null};
-  const r30 = {...gr(2),affiliate_clicks:click30,...gscTotals(gsc30),verified_revenue:null};
-  const r90 = {...gr(3),affiliate_clicks:null,...gscTotals(gsc90),verified_revenue:null};
-  const data = {
-    generated_at:new Date().toISOString(), status:'live_google_connected', measurement_status:'live_connected',
+  const sourceNames=(sources.rows||[]).slice(0,5).map(row=>dim(row));
+  const sourceDaily=sourceNames.length ? await optional('sources_daily',()=>post(`${ga}:runReport`,access,gaRequest(sourceWindow,['activeUsers'],{dimensions:[{name:'date'},{name:'sessionSource'}],dimensionFilter:{filter:{fieldName:'sessionSource',inListFilter:{values:sourceNames}}},keepEmptyRows:true,limit:1000,orderBys:[{dimension:{dimensionName:'date'}}]}))) : {rows:[]};
+  statuses.sources_daily ||= 'ok';
+  const daily = gaDaily ? dateSeries((gaDaily.rows||[]).map(row=>({date:gaDate(dim(row)),users:metric(row,0),sessions:metric(row,1),views:metric(row,2)})),gaWindow,['users','sessions','views']) : [];
+  const affiliate_daily = gaAffiliateDaily ? dateSeries((gaAffiliateDaily.rows||[]).map(row=>({date:gaDate(dim(row)),clicks:metric(row)})),gaWindow,['clicks']) : [];
+  const searchRows=(gscDaily?.rows||[]).map(row=>({date:row.keys[0],impressions:Math.round(row.impressions||0),clicks:Math.round(row.clicks||0)}));
+  // Missing trailing search dates may still be unprocessed. Never invent zeros for them.
+  const confirmedSearchDate=searchRows.map(row=>row.date).sort().at(-1)||'';
+  const search_daily=gscDaily ? dateSeries(searchRows,searchWindow,['impressions','clicks'],confirmedSearchDate) : [];
+  const sources_daily=sourceDaily ? Object.fromEntries(sourceNames.map(name=>[name,dateSeries((sourceDaily.rows||[]).filter(row=>dim(row,1)===name).map(row=>({date:gaDate(dim(row)),users:metric(row)})),sourceWindow,['users'])])) : {};
+  const ranges=Object.fromEntries(keys.map((key,i)=>{
+    const row=kpis.reports?.[i]?.rows?.[0], search=gscTotalsByRange[i].rows?.[0];
+    if(!kpis.reports?.[i] || !affTotals.reports?.[i]) throw new Error('Missing aggregate report');
+    return [key,{users:metric(row,0),sessions:metric(row,1),views:metric(row,2),affiliate_clicks:metric(affTotals.reports[i].rows?.[0]),search_impressions:search ? Math.round(search.impressions||0) : null,search_clicks:search ? Math.round(search.clicks||0) : null,verified_revenue:null}];
+  }));
+  const series_checks={};
+  for(const key of keys) {
+    const w=windows[key].ga;
+    const selected=rows=>rows.filter(row=>row.date>=w.start && row.date<=w.end);
+    series_checks[key]={};
+    for(const [field,rows,metricKey] of [['views',daily,'views'],['affiliate_clicks',affiliate_daily,'clicks']])
+      series_checks[key][field]=rows.length ? selected(rows).reduce((sum,row)=>sum+row[metricKey],0)===ranges[key][field] : null;
+    // Sessions and active users are not summed across dates: they can cross midnight or repeat.
+  }
+  const records=[
+    {label:'GA4 Property ID',value:propertyId,period:gaZone,source:'Google Analytics Data API'},
+    {label:'GA4 집계 기간',value:`${gaWindow.start} ~ ${gaWindow.end}`,period:'오늘 포함 · 오늘은 집계 중',source:gaZone},
+    {label:'Search Console site',value:siteUrl,period:`${searchWindow.start} ~ ${searchWindow.end}`,source:'America/Los_Angeles · 확정 데이터 · 최신일 지연 가능'},
+    {label:'검색 최신 기록일',value:confirmedSearchDate||'확정 기록 미제공',period:'검색 추이',source:'최신 누락 날짜는 0으로 표시하지 않음'},
+    {label:'유입 구성비',value:`조회된 ${sources.rows?.length||0}개 경로 내 사용자 집계 비중`,period:`${sourceWindow.start} ~ ${sourceWindow.end}`,source:'전체 순방문자 구성비 아님 · 기타는 조회 목록의 나머지'},
+    ...Object.entries(statuses).map(([name,status])=>({label:`추이 ${name}`,value:status==='ok'?'연결됨':'조회 실패 또는 불완전 응답',period:'이번 수집',source:'기존 KPI와 별도 처리'}))
+  ];
+  const data={
+    generated_at:collected.toISOString(),status:'live_google_connected',measurement_status:'live_connected',
     connections:{ga4:`연결됨 · property ${propertyId}`,search_console:`연결됨 · ${siteUrl}`,partner_revenue:'네트워크별 연결 필요'},
-    metrics:{today_users:rToday.users,today_users_note:`GA4 property ${propertyId}`,sessions_7d:r7.sessions,sessions_7d_note:'GA4 Data API 실집계',affiliate_clicks_30d:click30,affiliate_clicks_30d_note:'GA4 affiliate_click 30일 실집계',verified_revenue:null,verified_revenue_currency:'USD',verified_revenue_note:'파트너별 실제 수익 통합 미연결'},
-    ranges:{today:rToday,'7d':r7,'30d':r30,'90d':r90},
-    top_sources:(sources.rows||[]).map(x=>({name:dim(x),value:metric(x,0),note:`세션 ${metric(x,1)}`})),
-    top_pages:(pages.rows||[]).map(x=>({name:dim(x),value:metric(x,0),note:`사용자 ${metric(x,1)}`})),
-    affiliate_pages:(affPages.rows||[]).map(x=>({name:dim(x),value:metric(x,0),note:'제휴 클릭'})),
-    affiliate_links:(affLinks.rows||[]).map(x=>({page:dim(x,0),name:dim(x,1),value:metric(x,0),date:dim(x,3),note:`페이지 ${dim(x,0)} · 날짜 ${dim(x,3)} · 링크 텍스트: ${dim(x,2)}`})),
-    top_queries:(gscQueries.rows||[]).sort((a,b)=>(b.impressions||0)-(a.impressions||0)).slice(0,20).map(x=>({name:x.keys?.[0]||'알 수 없음',value:Math.round(x.impressions||0),note:`클릭 ${Math.round(x.clicks||0)} · CTR ${(Number(x.ctr||0)*100).toFixed(1)}% · 순위 ${Number(x.position||0).toFixed(1)}`})),
-    search_pages:(gscPages.rows||[]).sort((a,b)=>(b.impressions||0)-(a.impressions||0)).slice(0,20).map(x=>({name:x.keys?.[0]||'알 수 없음',value:Math.round(x.impressions||0),note:`클릭 ${Math.round(x.clicks||0)} · CTR ${(Number(x.ctr||0)*100).toFixed(1)}%`})),
-    snapshot:[
-      {label:'GA4 Property ID',value:propertyId,period:'현재 실행',source:'Google Analytics Data API'},
-      {label:'Search Console site',value:siteUrl,period:`${ago(89)} ~ ${yesterday}`,source:'Search Console API'},
-      {label:'30일 제휴 클릭',value:String(click30),period:'최근 30일',source:'GA4 affiliate_click'},
-      {label:'제휴 목적지 분석',value:String((affLinks.rows||[]).length),period:'최근 30일',source:'GA4 pagePath/linkUrl/linkText/date'},
-      {label:'데이터 생성 방식',value:'GitHub Actions 서버측 실집계',period:'현재',source:'scripts/generate_live_dashboard_data.mjs'}
-    ]
+    metrics:{today_users:ranges.today.users,today_users_note:`GA4 property ${propertyId}`,sessions_7d:ranges['7d'].sessions,sessions_7d_note:'GA4 Data API 실집계',affiliate_clicks_30d:ranges['30d'].affiliate_clicks,affiliate_clicks_30d_note:'GA4 affiliate_click 실집계',verified_revenue:null,verified_revenue_currency:'USD',verified_revenue_note:'파트너별 실제 수익 통합 미연결'},
+    ranges,windows,timezones:{ga:gaZone,search:'America/Los_Angeles'},daily,affiliate_daily,search_daily,sources_daily,series_status:statuses,series_checks,
+    top_sources:(sources.rows||[]).map(row=>({name:dim(row),value:metric(row),note:`세션 ${metric(row,1)}`})),
+    top_pages:(pages.rows||[]).map(row=>({name:dim(row),value:metric(row),note:`사용자 ${metric(row,1)}`})),
+    affiliate_pages:(affPages.rows||[]).map(row=>({name:dim(row),value:metric(row),note:'제휴 클릭'})),
+    affiliate_links:(affLinks.rows||[]).map(row=>({page:dim(row),name:dim(row,1),value:metric(row),date:dim(row,3),note:`페이지 ${dim(row)} · 날짜 ${dim(row,3)} · 링크 텍스트: ${dim(row,2)}`})),
+    top_queries:(gscQueries.rows||[]).sort((a,b)=>(b.impressions||0)-(a.impressions||0)).slice(0,20).map(row=>({name:row.keys?.[0]||'알 수 없음',value:Math.round(row.impressions||0),note:`클릭 ${Math.round(row.clicks||0)} · CTR ${(Number(row.ctr||0)*100).toFixed(1)}% · 순위 ${Number(row.position||0).toFixed(1)}`})),
+    search_pages:(gscPages.rows||[]).sort((a,b)=>(b.impressions||0)-(a.impressions||0)).slice(0,20).map(row=>({name:row.keys?.[0]||'알 수 없음',value:Math.round(row.impressions||0),note:`클릭 ${Math.round(row.clicks||0)} · CTR ${(Number(row.ctr||0)*100).toFixed(1)}%`})),
+    snapshot:records
   };
   write(data);
-} catch (e) {
+} catch {
   console.error('Google analytics collection failed; prior private snapshot is preserved.');
-  write(empty('google_api_error', 'Google API 연결 실패'));
+  write(empty('google_api_error','Google API 연결 실패'));
 }

--- a/projects/GlobalSaaSHub/scripts/tests/dashboard-series.test.mjs
+++ b/projects/GlobalSaaSHub/scripts/tests/dashboard-series.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';import os from 'node:os';import path from 'node:path';import {spawnSync} from 'node:child_process';import {fileURLToPath} from 'node:url';
+import {dateInZone,windowEnding,dateSeries} from '../dashboard-series.mjs';
+test('calendar windows respect timezone and fill sparse days without changing window size',()=>{
+ assert.equal(dateInZone(new Date('2026-09-10T00:30:00Z'),'America/Los_Angeles'),'2026-09-09');
+ assert.deepEqual(windowEnding('2026-09-10',7),{start:'2026-09-04',end:'2026-09-10'});
+ const rows=dateSeries([{date:'2026-08-01',users:100},{date:'2026-09-10',users:2}],windowEnding('2026-09-10',30),['users']);
+ assert.equal(rows.length,30);assert.equal(rows[0].date,'2026-08-12');assert.equal(rows[0].users,0);assert.equal(rows.at(-1).users,2);
+ assert.equal(dateSeries([],windowEnding('2026-09-10',1),['clicks'],'')[0].clicks,null);
+});
+function collect(extra={}){
+ const dir=fs.mkdtempSync(path.join(os.tmpdir(),'coshuma-fixture-'));const output=path.join(dir,'private.json');
+ try{
+  const run=spawnSync(process.execPath,['--import',new URL('./fixtures/google-reporting.mjs',import.meta.url).href,fileURLToPath(new URL('../generate_live_dashboard_data.mjs',import.meta.url))],{encoding:'utf8',env:{...process.env,...extra,DASHBOARD_OUTPUT_PATH:output}});
+  assert.equal(run.status,0,run.stderr);return JSON.parse(fs.readFileSync(output,'utf8'));
+ }finally{fs.rmSync(dir,{recursive:true,force:true});}
+}
+test('full collector aligns dates, all affiliate totals and source queries; retains GSC trailing uncertainty',()=>{
+ const d=collect();assert.equal(d.status,'live_google_connected');
+ assert.equal(d.daily.length,90);assert.equal(d.affiliate_daily.length,90);assert.equal(d.sources_daily.google.length,30);
+ assert.equal(d.windows['7d'].ga.start,'2026-09-04');assert.equal(d.windows['7d'].search.start,'2026-09-02');assert.equal(d.windows['7d'].search.end,'2026-09-08');
+ assert.equal(d.ranges.today.affiliate_clicks,7);assert.equal(d.ranges['7d'].affiliate_clicks,12);assert.equal(d.ranges['30d'].affiliate_clicks,12);assert.equal(d.ranges['90d'].affiliate_clicks,17);
+ assert.equal(d.ranges['7d'].users,2); // distinct aggregate, not sum of daily users
+ assert.equal(d.search_daily.at(-1).clicks,null);assert.equal(d.search_daily.find(r=>r.date==='2026-09-05').clicks,0);
+ assert.ok(Object.values(d.series_checks).every(v=>Object.values(v).every(x=>x===true)));
+});
+test('optional source query failure preserves live KPI and unrelated charts',()=>{
+ const d=collect({FIXTURE_FAIL_SOURCE:'1'});assert.equal(d.status,'live_google_connected');assert.equal(d.series_status.sources_daily,'unavailable');assert.deepEqual(d.sources_daily,{});assert.equal(d.daily.length,90);assert.equal(d.ranges['7d'].affiliate_clicks,12);
+});
+test('optional daily query failure leaves totals usable and never invents zeros',()=>{
+ const d=collect({FIXTURE_FAIL_DAILY:'1'});assert.equal(d.status,'live_google_connected');assert.deepEqual(d.daily,[]);assert.deepEqual(d.affiliate_daily,[]);assert.equal(d.ranges.today.affiliate_clicks,7);assert.equal(d.series_checks.today.views,null);
+});

--- a/projects/GlobalSaaSHub/scripts/tests/fixtures/google-reporting.mjs
+++ b/projects/GlobalSaaSHub/scripts/tests/fixtures/google-reporting.mjs
@@ -1,0 +1,32 @@
+import crypto from 'node:crypto';
+const RealDate=Date;
+class FixedDate extends RealDate { constructor(...args){super(...(args.length?args:['2026-09-10T00:30:00Z']));} static now(){return new RealDate('2026-09-10T00:30:00Z').valueOf();} }
+globalThis.Date=FixedDate;
+process.env.GOOGLE_SERVICE_ACCOUNT_JSON=JSON.stringify({client_email:'fixture@example.invalid',private_key:crypto.generateKeyPairSync('rsa',{modulusLength:2048,privateKeyEncoding:{type:'pkcs8',format:'pem'},publicKeyEncoding:{type:'spki',format:'pem'}}).privateKey});
+const row=(dims,values)=>({dimensionValues:dims.map(value=>({value})),metricValues:values.map(value=>({value:String(value)}))});
+const data=[['2026-07-02',2],['2026-08-01',3],['2026-09-07',5],['2026-09-10',7]];
+const subset=w=>data.filter(([date])=>date>=w.startDate && date<=w.endDate);
+const gaReport=b=>{
+ const dims=(b.dimensions||[]).map(d=>d.name).join(','),selected=subset(b.dateRanges[0]);
+ let rows;
+ if(dims==='date') rows=selected.map(([d,v])=>row([d.replaceAll('-','')],b.dimensionFilter?[v]:[v,v*2,v*3]));
+ else if(dims==='date,sessionSource')rows=selected.map(([d,v])=>row([d.replaceAll('-',''),'google'],[v]));
+ else if(dims==='sessionSource')rows=[row(['google'],[12,24]),row(['direct'],[8,16])];
+ else if(dims==='pagePath')rows=[row(['/tool/gohighlevel.html'],[12,8])];
+ else if(dims)rows=[];
+ else {const sum=selected.reduce((n,x)=>n+x[1],0);rows=[row([],b.dimensionFilter?[sum]:[selected.length,sum*2,sum*3])];}
+ return {rows,metadata:{timeZone:'Asia/Seoul'},rowCount:rows.length};
+};
+globalThis.fetch=async(url,options)=>{
+ if(url.includes('oauth2'))return {ok:true,json:async()=>({access_token:'fixture-only'})};
+ const b=JSON.parse(options.body),dims=(b.dimensions||[]).map(d=>d.name||d).join(',');
+ if(process.env.FIXTURE_FAIL_SOURCE==='1' && dims==='date,sessionSource')return {ok:false,status:429,text:async()=> 'fixture'};
+ if(process.env.FIXTURE_FAIL_DAILY==='1' && dims==='date' && !url.includes('searchconsole'))return {ok:false,status:429,text:async()=> 'fixture'};
+ let result;
+ if(url.includes('searchconsole')){
+   if(b.startDate>b.endDate)throw new Error('Invalid window');
+   const rows=[{keys:['2026-09-04'],impressions:9,clicks:2},{keys:['2026-09-06'],impressions:6,clicks:1}].filter(r=>r.keys[0]>=b.startDate&&r.keys[0]<=b.endDate);
+   result=dims==='date'?{rows}:dims?{rows:[]}:{rows:rows.length?[{impressions:rows.reduce((n,r)=>n+r.impressions,0),clicks:rows.reduce((n,r)=>n+r.clicks,0)}]:[]};
+ }else result=url.includes('batchRunReports')?{reports:b.requests.map(gaReport)}:gaReport(b);
+ return {ok:true,json:async()=>result};
+};

--- a/projects/GlobalSaaSHub/worker/src/ops-dashboard-view.js
+++ b/projects/GlobalSaaSHub/worker/src/ops-dashboard-view.js
@@ -8,6 +8,79 @@ export function dashboardClient() {
   const show = (id, v) => { $(id).textContent = v === null || v === undefined ? '—' : String(v); };
   const money = (v, currency = 'USD') => v === null ? '—' : `${currency} ${v.toFixed(2)}`;
   function connected() { return snapshot?.status === 'live_google_connected' && snapshot?.measurement_status === 'live_connected'; }
+  function calendarRows(rows, kind = 'ga', key = range) {
+    const window = snapshot?.windows?.[key]?.[kind];
+    if (!window) return [];
+    const byDate = new Map((rows || []).filter(row=>row && typeof row.date === 'string').map(row=>[row.date,row]));
+    const result=[];
+    for(let date=window.start; date<=window.end && result.length<366; date=new Date(Date.parse(`${date}T00:00:00Z`)+86400000).toISOString().slice(0,10)) result.push(byDate.get(date)||{date});
+    return result;
+  }
+  function windowLabel(kind, key = range) {
+    const w=snapshot?.windows?.[key]?.[kind];
+    return w ? `${w.start} ~ ${w.end}` : '조회 기간 확인 필요';
+  }
+  function sparkline(values, color) {
+    const nums=(values||[]).map(number), finite=nums.filter(value=>value!==null);
+    if (!finite.length) return '';
+    const width=100,height=26,max=Math.max(...finite,1),min=Math.min(...finite,0),spread=max-min||1;
+    const point=(value,i)=>({x:nums.length===1 ? 50 : i*width/(nums.length-1),y:height-(value-min)/spread*height});
+    const groups=[];let group=[];
+    nums.forEach((value,i)=>{if(value===null){if(group.length)groups.push(group);group=[];}else group.push(point(value,i));});
+    if(group.length)groups.push(group);
+    const paths=groups.map(points=>points.length===1 ? `<circle cx="${points[0].x.toFixed(1)}" cy="${points[0].y.toFixed(1)}" r="2" fill="${color}"/>` : `<polyline points="${points.map(p=>`${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ')}" fill="none" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke"/>`).join('');
+    const lastIndex=nums.findLastIndex(value=>value!==null),last=point(nums[lastIndex],lastIndex);
+    return `<svg viewBox="-2 -3 104 32" width="100%" height="26" preserveAspectRatio="none" role="img" aria-label="일별 추이: ${finite.length}개 값, 빈 구간은 미확정 또는 조회 불가" style="display:block"><title>일별 값: ${nums.map(v=>v===null?'미확정':v).join(', ')}</title>${paths}<circle cx="${last.x.toFixed(1)}" cy="${last.y.toFixed(1)}" r="2" fill="${color}"/></svg>`;
+  }
+  function chart(series, field, color) {
+    const html=sparkline(series.map(row=>row[field]),color);
+    return html || '<span style="color:var(--muted);font-size:12px">확정 기록 미제공 또는 추이 조회 불가</span>';
+  }
+  // A segmented "who makes up this total" bar for the top sources, using
+  // the same items list() already ranks — no extra data needed.
+  function compositionBar(items) {
+    if (!items || !items.length) return '';
+    const colors = ['var(--cyan)', 'var(--purple)', 'var(--green)', 'var(--amber)', 'var(--red)'];
+    const total = items.reduce((sum, x) => sum + (Number(x.value) || 0), 0);
+    if (total <= 0) return '';
+    const top = [...items].sort((a,b)=>(Number(b.value)||0)-(Number(a.value)||0)).slice(0, 5);
+    const other = Math.max(0, total - top.reduce((sum, x) => sum + (Number(x.value) || 0), 0));
+    const segments = top.map((x, i) => ({ label: x.name, value: Number(x.value) || 0, color: colors[i] || 'var(--muted)' }));
+    if (other > 0) segments.push({ label: '기타(조회 목록 내)', value: other, color: 'var(--muted)' });
+    const bars = segments.filter(s => s.value > 0).map(s => `<div style="width:${(s.value / total * 100).toFixed(2)}%;height:100%;background:${s.color}"></div>`).join('');
+    const legend = segments.map(s => `<span style="display:inline-flex;align-items:center;gap:5px;font-size:11px;color:var(--muted);margin:6px 12px 0 0"><i style="width:9px;height:9px;border-radius:3px;background:${s.color};display:inline-block"></i>${esc(s.label)} ${esc(s.value)}</span>`).join('');
+    return `<div style="font-size:11px;color:var(--muted);margin-bottom:6px">조회된 ${items.length}개 경로 내 사용자 집계 비중 · 중복 사용자 포함</div><div style="display:flex;width:100%;height:9px;border-radius:999px;overflow:hidden;background:var(--line);gap:2px">${bars}</div><div style="display:flex;flex-wrap:wrap">${legend}</div>`;
+  }
+  // Adds a chart container as the last child of a metric's own .card,
+  // reusing whatever card markup the page already has instead of assuming
+  // new hooks exist in the stored HTML template. Real DOM only (the unit
+  // test's minimal fake nodes have no closest/insertAdjacentHTML, so this
+  // silently no-ops there rather than throwing).
+  function ensureSlot(anchorId, slotId, buildSection) {
+    const anchor = $(anchorId);
+    if (!anchor || typeof anchor.closest !== 'function') return null;
+    let slot = typeof document.getElementById === 'function' ? document.getElementById(slotId) : null;
+    if (slot) return slot;
+    const card = anchor.closest('.card');
+    if (!card || typeof card.insertAdjacentHTML !== 'function') return null;
+    card.insertAdjacentHTML('beforeend', buildSection(slotId));
+    return document.getElementById(slotId);
+  }
+  // New trend cards (제휴 클릭/검색 노출/검색 클릭) have no pre-existing
+  // container in the stored template, so they're inserted once next to the
+  // metrics grid — the one section every version of this template has had.
+  function ensureMiniTrends() {
+    if ($('miniTrends')) return $('miniTrends');
+    if (typeof document.querySelector !== 'function') return null;
+    const metricsSection = document.querySelector('section.grid.metrics, .metrics');
+    if (!metricsSection || typeof metricsSection.insertAdjacentHTML !== 'function') return null;
+    metricsSection.insertAdjacentHTML('afterend', `<section class="section grid three" id="miniTrends">
+      <div class="card"><div class="section-title"><h2>제휴 클릭 추이</h2><span id="miniAffiliateRange"></span></div><div id="miniAffiliateChart"></div></div>
+      <div class="card"><div class="section-title"><h2>검색 노출 추이</h2><span id="miniImpressionsRange"></span></div><div id="miniImpressionsChart"></div></div>
+      <div class="card"><div class="section-title"><h2>검색 클릭 추이</h2><span id="miniClicksRange"></span></div><div id="miniClicksChart"></div></div>
+    </section>`);
+    return document.getElementById('miniTrends');
+  }
   function pageLabel(value) {
     const label = esc(value);
     try {
@@ -23,8 +96,16 @@ export function dashboardClient() {
     const sort = $(`sort-${id}`)?.value || 'desc';
     const filtered = (items || []).filter(x => `${x[label]} ${x.note || ''}`.toLowerCase().includes(search));
     filtered.sort((a,b) => sort === 'name' ? String(a[label]).localeCompare(String(b[label])) : (Number(a[value])-Number(b[value]))*(sort === 'asc' ? 1 : -1));
-    const rows = filtered.map(x => `<tr><td>${id === 'pages' ? pageLabel(x[label]) : esc(x[label])}${x.note ? `<small>${esc(x.note)}</small>` : ''}</td><td>${esc(x[value])}${suffix}</td></tr>`).join('');
-    $(id).innerHTML = `<table class="performance-table"><thead><tr><th>${id === 'pages' ? '페이지' : id === 'queries' ? '검색어' : '채널'}</th><th>${id === 'pages' ? '조회' : id === 'queries' ? '노출' : '방문자'}</th></tr></thead><tbody>${rows || `<tr><td colspan="2">${search ? '검색 결과 없음' : connected() ? '조회 기간에 기록 없음' : '데이터 확인 필요'}</td></tr>`}</tbody></table><div class="result-count">수집된 ${items?.length || 0}개 중 ${filtered.length}개 표시</div>`;
+    // 유입 경로 표에만 있는, 기간 내 일별 방문자 추이 — 상위 5개 채널만 제공된다.
+    const trendById = id === 'sources' ? (snapshot?.sources_daily || {}) : null;
+    const trendHead = trendById ? '<th>추이</th>' : '';
+    const rows = filtered.map(x => {
+      const trendCell = trendById ? `<td>${sparkline(calendarRows(trendById[x[label]], 'ga', '30d').map(row=>row.users), 'var(--cyan)') || '<span style="color:var(--muted)">—</span>'}</td>` : '';
+      return `<tr><td>${id === 'pages' ? pageLabel(x[label]) : esc(x[label])}${x.note ? `<small>${esc(x.note)}</small>` : ''}</td><td>${esc(x[value])}${suffix}</td>${trendCell}</tr>`;
+    }).join('');
+    const colspan = trendById ? 3 : 2;
+    const composition = id === 'sources' ? compositionBar(items) : '';
+    $(id).innerHTML = `${composition}<table class="performance-table"><thead><tr><th>${id === 'pages' ? '페이지' : id === 'queries' ? '검색어' : '채널'}</th><th>${id === 'pages' ? '조회' : id === 'queries' ? '노출' : '방문자'}</th>${trendHead}</tr></thead><tbody>${rows || `<tr><td colspan="${colspan}">${search ? '검색 결과 없음' : connected() ? '조회 기간에 기록 없음' : '데이터 확인 필요'}</td></tr>`}</tbody></table><div class="result-count">수집된 ${items?.length || 0}개 중 ${filtered.length}개 표시</div>`;
   }
   function opportunities() {
     const rows = [];
@@ -46,7 +127,8 @@ export function dashboardClient() {
     show('users', users); show('sessions', sessions); show('views', views); show('clicks', clicks);
     const period = ({ today: '오늘', '7d': '최근 7일', '30d': '최근 30일', '90d': '최근 90일' })[range];
     for (const id of ['usersNote','sessionsNote','viewsNote']) show(id, connected() ? `${period} · GA4 실측` : 'GA4 데이터 확인 중');
-    show('clicksNote', !connected() ? 'GA4 데이터 확인 중' : clicks === null ? `${period} 집계 미제공 · 30일 탭에서 확인` : `${period} · affiliate_click 실측`);
+    for(const id of ['usersNote','sessionsNote','viewsNote']) $(id).title=`${windowLabel('ga')} · ${snapshot?.timezones?.ga || ''} · 오늘 집계 중`;
+    show('clicksNote', !connected() ? 'GA4 데이터 확인 중' : clicks === null ? `${period} 집계 미제공` : `${period} · affiliate_click 실측`);
     show('affiliateCtr', users > 0 && clicks !== null ? `${(clicks/users*100).toFixed(1)}%` : null);
     $('revenue').textContent = money(revenue, m.verified_revenue_currency || 'USD');
     $('revenueNote').textContent = revenue === null ? '전체 네트워크 통합 미완료 · 0원 아님' : `${period} · 검증된 수익`;
@@ -55,7 +137,37 @@ export function dashboardClient() {
     const values = [number(r.search_impressions), number(r.search_clicks), users, clicks, revenue];
     const max = Math.max(1, ...values.filter(v => v !== null));
     ['barImpressions','barSearchClicks','barUsers','barAffiliate','barRevenue'].forEach((id, i) => $(id).style.width = values[i] === null || values[i] === 0 ? '0%' : `${Math.min(100, values[i]/max*100)}%`);
+    for(const id of ['impressions','searchClicks']) $(id).title=`${windowLabel('search')} · America/Los_Angeles · 확정치, 최신일 지연 가능`;
     list('sources', snapshot?.top_sources); list('pages', snapshot?.top_pages); list('queries', snapshot?.top_queries, 'name', 'value', ' 노출');
+    const gaRows=calendarRows(snapshot?.daily);
+    const affiliateRows=calendarRows(snapshot?.affiliate_daily);
+    const searchRows=calendarRows(snapshot?.search_daily,'search');
+    const trendColors = { users: 'var(--cyan)', sessions: 'var(--purple)', views: 'var(--green)', clicks: 'var(--amber)' };
+    const trendSeries = {
+      users: gaRows.map(d => d.users),
+      sessions: gaRows.map(d => d.sessions),
+      views: gaRows.map(d => d.views),
+      clicks: affiliateRows.map(d => d.clicks),
+    };
+    for (const metricId of ['users', 'sessions', 'views', 'clicks']) {
+      const slot = ensureSlot(metricId, `spark-${metricId}`, (slotId) => `<div class="spark-wrap" id="${slotId}" style="margin-top:8px"></div>`);
+      if (slot) { slot.innerHTML = sparkline(trendSeries[metricId], trendColors[metricId]); slot.title=windowLabel('ga'); }
+    }
+    // 제휴 클릭/검색 노출/검색 클릭은 서로 스케일 차이가 커서 (수백 대 수십)
+    // 하나의 축에 같이 그리면 작은 값이 눌려 보이므로, 각자 자기 스케일로
+    // 그리는 작은 그래프 3개로 분리한다.
+    const miniTrends = ensureMiniTrends();
+    if (miniTrends) {
+      $('miniAffiliateChart').innerHTML = chart(affiliateRows,'clicks','var(--amber)');
+      $('miniImpressionsChart').innerHTML = chart(searchRows,'impressions','var(--purple)');
+      $('miniClicksChart').innerHTML = chart(searchRows,'clicks','var(--cyan)');
+      show('miniAffiliateRange', `${period} · 오늘 집계 중`);
+      show('miniImpressionsRange', `${windowLabel('search')} · 확정치`);
+      show('miniClicksRange', `${windowLabel('search')} · 확정치`);
+      $('miniAffiliateRange').title=`${windowLabel('ga')} · ${snapshot?.timezones?.ga || ''}`;
+      for(const id of ['miniImpressionsRange','miniClicksRange']) $(id).title='America/Los_Angeles · 최신 날짜 집계 지연 가능 · 빈 구간은 미확정';
+
+    }
     $('gaApiState').textContent = snapshot?.connections?.ga4 || '데이터 확인 중';
     $('gscState').textContent = snapshot?.connections?.search_console || '데이터 확인 중';
     $('gaApiDot').className = $('gscDot').className = connected() ? 'ok' : 'warn';

--- a/projects/GlobalSaaSHub/worker/test/ops-dashboard-view.test.js
+++ b/projects/GlobalSaaSHub/worker/test/ops-dashboard-view.test.js
@@ -38,3 +38,26 @@ test('dashboard transformation replaces obsolete initial instructions, and fails
   assert.match(output, /partnerstack-summary.json/);
   assert.throws(() => decorateOpsHtml('<html>unexpected template</html>'));
 });
+
+
+test('new charts use calendar windows, render a single day, and retain missing search gaps', async () => {
+  const nodes=new Map();
+  const get=id=>{if(!nodes.has(id))nodes.set(id,{textContent:'',innerHTML:'',style:{},className:'',closest:()=>({})});return nodes.get(id);};
+  const tabs=['7d','today'].map(key=>({dataset:{range:key},classList:{add(){},remove(){}}}));
+  const window={start:'2026-09-04',end:'2026-09-10'},today={start:'2026-09-10',end:'2026-09-10'};
+  const data={status:'live_google_connected',measurement_status:'live_connected',connections:{},metrics:{},ranges:{'7d':{users:2,affiliate_clicks:3},today:{users:1,affiliate_clicks:1}},windows:{'7d':{ga:window,search:window},'30d':{ga:window,search:window},today:{ga:today,search:today}},
+    daily:[{date:'2026-08-01',users:999,views:999},{date:'2026-09-04',users:2,views:4},{date:'2026-09-10',users:1,views:2}],
+    affiliate_daily:[{date:'2026-09-04',clicks:2},{date:'2026-09-10',clicks:1}],
+    search_daily:[{date:'2026-09-04',clicks:0,impressions:5},{date:'2026-09-10',clicks:null,impressions:null}],
+    top_sources:[{name:'google',value:2},{name:'direct',value:1}],sources_daily:{google:[{date:'2026-09-04',users:2}]},snapshot:[]};
+  vm.runInNewContext(`(${dashboardClient.toString()})();`,{URL,document:{getElementById:get,querySelectorAll:()=>tabs},fetch:async url=>({ok:true,json:async()=>url.includes('partnerstack')?{}:data})});
+  await new Promise(r=>setImmediate(r));tabs[0].onclick();
+  assert.doesNotMatch(get('spark-users').innerHTML,/999/);
+  assert.match(get('spark-users').innerHTML,/일별 값: 2, 미확정, 미확정, 미확정, 미확정, 미확정, 1/);
+  assert.match(get('miniClicksChart').innerHTML,/일별 값: 0, 미확정/);
+  assert.equal(get('clicks').textContent,'3');
+  tabs[1].onclick();assert.match(get('spark-users').innerHTML,/<circle/);assert.match(get('miniAffiliateChart').innerHTML,/<svg/);
+  assert.match(get('miniClicksChart').innerHTML,/확정 기록 미제공/);
+  assert.match(get('sources').innerHTML,/조회된 2개 경로 내/);
+  assert.doesNotMatch(get('sources').innerHTML,/NaN|Infinity|undefined/);
+});


### PR DESCRIPTION
Adds Claude's KPI sparklines, source composition and three mini trend cards to the authenticated /ops dashboard, based on supplied patch 83311d5. Retains its layout while correcting calendar selection, single-day points, source-scope labels and affiliate totals for every period.

GA4 uses its property reporting time zone and explicit inclusive windows. Search uses completed Pacific calendar days and preserves uncertain trailing values. Optional chart failures no longer prevent core KPI updates. HTML and analytics remain behind owner authentication in D1; authentication and payment routes were not changed.

Validation completed:
- 18 Worker tests, 4 collector/calendar tests, and 1 public-output guard test passed; targeted lint and Worker build passed.
- Live Google collection and private upload succeeded: https://github.com/heukshow/aicity-os/actions/runs/34424027433. All four series requests succeeded, exact 90/30-day continuity passed, and pageview/affiliate-click sums matched aggregate reports for all four periods.
- Deployed Worker version c4ca170e-ddf1-4c5d-9f5c-497531526c55. Actual authenticated browser checks passed for period values against the private snapshot, charts, single-day points, missing search dates, filter/sort, internal-link navigation and 390px mobile layout.
- Owner HTML/JSON 200; anonymous HTML/JSON/PartnerStack 401; former public copies 404; homepage and Worker health 200.

Known limits: the existing Tailwind CDN warning remains. Source composition covers returned source rows rather than unique sitewide visitors; search processing can lag. Cross-network revenue and prior-period comparison are outside this change.