### PR TITLE
feat(coshuma): surface verified GetGenie buyer guide

### DIFF
--- a/projects/GlobalSaaSHub/public/best/index.html
+++ b/projects/GlobalSaaSHub/public/best/index.html
@@ -37,7 +37,8 @@
           {"@type":"ListItem","position":15,"url":"https://coshuma.com/best/fireflies-ai-free-plan.html","name":"Fireflies.ai Free Plan & Pricing Guide"},
           {"@type":"ListItem","position":16,"url":"https://coshuma.com/best/bookyourdata-free-trial.html","name":"Bookyourdata Free Trial Guide"},
           {"@type":"ListItem","position":17,"url":"https://coshuma.com/best/teachable-30-day-free-trial.html","name":"Teachable 30-Day Free Trial Guide"},
-          {"@type":"ListItem","position":18,"url":"https://coshuma.com/best/jotform-pricing-free-plan.html","name":"Jotform Pricing & Free Plan Guide"}
+          {"@type":"ListItem","position":18,"url":"https://coshuma.com/best/jotform-pricing-free-plan.html","name":"Jotform Pricing & Free Plan Guide"},
+          {"@type":"ListItem","position":19,"url":"https://coshuma.com/tool/getgenie.html","name":"GetGenie Pricing & Free Plan Guide"}
         ]
       }
     }
@@ -119,6 +120,11 @@
             <div class="text-xs uppercase tracking-wider font-bold text-emerald-300">Forms & AI agents · vendor-confirmed pricing route</div>
             <h3 class="text-lg font-extrabold text-white mt-2">Jotform Pricing & Free Plan</h3>
             <p class="text-sm text-slate-300 mt-2 leading-relaxed">Compare the free Starter tier and paid limits, then use Jotform's vendor-confirmed tracked pricing route only if the upgrade fits your workflow.</p>
+          </a>
+          <a href="/tool/getgenie.html" class="p-5 rounded-2xl bg-[#131520] border border-emerald-500/25 hover:border-emerald-400/60 transition-all">
+            <div class="text-xs uppercase tracking-wider font-bold text-emerald-300">AI content & SEO · vendor-confirmed partner route</div>
+            <h3 class="text-lg font-extrabold text-white mt-2">GetGenie Pricing & Free Plan</h3>
+            <p class="text-sm text-slate-300 mt-2 leading-relaxed">Compare the $0 no-card Free plan with Starter, Writer, Pro and Agency, then start through COSHUMA's vendor-confirmed referral route if the workflow fits.</p>
           </a>
           <a href="/best/databox-genie-ai-analyst.html" class="p-5 rounded-2xl bg-[#131520] border border-purple-500/25 hover:border-purple-400/60 transition-all">
             <div class="text-xs uppercase tracking-wider font-bold text-purple-300">Analytics</div>


### PR DESCRIPTION
## Revenue objective
Surface the existing GetGenie pricing/free-plan page from COSHUMA's high-intent buyer-guide hub instead of creating a duplicate page, so purchase-oriented visitors can reach an already monetized GetGenie path.

## Verified basis
- GetGenie human support reconfirmed the exact customer-facing affiliate URL for the registered `support@coshuma.com` account on 2026-09-10: `https://getgenie.ai?rui=3921` (Gmail message `1a089dd50b6495b5`).
- `/tool/getgenie.html` already uses that exact URL in affiliate CTAs and separately links the official pricing page.
- GetGenie's official pricing page was rechecked on 2026-09-10 and currently lists a $0 no-card Free plan plus Starter, Writer, Pro and Agency.
- Before this change, `/best/index.html` did not surface the GetGenie buyer page.

## Change
- Add `/tool/getgenie.html` to the high-intent guide grid.
- Add the same buyer page to the structured ItemList as position 19.

## Guardrails
- No new GetGenie page, avoiding duplicate search intent/cannibalization.
- No affiliate URL construction or replacement.
- No duplicate affiliate application.
- No claim of clicks, signup, paid customer, commission or revenue.
- No paid resources.