### PR TITLE
feat(coshuma): emphasize Brand24 trial in buyer hub

### DIFF
--- a/projects/GlobalSaaSHub/scripts/surface_verified_claap_guide.py
+++ b/projects/GlobalSaaSHub/scripts/surface_verified_claap_guide.py
@@ -15,6 +15,11 @@ text = HUB.read_text(encoding="utf-8")
 #   already-built 30-day trial buyer page is a low-cost conversion experiment.
 # - Moosend's current first-party registration/terms evidence confirms a 30-day
 #   free trial and no credit card required to get started.
+# - Brand24's last healthy Search Console snapshot recorded 163 impressions / 0
+#   clicks for /tool/brand24.html, while the verified PartnerStack evidence recorded
+#   7 clicks / 0 signups / $0. Its current first-party pricing page confirms a
+#   14-day free trial with no credit card required. Surface that concrete trial
+#   value from the buyer hub without changing Brand24's verified affiliate URL.
 # - Existing tool/buyer pages remain responsible for exact affiliate CTAs; this
 #   patch only improves internal discovery from the high-intent buyer hub.
 # - Do not construct pricing/deep-link wrappers or infer clicks, signups or revenue.
@@ -37,6 +42,14 @@ if 'https://coshuma.com/best/moosend-free-trial.html\",\"name\":\"Moosend 30-Day
     if moosend_item_marker not in text:
         raise SystemExit("Claap ItemList marker not found; refusing unsafe Moosend buyer-hub rewrite")
     text = text.replace(moosend_item_marker, moosend_item_marker + ',\n' + moosend_item, 1)
+
+# Keep Brand24's existing URL/position but make the structured name match the
+# concrete high-intent value already present on the destination page.
+text = text.replace(
+    '"url":"https://coshuma.com/best/brand24-ai-visibility.html","name":"Brand24 AI Visibility Review"',
+    '"url":"https://coshuma.com/best/brand24-ai-visibility.html","name":"Brand24 14-Day Free Trial & AI Visibility Guide"',
+    1,
+)
 
 card_marker = '''          <a href="/best/databox-genie-ai-analyst.html" class="p-5 rounded-2xl bg-[#131520] border border-purple-500/25 hover:border-purple-400/60 transition-all">'''
 claap_card_block = '''          <a href="/tool/claap.html" class="p-5 rounded-2xl bg-[#131520] border border-emerald-500/25 hover:border-emerald-400/60 transition-all">
@@ -72,6 +85,23 @@ if moosend_card_heading not in text:
         raise SystemExit("Databox buyer-hub marker not found; refusing unsafe Moosend card insertion")
     text = text.replace(card_marker, moosend_card_block + card_marker, 1)
 
+brand24_old_card = '''          <a href="/best/brand24-ai-visibility.html" class="p-5 rounded-2xl bg-[#131520] border border-purple-500/25 hover:border-purple-400/60 transition-all">
+            <div class="text-xs uppercase tracking-wider font-bold text-purple-300">AI visibility</div>
+            <h3 class="text-lg font-extrabold text-white mt-2">Brand24 AI Visibility</h3>
+            <p class="text-sm text-slate-400 mt-2 leading-relaxed">A buyer-focused look at AI visibility and GEO tracking before adding it to a monitoring stack.</p>
+          </a>
+'''
+brand24_card = '''          <a href="/best/brand24-ai-visibility.html" class="p-5 rounded-2xl bg-[#131520] border border-emerald-500/25 hover:border-emerald-400/60 transition-all">
+            <div class="text-xs uppercase tracking-wider font-bold text-emerald-300">AI visibility · verified partner route</div>
+            <h3 class="text-lg font-extrabold text-white mt-2">Brand24 14-Day Trial & AI Visibility</h3>
+            <p class="text-sm text-slate-300 mt-2 leading-relaxed">Test Brand24 for 14 days with no credit card, then evaluate AI Visibility and continue through COSHUMA's verified customer referral route only if the monitoring workflow fits.</p>
+          </a>
+'''
+if brand24_card not in text:
+    if brand24_old_card not in text:
+        raise SystemExit("Brand24 buyer-hub card shape changed; refusing uncertain rewrite")
+    text = text.replace(brand24_old_card, brand24_card, 1)
+
 required = [
     'https://coshuma.com/tool/claap.html\",\"name\":\"Claap Pricing & Verified Partner Guide\"',
     'href="/tool/claap.html"',
@@ -79,6 +109,9 @@ required = [
     'https://coshuma.com/best/moosend-free-trial.html\",\"name\":\"Moosend 30-Day Free Trial & Pricing Guide\"',
     moosend_card_heading,
     '30-day no-card trial',
+    'https://coshuma.com/best/brand24-ai-visibility.html\",\"name\":\"Brand24 14-Day Free Trial & AI Visibility Guide\"',
+    '<h3 class="text-lg font-extrabold text-white mt-2">Brand24 14-Day Trial & AI Visibility</h3>',
+    'Test Brand24 for 14 days with no credit card',
 ]
 for marker in required:
     if marker not in text:
@@ -89,4 +122,4 @@ for stale in ('30% off the first 2 months', '10% off the first year', 'Claap Pri
         raise SystemExit(f"Stale Claap buyer-discount claim remains in buyer hub: {stale}")
 
 HUB.write_text(text, encoding="utf-8")
-print("buyer-hub-claap-moosend-current-terms-v4")
+print("buyer-hub-claap-moosend-brand24-current-terms-v5")


### PR DESCRIPTION
Revenue-first, zero-cost buyer-hub improvement backed by existing repository evidence and a fresh first-party check on 2026-09-10.

- Keep the existing Brand24 buyer page and verified tracking route unchanged.
- Reframe only the buyer-hub card around the current 14-day free trial / no-card entry point and AI Visibility intent.
- Align the ItemList label with that concrete buyer intent.
- Preserve Claap and Moosend safeguards already in this build patch.
- No new affiliate application, guessed deep link, signup, sale, commission, or revenue claim.

Evidence: last healthy Search Console snapshot records /tool/brand24.html at 163 impressions / 0 clicks; approved tracking evidence records the vendor-issued Brand24 route with 7 clicks / 0 signups / $0 as of 2026-09-08. Brand24's current official pricing page still states a 14-day free trial with no credit card required.