### PR TITLE
feat(coshuma): add verified Teachable 30-day trial buyer guide

### DIFF
--- a/projects/GlobalSaaSHub/public/best/teachable-30-day-free-trial.html
+++ b/projects/GlobalSaaSHub/public/best/teachable-30-day-free-trial.html
@@ -1,0 +1,142 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Teachable 30-Day Free Trial 2026: Verified COSHUMA Partner Route & Pricing</title>
+  <meta name="description" content="Teachable trial and pricing guide for 2026: compare the public 7-day trial with COSHUMA's vendor-confirmed 30-day PartnerStack trial route, plus Starter, Builder and Growth pricing before you choose." />
+  <link rel="canonical" href="https://coshuma.com/best/teachable-30-day-free-trial.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="COSHUMA" />
+  <meta property="og:url" content="https://coshuma.com/best/teachable-30-day-free-trial.html" />
+  <meta property="og:title" content="Teachable 30-Day Free Trial 2026: Verified COSHUMA Partner Route" />
+  <meta property="og:description" content="A buyer-focused Teachable trial and pricing guide that separates Teachable's public 7-day trial from the 30-day PartnerStack route Teachable supplied directly to COSHUMA." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"Teachable 30-Day Free Trial 2026: Verified COSHUMA Partner Route & Pricing",
+    "dateModified":"2026-09-10",
+    "author":{"@type":"Organization","name":"COSHUMA"},
+    "publisher":{"@type":"Organization","name":"COSHUMA"},
+    "mainEntityOfPage":"https://coshuma.com/best/teachable-30-day-free-trial.html"
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"How long is Teachable's public free trial?","acceptedAnswer":{"@type":"Answer","text":"Teachable's public pricing page currently advertises a 7-day free trial and a 30-day guarantee."}},
+      {"@type":"Question","name":"Does COSHUMA have a 30-day Teachable trial route?","acceptedAnswer":{"@type":"Answer","text":"Yes. A Teachable affiliate manager supplied COSHUMA an exact PartnerStack customer-facing route specifically described as the 30-day Free Trial route. COSHUMA uses that vendor-issued URL rather than constructing or guessing a tracking link."}},
+      {"@type":"Question","name":"How much does Teachable cost?","acceptedAnswer":{"@type":"Answer","text":"As rechecked on September 10, 2026, Teachable lists Starter at $39/month, Builder at $89/month and Growth at $189/month on monthly billing. Annual billing is listed at $29, $69 and $139 per month respectively, billed annually."}}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="/affiliate-attribution.js"></script>
+  <style>body{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}</style>
+</head>
+<body class="bg-[#08090d] text-slate-100 antialiased">
+  <header class="sticky top-0 z-50 border-b border-white/10 bg-[#0c0e14]/95 backdrop-blur">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-5 py-4">
+      <a href="/" class="text-xl font-black tracking-tight text-white">COSHUMA</a>
+      <a href="/best/index.html" class="text-sm font-bold text-slate-400 hover:text-white">Buyer guides →</a>
+    </div>
+  </header>
+
+  <main class="mx-auto max-w-6xl px-5 py-12 sm:py-16">
+    <nav class="mb-7 text-sm text-slate-500"><a class="hover:text-white" href="/">Home</a><span class="px-2">/</span><a class="hover:text-white" href="/best/index.html">Best</a><span class="px-2">/</span>Teachable 30-Day Free Trial</nav>
+
+    <section class="grid gap-8 lg:grid-cols-[1.35fr_.65fr] lg:items-start">
+      <div>
+        <div class="mb-5 inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">Trial & pricing rechecked September 10, 2026</div>
+        <h1 class="text-4xl font-black tracking-[-0.04em] text-white sm:text-6xl">Teachable 30-day free trial: use the exact route Teachable gave COSHUMA</h1>
+        <p class="mt-5 max-w-3xl text-lg leading-8 text-slate-300">Teachable's public pricing page currently shows a <strong class="text-white">7-day free trial</strong>. Separately, Teachable affiliate manager Camila Gouveia supplied COSHUMA the exact PartnerStack URL below and described it as COSHUMA's <strong class="text-white">30-day Free Trial</strong> route. That distinction matters: COSHUMA does not manufacture a longer-trial URL by adding parameters to Teachable's website.</p>
+        <div class="mt-7 flex flex-col gap-3 sm:flex-row">
+          <a data-cta="affiliate" data-tool-id="teachable" data-cta-source="teachable_30day_trial_hero" href="https://partnerstack.teachable.com/COSHUMA" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-emerald-600 px-6 py-4 text-center font-black text-white hover:bg-emerald-500">Open verified 30-day trial route →</a>
+          <a data-cta="official" href="https://www.teachable.com/pricing" target="_blank" rel="noopener noreferrer" class="rounded-xl border border-white/15 bg-white/[0.04] px-6 py-4 text-center font-bold text-slate-200 hover:bg-white/[0.08]">Verify public pricing →</a>
+        </div>
+        <p class="mt-3 text-xs leading-5 text-slate-500">Affiliate disclosure: the first button uses the customer-facing PartnerStack route that Teachable supplied directly to COSHUMA. COSHUMA may earn a commission if an eligible paid customer is attributed through it, at no extra cost to the buyer. Link issuance does not prove a signup, sale or commission.</p>
+      </div>
+
+      <aside class="rounded-3xl border border-emerald-400/20 bg-emerald-400/[0.06] p-6">
+        <div class="text-xs font-black uppercase tracking-widest text-emerald-300">Quick decision</div>
+        <dl class="mt-5 space-y-4 text-sm">
+          <div><dt class="text-slate-500">Public Teachable trial</dt><dd class="mt-1 font-black text-white">7 days</dd></div>
+          <div><dt class="text-slate-500">COSHUMA vendor-supplied route</dt><dd class="mt-1 font-black text-white">30-day Free Trial</dd></div>
+          <div><dt class="text-slate-500">Public guarantee</dt><dd class="mt-1 font-black text-white">30 days</dd></div>
+          <div><dt class="text-slate-500">Free plan</dt><dd class="mt-1 font-black text-white">No</dd></div>
+        </dl>
+        <p class="mt-4 text-[11px] leading-5 text-slate-500">Offers can change. Confirm the trial length and billing terms shown on the destination before completing signup.</p>
+      </aside>
+    </section>
+
+    <section class="mt-14">
+      <div class="mb-6 max-w-3xl">
+        <div class="text-xs font-black uppercase tracking-widest text-violet-300">Current plan prices</div>
+        <h2 class="mt-2 text-3xl font-black text-white">What happens if you keep Teachable after the trial?</h2>
+        <p class="mt-3 text-sm leading-7 text-slate-400">Teachable's official pricing page was rechecked on September 10, 2026. Prices are USD and can change, so use the official-pricing button above to confirm checkout before paying.</p>
+      </div>
+      <div class="grid gap-4 md:grid-cols-3">
+        <article class="rounded-2xl border border-white/10 bg-white/[0.04] p-5"><div class="text-sm font-bold text-slate-400">Starter</div><div class="mt-2 text-3xl font-black text-white">$39/mo</div><p class="mt-2 text-sm text-slate-400">$29/mo when billed annually. Teachable currently lists a 7.5% transaction fee on this plan.</p></article>
+        <article class="rounded-2xl border border-violet-400/20 bg-violet-400/[0.06] p-5"><div class="text-sm font-bold text-violet-300">Builder</div><div class="mt-2 text-3xl font-black text-white">$89/mo</div><p class="mt-2 text-sm text-slate-300">$69/mo when billed annually. Teachable currently lists 0% platform transaction fees with the qualifying gateways described on its pricing page.</p></article>
+        <article class="rounded-2xl border border-white/10 bg-white/[0.04] p-5"><div class="text-sm font-bold text-slate-400">Growth</div><div class="mt-2 text-3xl font-black text-white">$189/mo</div><p class="mt-2 text-sm text-slate-400">$139/mo when billed annually. Teachable currently lists 0% platform transaction fees with the qualifying gateways described on its pricing page.</p></article>
+      </div>
+    </section>
+
+    <section class="mt-14 grid gap-6 lg:grid-cols-2">
+      <article class="rounded-3xl border border-emerald-400/20 bg-emerald-400/[0.05] p-6 sm:p-8">
+        <div class="text-xs font-black uppercase tracking-widest text-emerald-300">Use the longer trial when…</div>
+        <h2 class="mt-2 text-2xl font-black text-white">You need enough time to test a real course workflow</h2>
+        <ul class="mt-5 space-y-3 text-sm leading-6 text-slate-300">
+          <li>✓ You want to build and publish a representative course or digital product before deciding.</li>
+          <li>✓ You need to inspect checkout, student experience and creator admin over more than one week.</li>
+          <li>✓ You are comparing Starter's lower subscription cost against its transaction fee.</li>
+          <li>✓ You want a vendor-issued tracked route rather than a guessed coupon or URL parameter.</li>
+        </ul>
+      </article>
+      <article class="rounded-3xl border border-amber-400/20 bg-amber-400/[0.05] p-6 sm:p-8">
+        <div class="text-xs font-black uppercase tracking-widest text-amber-300">Do not pay yet when…</div>
+        <h2 class="mt-2 text-2xl font-black text-white">You have not tested the economics of your actual offer</h2>
+        <ul class="mt-5 space-y-3 text-sm leading-6 text-slate-300">
+          <li>• Your course, coaching product or download is still only an idea.</li>
+          <li>• You have not compared the Starter transaction fee with Builder's higher fixed subscription.</li>
+          <li>• You need a feature that is not clearly included in the plan you are considering.</li>
+          <li>• The destination no longer shows the trial terms described here; in that case, trust the live checkout.</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="mt-14 rounded-3xl border border-white/10 bg-[#11131a] p-6 sm:p-8">
+      <h2 class="text-2xl font-black text-white">7-day public trial vs COSHUMA's 30-day partner route</h2>
+      <div class="mt-5 overflow-x-auto">
+        <table class="w-full min-w-[640px] text-left text-sm">
+          <thead class="text-slate-400"><tr class="border-b border-white/10"><th class="py-3 pr-4">Route</th><th class="py-3 pr-4">Trial wording</th><th class="py-3 pr-4">Evidence</th><th class="py-3">Best use</th></tr></thead>
+          <tbody class="text-slate-300">
+            <tr class="border-b border-white/10"><td class="py-4 pr-4 font-bold text-white">Teachable public pricing</td><td class="py-4 pr-4">7-day free trial</td><td class="py-4 pr-4">Official pricing page</td><td class="py-4">Independent terms check</td></tr>
+            <tr><td class="py-4 pr-4 font-bold text-white">COSHUMA PartnerStack</td><td class="py-4 pr-4">30-day Free Trial</td><td class="py-4 pr-4">Exact route supplied by Teachable manager</td><td class="py-4">Longer tracked evaluation when still offered at destination</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="mt-14 rounded-3xl border border-violet-400/20 bg-violet-400/[0.05] p-6 sm:p-8">
+      <div class="grid gap-5 lg:grid-cols-[1fr_auto] lg:items-center">
+        <div><div class="text-xs font-black uppercase tracking-widest text-violet-300">Next step</div><h2 class="mt-2 text-2xl font-black text-white">Test Teachable before committing to a paid billing cycle</h2><p class="mt-3 max-w-3xl text-sm leading-7 text-slate-300">Open the exact 30-day PartnerStack route below, confirm the offer shown at the destination, and use the trial to validate your real course or digital-product workflow. For a broader feature breakdown, read COSHUMA's Teachable pricing guide first.</p></div>
+        <div class="flex flex-col gap-3">
+          <a data-cta="affiliate" data-tool-id="teachable" data-cta-source="teachable_30day_trial_bottom" href="https://partnerstack.teachable.com/COSHUMA" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-violet-600 px-6 py-4 text-center font-black text-white hover:bg-violet-500">Start through verified 30-day route →</a>
+          <a href="/tool/teachable.html" class="rounded-xl border border-white/15 px-6 py-3 text-center text-sm font-bold text-slate-300 hover:bg-white/[0.05]">Read Teachable pricing guide →</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="mt-12 border-t border-white/10 pt-8 text-xs leading-6 text-slate-500">
+      <p><strong class="text-slate-300">Sources checked:</strong> Teachable's official pricing page for current plan prices, public 7-day trial, 30-day guarantee and transaction-fee terms; Teachable's direct PartnerStack message to COSHUMA for the exact 30-day Free Trial customer route. Last checked September 10, 2026.</p>
+      <p class="mt-2">COSHUMA has not verified a signup, paying customer, commission or revenue event from publication of this page. Those states remain unverified until partner-side evidence exists.</p>
+    </section>
+  </main>
+
+  <footer class="border-t border-white/10 px-5 py-8 text-center text-xs text-slate-600">© 2026 COSHUMA · Independent AI & SaaS buyer guides</footer>
+</body>
+</html>


### PR DESCRIPTION
## Revenue objective
Add a zero-cost, buyer-intent Teachable landing page around COSHUMA's vendor-confirmed 30-day PartnerStack trial route.

## Evidence
- Teachable affiliate manager Camila Gouveia supplied COSHUMA's exact 30-day Free Trial route: `https://partnerstack.teachable.com/COSHUMA`.
- Teachable's public pricing page rechecked 2026-09-10 currently advertises a 7-day free trial and 30-day guarantee, with Starter $39/mo, Builder $89/mo, Growth $189/mo; annual equivalents $29/$69/$139 per month billed annually.

## Safety
- Keeps the public 7-day offer distinct from the separately vendor-issued COSHUMA 30-day route.
- Does not synthesize tracking parameters or use dashboard/login URLs.
- Includes affiliate disclosure and explicitly does not infer signup, sale, commission, or revenue.
- No paid resources.

## Build behavior
`ensure_best_pages_in_sitemap.py` scans `public/best/*.html`, so the new canonical page is automatically added to the production sitemap during deploy.