### PR TITLE
ci(coshuma): track Kittl buyer discovery guard

### DIFF
--- a/.github/workflows/coshuma-site-deploy.yml
+++ b/.github/workflows/coshuma-site-deploy.yml
@@ -29,6 +29,7 @@ on:
       - 'projects/GlobalSaaSHub/scripts/public-copy-templates/**'
       - 'projects/GlobalSaaSHub/scripts/tests/test_public_copy.py'
       - 'projects/GlobalSaaSHub/scripts/ensure_best_pages_in_sitemap.py'
+      - 'projects/GlobalSaaSHub/scripts/surface_verified_kittl_commercial_guide.py'
       - 'projects/GlobalSaaSHub/scripts/sync_revenue_seo.py'
       - 'projects/GlobalSaaSHub/scripts/tests/test_revenue_seo.py'
       - 'projects/GlobalSaaSHub/scripts/inject_pictory_partner_offer.py'


### PR DESCRIPTION
Add the new Kittl buyer-discovery guard to the COSHUMA production workflow path filter. The prior guard-fix commit changed only that script, so the path filter did not start a new deploy. This makes future edits to the revenue-discovery guard automatically build and verify instead of silently remaining undeployed.

No product data, affiliate URL, conversion state, or paid resource is changed.