### PR TITLE
feat(coshuma): add HelpDesk vs Freshdesk revenue comparison

### DIFF
--- a/projects/GlobalSaaSHub/public/best/helpdesk-vs-freshdesk.html
+++ b/projects/GlobalSaaSHub/public/best/helpdesk-vs-freshdesk.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>HelpDesk vs Freshdesk (2026): Pricing, AI & Free Trial | COSHUMA</title>
+  <meta name="description" content="Compare HelpDesk vs Freshdesk pricing, 14-day trials, AI allowances, support features and buyer fit. HelpDesk uses COSHUMA's verified customer-facing partner route; Freshdesk links remain official only." />
+  <link rel="canonical" href="https://coshuma.com/best/helpdesk-vs-freshdesk.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="COSHUMA" />
+  <meta property="og:url" content="https://coshuma.com/best/helpdesk-vs-freshdesk.html" />
+  <meta property="og:title" content="HelpDesk vs Freshdesk (2026): Pricing, AI & Free Trial" />
+  <meta property="og:description" content="A buyer-focused comparison of HelpDesk and Freshdesk using current first-party pricing and trial terms." />
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"Article","headline":"HelpDesk vs Freshdesk (2026): Pricing, AI & Free Trial","dateModified":"2026-09-10","publisher":{"@type":"Organization","name":"COSHUMA"},"mainEntityOfPage":"https://coshuma.com/best/helpdesk-vs-freshdesk.html","about":[{"@type":"SoftwareApplication","name":"HelpDesk","url":"https://www.helpdesk.com/"},{"@type":"SoftwareApplication","name":"Freshdesk","url":"https://www.freshworks.com/freshdesk/"}]}
+  </script>
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"FAQPage","mainEntity":[
+    {"@type":"Question","name":"Which is cheaper, HelpDesk or Freshdesk?","acceptedAnswer":{"@type":"Answer","text":"On current annual billing, HelpDesk Essential and Freshdesk Growth both start at $19 per seat per month. Higher tiers differ substantially, so compare the features and AI usage you actually need rather than the entry price alone."}},
+    {"@type":"Question","name":"Do HelpDesk and Freshdesk offer free trials?","acceptedAnswer":{"@type":"Answer","text":"Yes. Both currently advertise a 14-day free trial without requiring a credit card."}},
+    {"@type":"Question","name":"Does COSHUMA have a Freshdesk affiliate link?","acceptedAnswer":{"@type":"Answer","text":"No verified COSHUMA Freshdesk affiliate URL is used on this page. Freshdesk buttons go to the official Freshdesk pricing page. Only the HelpDesk buttons labeled as partner links use COSHUMA's verified customer-facing campaign URL."}}
+  ]}
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="/affiliate-attribution.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen bg-[#0b0c10] text-slate-100">
+  <header class="sticky top-0 z-50 border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md">
+    <div class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-5 py-4">
+      <a href="/" class="flex items-center gap-3"><span class="flex h-9 w-9 items-center justify-center rounded-xl bg-purple-600 font-black text-white">C</span><span class="font-extrabold text-white">COSHUMA</span></a>
+      <a href="/best/index.html" class="rounded-full border border-purple-500/30 bg-purple-500/10 px-4 py-2 text-xs font-bold text-purple-200">Buyer Guides →</a>
+    </div>
+  </header>
+
+  <main class="mx-auto max-w-6xl space-y-9 px-5 py-10 md:py-14">
+    <section class="rounded-3xl border border-purple-500/25 bg-gradient-to-b from-purple-500/[0.09] to-[#121520] p-6 shadow-2xl md:p-10">
+      <div class="max-w-4xl">
+        <div class="inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-xs font-black uppercase tracking-[0.14em] text-emerald-200">Buyer comparison · terms checked Sep 10, 2026</div>
+        <h1 class="mt-5 text-4xl font-black tracking-[-0.04em] text-white md:text-6xl">HelpDesk vs Freshdesk: both start at $19 annually, but the AI economics are different.</h1>
+        <p class="mt-5 text-lg leading-8 text-slate-300">Both products currently offer a 14-day no-card trial. HelpDesk packages its AI Agent around monthly resolution allowances; Freshdesk packages Freddy AI Agent around session allowances. The practical choice depends on your support workflow, seat count and expected AI usage.</p>
+      </div>
+      <div class="mt-7 grid gap-4 md:grid-cols-2">
+        <article class="rounded-2xl border border-purple-400/25 bg-purple-400/[0.07] p-6">
+          <div class="text-xs font-black uppercase tracking-widest text-purple-300">HelpDesk</div>
+          <div class="mt-2 text-3xl font-black text-white">$19/user/mo yearly</div>
+          <p class="mt-3 text-sm leading-6 text-slate-300">Essential includes ticketing, shared inbox, 1 AI Agent and 10 AI resolutions per month. Growth is $79/user/month yearly with 10 AI Agents and 200 AI resolutions per month.</p>
+          <a data-cta="affiliate" data-tool-id="helpdesk" data-cta-source="helpdesk_vs_freshdesk_hero_helpdesk" href="https://www.helpdesk.com/?a=8IetMhQvR&utm_campaign=pp_helpdesk-default&utm_source=PP&d=14" target="_blank" rel="sponsored noopener noreferrer" class="mt-5 inline-flex rounded-xl bg-purple-600 px-6 py-3.5 font-black text-white hover:bg-purple-500">Try HelpDesk via verified COSHUMA link →</a>
+        </article>
+        <article class="rounded-2xl border border-cyan-400/25 bg-cyan-400/[0.06] p-6">
+          <div class="text-xs font-black uppercase tracking-widest text-cyan-300">Freshdesk</div>
+          <div class="mt-2 text-3xl font-black text-white">$19/agent/mo yearly</div>
+          <p class="mt-3 text-sm leading-6 text-slate-300">Growth includes ticketing, shared inbox, customer portal, knowledge base and the first 500 Freddy AI Agent sessions. Pro is $55/agent/month yearly; Enterprise is $89.</p>
+          <a data-cta="official" href="https://www.freshworks.com/freshdesk/pricing/" target="_blank" rel="noopener noreferrer" class="mt-5 inline-flex rounded-xl border border-cyan-400/40 bg-cyan-400/10 px-6 py-3.5 font-black text-cyan-100 hover:bg-cyan-400/15">Check Freshdesk official pricing →</a>
+        </article>
+      </div>
+      <p class="mt-4 text-[11px] leading-5 text-slate-500"><strong class="text-slate-400">Affiliate disclosure:</strong> COSHUMA may earn a commission from an eligible HelpDesk purchase attributed through the verified HelpDesk partner URL, at no added cost to the buyer. COSHUMA does not currently publish a verified Freshdesk affiliate URL on this page.</p>
+    </section>
+
+    <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8">
+      <h2 class="text-3xl font-black text-white">Current price and trial snapshot</h2>
+      <p class="mt-2 text-sm leading-6 text-slate-400">These figures were checked against each vendor's current first-party pricing page on September 10, 2026. Final checkout terms control.</p>
+      <div class="mt-6 overflow-x-auto">
+        <table class="w-full min-w-[720px] text-left text-sm">
+          <thead><tr class="border-b border-[#303448] text-slate-400"><th class="p-3">Decision point</th><th class="p-3 text-white">HelpDesk</th><th class="p-3 text-white">Freshdesk</th></tr></thead>
+          <tbody class="divide-y divide-[#24283a] text-slate-300">
+            <tr><td class="p-3 font-bold text-white">Entry paid tier</td><td class="p-3">Essential · $19/user/mo yearly · $25 monthly</td><td class="p-3">Growth · $19/agent/mo yearly</td></tr>
+            <tr><td class="p-3 font-bold text-white">Next tier</td><td class="p-3">Growth · $79/user/mo yearly · $99 monthly</td><td class="p-3">Pro · $55/agent/mo yearly</td></tr>
+            <tr><td class="p-3 font-bold text-white">Enterprise tier</td><td class="p-3">Custom pricing</td><td class="p-3">$89/agent/mo yearly</td></tr>
+            <tr><td class="p-3 font-bold text-white">Trial</td><td class="p-3">14 days · no credit card</td><td class="p-3">14 days · no credit card</td></tr>
+            <tr><td class="p-3 font-bold text-white">Included AI at entry</td><td class="p-3">1 AI Agent · 10 AI resolutions/month</td><td class="p-3">Freddy AI Agent · first 500 sessions included</td></tr>
+            <tr><td class="p-3 font-bold text-white">Extra AI usage</td><td class="p-3">50 AI resolutions · $49.50 auto-refill</td><td class="p-3">100 additional AI Agent sessions · $49</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="grid gap-5 lg:grid-cols-2">
+      <article class="rounded-3xl border border-purple-500/20 bg-purple-500/[0.05] p-6 md:p-8">
+        <div class="text-xs font-black uppercase tracking-widest text-purple-300">Choose HelpDesk when</div>
+        <h2 class="mt-2 text-2xl font-black text-white">You want a compact support stack with explicit AI-resolution allowances.</h2>
+        <ul class="mt-5 space-y-3 text-sm leading-6 text-slate-300"><li>✓ Shared inbox, ticketing, chat and automation are the core job.</li><li>✓ You prefer to model AI cost around resolved customer questions.</li><li>✓ Essential's lower entry price and included AI are enough for a small team.</li><li>✓ You want to test the full workflow for 14 days before paying.</li></ul>
+        <a href="/tool/helpdesk.html" class="mt-5 inline-flex font-black text-purple-300 hover:text-purple-200">Read the full HelpDesk pricing guide →</a>
+      </article>
+      <article class="rounded-3xl border border-cyan-500/20 bg-cyan-500/[0.05] p-6 md:p-8">
+        <div class="text-xs font-black uppercase tracking-widest text-cyan-300">Choose Freshdesk when</div>
+        <h2 class="mt-2 text-2xl font-black text-white">You need the Freshdesk feature ladder and session-based Freddy AI model.</h2>
+        <ul class="mt-5 space-y-3 text-sm leading-6 text-slate-300"><li>✓ Customer portal and knowledge base are important from the Growth tier.</li><li>✓ Pro-level multilingual helpdesk, custom dashboards or intelligent routing matter.</li><li>✓ You prefer to model AI usage around Freddy AI Agent sessions.</li><li>✓ You want to trial the official Freshdesk product before committing.</li></ul>
+      </article>
+    </section>
+
+    <section class="rounded-3xl border border-amber-500/20 bg-amber-500/[0.05] p-6 md:p-8">
+      <h2 class="text-3xl font-black text-white">Do not compare the $19 headline alone</h2>
+      <p class="mt-4 text-sm leading-7 text-slate-300">The entry annual price is currently the same, but AI units are not equivalent: HelpDesk counts AI resolutions, while Freshdesk sells additional Freddy AI Agent sessions. A low-cost test should use your real ticket mix for the full 14-day trial and record how many AI resolutions or sessions your team consumes before estimating monthly cost.</p>
+    </section>
+
+    <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8">
+      <h2 class="text-3xl font-black text-white">Quick buyer decision</h2>
+      <div class="mt-5 grid gap-4 md:grid-cols-2">
+        <div class="rounded-2xl border border-purple-500/25 bg-[#0e1119] p-5"><div class="font-black text-white">Start with HelpDesk</div><p class="mt-2 text-sm leading-6 text-slate-400">Best next step if the HelpDesk feature set fits: use the verified COSHUMA route, run the no-card trial with real support cases, and only pay if the measured workflow justifies it.</p><a data-cta="affiliate" data-tool-id="helpdesk" data-cta-source="helpdesk_vs_freshdesk_bottom_helpdesk" href="https://www.helpdesk.com/?a=8IetMhQvR&utm_campaign=pp_helpdesk-default&utm_source=PP&d=14" target="_blank" rel="sponsored noopener noreferrer" class="mt-4 inline-flex font-black text-purple-300 hover:text-purple-200">Open HelpDesk partner route →</a></div>
+        <div class="rounded-2xl border border-cyan-500/25 bg-[#0e1119] p-5"><div class="font-black text-white">Start with Freshdesk</div><p class="mt-2 text-sm leading-6 text-slate-400">If Freshdesk's product structure fits better, use the official pricing page below. COSHUMA is deliberately not turning that generic vendor URL into a claimed affiliate link.</p><a data-cta="official" href="https://www.freshworks.com/freshdesk/pricing/" target="_blank" rel="noopener noreferrer" class="mt-4 inline-flex font-black text-cyan-300 hover:text-cyan-200">Open Freshdesk official pricing →</a></div>
+      </div>
+    </section>
+
+    <section class="rounded-3xl border border-[#262a3d] bg-[#121520] p-6 md:p-8">
+      <h2 class="text-3xl font-black text-white">FAQ</h2>
+      <div class="mt-5 space-y-4 text-sm">
+        <details class="rounded-2xl border border-[#2a2e42] bg-[#0e1119] p-5"><summary class="cursor-pointer font-black text-white">Which starts cheaper?</summary><p class="mt-3 leading-6 text-slate-400">Their current entry annual prices are tied at $19 per seat per month: HelpDesk Essential is priced per user and Freshdesk Growth per agent. Feature and AI usage differences become more important than the headline price.</p></details>
+        <details class="rounded-2xl border border-[#2a2e42] bg-[#0e1119] p-5"><summary class="cursor-pointer font-black text-white">Can I test both without a card?</summary><p class="mt-3 leading-6 text-slate-400">Both vendors currently advertise a 14-day free trial without a credit card. Recheck the live signup terms before starting because trial conditions can change.</p></details>
+        <details class="rounded-2xl border border-[#2a2e42] bg-[#0e1119] p-5"><summary class="cursor-pointer font-black text-white">Is the Freshdesk button monetized by COSHUMA?</summary><p class="mt-3 leading-6 text-slate-400">No. COSHUMA has not verified a customer-facing Freshdesk tracking URL for this page, so the Freshdesk buttons remain official vendor links only. The HelpDesk buttons use the exact customer-facing campaign URL already verified through the existing partner account.</p></details>
+      </div>
+    </section>
+
+    <section class="rounded-2xl border border-slate-700 bg-[#0e1119] p-5 text-xs leading-6 text-slate-400">
+      <strong class="text-white">Sources checked September 10, 2026:</strong>
+      <a class="text-purple-300 underline" href="https://www.helpdesk.com/pricing/" target="_blank" rel="noopener noreferrer">HelpDesk official pricing</a> and
+      <a class="text-cyan-300 underline" href="https://www.freshworks.com/freshdesk/pricing/" target="_blank" rel="noopener noreferrer">Freshdesk official pricing</a>.
+      Pricing, trial terms, included AI allowances and add-on pricing can change. COSHUMA separately verified the HelpDesk customer-facing partner URL in the authenticated partner campaign; no Freshdesk affiliate route is claimed here. No click, signup, sale, commission or revenue is inferred from this comparison.
+    </section>
+  </main>
+  <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">© 2026 COSHUMA · Independent AI & SaaS buyer guides.</footer>
+</body>
+</html>


