### PR TITLE
feat(coshuma): surface verified Jotform buyer guide

### DIFF
--- a/projects/GlobalSaaSHub/public/best/index.html
+++ b/projects/GlobalSaaSHub/public/best/index.html
@@ -36,7 +36,8 @@
           {"@type":"ListItem","position":14,"url":"https://coshuma.com/best/esignature-software.html","name":"Best E-Signature Software"},
           {"@type":"ListItem","position":15,"url":"https://coshuma.com/best/fireflies-ai-free-plan.html","name":"Fireflies.ai Free Plan & Pricing Guide"},
           {"@type":"ListItem","position":16,"url":"https://coshuma.com/best/bookyourdata-free-trial.html","name":"Bookyourdata Free Trial Guide"},
-          {"@type":"ListItem","position":17,"url":"https://coshuma.com/best/teachable-30-day-free-trial.html","name":"Teachable 30-Day Free Trial Guide"}
+          {"@type":"ListItem","position":17,"url":"https://coshuma.com/best/teachable-30-day-free-trial.html","name":"Teachable 30-Day Free Trial Guide"},
+          {"@type":"ListItem","position":18,"url":"https://coshuma.com/best/jotform-pricing-free-plan.html","name":"Jotform Pricing & Free Plan Guide"}
         ]
       }
     }
@@ -113,6 +114,11 @@
             <div class="text-xs uppercase tracking-wider font-bold text-emerald-300">Course platforms · vendor-confirmed partner route</div>
             <h3 class="text-lg font-extrabold text-white mt-2">Teachable 30-Day Free Trial</h3>
             <p class="text-sm text-slate-300 mt-2 leading-relaxed">Compare Teachable's public trial with COSHUMA's vendor-confirmed 30-day PartnerStack route before choosing a paid creator plan.</p>
+          </a>
+          <a href="/best/jotform-pricing-free-plan.html" class="p-5 rounded-2xl bg-[#131520] border border-emerald-500/25 hover:border-emerald-400/60 transition-all">
+            <div class="text-xs uppercase tracking-wider font-bold text-emerald-300">Forms & AI agents · vendor-confirmed pricing route</div>
+            <h3 class="text-lg font-extrabold text-white mt-2">Jotform Pricing & Free Plan</h3>
+            <p class="text-sm text-slate-300 mt-2 leading-relaxed">Compare the free Starter tier and paid limits, then use Jotform's vendor-confirmed tracked pricing route only if the upgrade fits your workflow.</p>
           </a>
           <a href="/best/databox-genie-ai-analyst.html" class="p-5 rounded-2xl bg-[#131520] border border-purple-500/25 hover:border-purple-400/60 transition-all">
             <div class="text-xs uppercase tracking-wider font-bold text-purple-300">Analytics</div>


### PR DESCRIPTION
## Revenue objective
Surface the existing high-intent Jotform pricing/free-plan buyer page from COSHUMA's `/best/` hub so visitors already browsing purchase-oriented guides can reach the monetized Jotform page.

## Verified basis
- Jotform Affiliate Manager Ayşe Dinçer supplied COSHUMA's exact tracked pricing URL in Gmail message `1a08a037dece876d`: `https://www.jotform.com/pricing/?partner=coshuma`.
- The existing `/best/jotform-pricing-free-plan.html` already uses that vendor-confirmed route and labels it as an affiliate CTA.
- Before this change, `/best/index.html` did not link to that buyer page.

## Change
- Add Jotform Pricing & Free Plan to the high-intent guide grid.
- Add the same page to the structured `ItemList` as position 18.

## Guardrails
- No affiliate URL construction or replacement.
- No duplicate affiliate application.
- No claim of click, signup, sale, commission, or revenue.
- No paid resources.