### PR DESCRIPTION
## Revenue objective
Create a distinct high-intent HelpDesk vs Freshdesk comparison that routes eligible HelpDesk buyers through COSHUMA's already verified customer-facing campaign URL while keeping Freshdesk strictly on its official non-affiliate pricing URL.

## Evidence and safety
- HelpDesk affiliate URL is the existing approved_tracking route already recorded in the repository: `https://www.helpdesk.com/?a=8IetMhQvR&utm_campaign=pp_helpdesk-default&utm_source=PP&d=14`.
- No Freshdesk affiliate URL is claimed or guessed; Freshdesk CTAs use only `https://www.freshworks.com/freshdesk/pricing/` and are marked `data-cta="official"`.
- Current pricing/trial/AI facts were rechecked against first-party HelpDesk and Freshdesk pricing pages on 2026-09-10.
- Both currently advertise a 14-day no-card trial.
- No click, signup, paying customer, commission or revenue is inferred.
- No paid subscription, checkout, legal acceptance, or duplicate affiliate application is involved.

## SEO scope
No existing `helpdesk-vs-freshdesk` page was found in the repository. The existing `/tool/helpdesk.html` remains the HelpDesk-specific pricing guide; this new page targets a separate comparison decision intent.

Because this is under `public/best/**`, the existing COSHUMA production workflow will add it to the sitemap and run approved-tracking/link-integrity checks before publishing.