### PR TITLE
feat(coshuma): add UpLead free-trial revenue guide

### DIFF
--- a/projects/GlobalSaaSHub/public/best/uplead-free-trial-pricing.html
+++ b/projects/GlobalSaaSHub/public/best/uplead-free-trial-pricing.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>UpLead Free Trial & Pricing (2026): 7 Days, 5 Credits | COSHUMA</title>
+  <meta name="description" content="Compare UpLead's 7-day free trial, Essentials and Plus pricing, credit limits and billing model, then use COSHUMA's verified UpLead referral route if the product fits." />
+  <link rel="canonical" href="https://coshuma.com/best/uplead-free-trial-pricing.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="COSHUMA" />
+  <meta property="og:title" content="UpLead Free Trial & Pricing (2026)" />
+  <meta property="og:description" content="A buyer-focused UpLead guide covering the 7-day trial, 5 credits, current paid-plan pricing and COSHUMA's verified referral route." />
+  <meta property="og:url" content="https://coshuma.com/best/uplead-free-trial-pricing.html" />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"UpLead Free Trial & Pricing (2026): 7 Days, 5 Credits",
+    "dateModified":"2026-09-10",
+    "author":{"@type":"Organization","name":"COSHUMA"},
+    "publisher":{"@type":"Organization","name":"COSHUMA"},
+    "mainEntityOfPage":"https://coshuma.com/best/uplead-free-trial-pricing.html"
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"How long is the UpLead free trial?","acceptedAnswer":{"@type":"Answer","text":"UpLead's official pricing page currently lists a $0 free trial lasting 7 days with 5 credits."}},
+      {"@type":"Question","name":"What does one UpLead credit unlock?","acceptedAnswer":{"@type":"Answer","text":"UpLead says one credit unlocks one contact for download or CRM export and provides access to that contact's email and mobile direct dial."}},
+      {"@type":"Question","name":"Does the UpLead trial require payment details?","acceptedAnswer":{"@type":"Answer","text":"UpLead's current support guidance says payment details are entered to activate full trial access and that billing begins after the trial unless it is canceled first. Confirm the current checkout terms before starting."}}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="/affiliate-attribution.js"></script>
+</head>
+<body class="bg-[#08090d] text-slate-100 antialiased">
+  <header class="border-b border-white/10 bg-[#0c0e14]">
+    <div class="mx-auto flex max-w-5xl items-center justify-between px-5 py-4">
+      <a href="/" class="text-xl font-black tracking-tight text-white">COSHUMA</a>
+      <a href="/best/index.html" class="rounded-full border border-violet-400/30 bg-violet-500/10 px-4 py-2 text-xs font-bold text-violet-200">All buyer guides</a>
+    </div>
+  </header>
+
+  <main class="mx-auto max-w-5xl px-5 py-12 sm:py-16">
+    <section class="rounded-3xl border border-emerald-400/25 bg-emerald-400/[0.06] p-6 sm:p-9">
+      <div class="inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-xs font-black uppercase tracking-[0.16em] text-emerald-200">Pricing checked Sep 10, 2026</div>
+      <h1 class="mt-5 text-4xl font-black tracking-[-0.04em] text-white sm:text-6xl">UpLead free trial & pricing</h1>
+      <p class="mt-5 max-w-3xl text-lg leading-8 text-slate-300">UpLead currently offers a <strong class="text-white">$0, 7-day trial with 5 credits</strong>. It is designed for teams that want verified B2B emails, mobile direct dials and downloadable contact data without bundling a full outbound sequencing platform into the same product.</p>
+      <div class="mt-7 flex flex-col gap-3 sm:flex-row">
+        <a data-cta="affiliate" data-tool-id="uplead" data-cta-source="uplead_free_trial_hero" href="https://www.uplead.com?fp_ref=sangkwon-3af7dc" target="_blank" rel="sponsored noopener noreferrer" class="flex-1 rounded-xl bg-emerald-600 px-6 py-4 text-center text-sm font-black text-white hover:bg-emerald-500">Start UpLead via verified COSHUMA link →</a>
+        <a href="https://www.uplead.com/pricing/" target="_blank" rel="noopener noreferrer" class="flex-1 rounded-xl border border-white/10 bg-white/[0.03] px-6 py-4 text-center text-sm font-bold text-slate-200 hover:bg-white/[0.06]">Check official pricing →</a>
+      </div>
+      <p class="mt-4 text-xs leading-5 text-slate-500">Affiliate disclosure: the green button uses the exact customer referral URL UpLead issued to COSHUMA. COSHUMA may earn a commission on a qualifying paid subscription. Approval and link issuance do not by themselves prove a signup, sale or commission.</p>
+    </section>
+
+    <section class="mt-8 grid gap-4 md:grid-cols-3">
+      <div class="rounded-2xl border border-emerald-400/25 bg-[#11131a] p-5">
+        <div class="text-xs font-black uppercase tracking-wider text-emerald-300">Free trial</div>
+        <div class="mt-2 text-3xl font-black text-white">$0 / 7 days</div>
+        <div class="mt-2 text-sm font-bold text-white">5 credits</div>
+        <p class="mt-3 text-sm leading-6 text-slate-400">Includes verified emails, mobile phones and the Chrome extension according to UpLead's current pricing page.</p>
+      </div>
+      <div class="rounded-2xl border border-white/10 bg-[#11131a] p-5">
+        <div class="text-xs font-black uppercase tracking-wider text-slate-400">Essentials</div>
+        <div class="mt-2 text-3xl font-black text-white">$99/mo</div>
+        <div class="mt-2 text-sm font-bold text-emerald-300">170 credits/month</div>
+        <p class="mt-3 text-sm leading-6 text-slate-400">UpLead currently lists an annual option at $74/month billed annually with 2,040 credits for the year.</p>
+      </div>
+      <div class="rounded-2xl border border-white/10 bg-[#11131a] p-5">
+        <div class="text-xs font-black uppercase tracking-wider text-slate-400">Plus</div>
+        <div class="mt-2 text-3xl font-black text-white">$199/mo</div>
+        <div class="mt-2 text-sm font-bold text-emerald-300">400 credits/month</div>
+        <p class="mt-3 text-sm leading-6 text-slate-400">The current annual option is $149/month billed annually with 4,800 credits for the year. Professional pricing is custom.</p>
+      </div>
+    </section>
+
+    <section class="mt-8 rounded-3xl border border-white/10 bg-[#11131a] p-6 sm:p-8">
+      <h2 class="text-3xl font-black text-white">What a credit actually buys</h2>
+      <p class="mt-4 text-sm leading-7 text-slate-300">UpLead says one credit unlocks one contact for download or CRM export and gives access to that contact's email and mobile direct dial. That makes the trial easiest to evaluate by using the five credits on a narrow target segment rather than spreading them across unrelated searches.</p>
+      <div class="mt-5 grid gap-3 sm:grid-cols-2">
+        <div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold text-white">Good trial test</div><p class="mt-1 text-sm leading-6 text-slate-400">Choose one ICP, run a focused search, inspect the available fields and verify whether the exported contacts match the job titles and companies you actually target.</p></div>
+        <div class="rounded-xl bg-white/[0.04] p-4"><div class="font-bold text-white">Watch the billing model</div><p class="mt-1 text-sm leading-6 text-slate-400">UpLead's support guidance says payment details are part of activating full trial access and paid billing begins after the trial unless canceled. Confirm the live checkout terms before activating.</p></div>
+      </div>
+    </section>
+
+    <section class="mt-8 rounded-3xl border border-amber-400/20 bg-amber-400/[0.05] p-6 sm:p-8">
+      <h2 class="text-3xl font-black text-white">Monthly or annual?</h2>
+      <p class="mt-4 text-sm leading-7 text-slate-300">The current Essentials monthly price is $99 while the annual option is listed at $74 per month billed annually. Plus is $199 monthly or $149 per month billed annually. Annual billing lowers the effective monthly price but creates a larger upfront commitment, so use the trial to check data fit before choosing a billing term.</p>
+      <p class="mt-3 text-xs leading-5 text-amber-100/70">Prices, trial mechanics and billing terms can change. UpLead's live checkout and pricing page are authoritative at the time of purchase.</p>
+    </section>
+
+    <section class="mt-8 rounded-3xl border border-white/10 bg-[#11131a] p-6 sm:p-8">
+      <h2 class="text-3xl font-black text-white">Who UpLead fits best</h2>
+      <div class="mt-5 grid gap-4 md:grid-cols-2 text-sm leading-6 text-slate-300">
+        <div class="rounded-2xl border border-emerald-400/20 bg-emerald-400/[0.04] p-5"><h3 class="font-black text-emerald-200">Consider UpLead when...</h3><p class="mt-2">Your main job is finding verified B2B contacts and direct dials, and you prefer a credit-based data subscription that can export to a CRM or CSV.</p></div>
+        <div class="rounded-2xl border border-slate-700 bg-black/10 p-5"><h3 class="font-black text-slate-200">Compare alternatives when...</h3><p class="mt-2">You need a pay-as-you-go list instead of a recurring plan, or you want prospect data and outbound sequencing bundled into one sales-engagement workflow.</p></div>
+      </div>
+      <a href="/best/b2b-email-list-providers.html" class="mt-5 inline-flex rounded-xl border border-white/10 px-5 py-3 text-sm font-bold text-slate-200 hover:bg-white/5">Compare UpLead with Bookyourdata and Apollo →</a>
+    </section>
+
+    <section class="mt-8 rounded-3xl border border-emerald-500/20 bg-emerald-500/[0.05] p-6 text-center sm:p-8">
+      <h2 class="text-3xl font-black text-white">Use the five trial credits as a data-quality test</h2>
+      <p class="mx-auto mt-3 max-w-2xl text-sm leading-6 text-slate-300">Start with one narrow buyer segment, inspect the returned contact data, and only keep the subscription if the results justify the recurring cost.</p>
+      <a data-cta="affiliate" data-tool-id="uplead" data-cta-source="uplead_free_trial_bottom" href="https://www.uplead.com?fp_ref=sangkwon-3af7dc" target="_blank" rel="sponsored noopener noreferrer" class="mt-5 inline-flex rounded-xl bg-emerald-600 px-8 py-4 text-sm font-black text-white hover:bg-emerald-500">Try UpLead via COSHUMA →</a>
+    </section>
+
+    <section class="mt-8 rounded-2xl border border-white/10 bg-[#0e1017] p-5 text-xs leading-6 text-slate-500">
+      <strong class="text-slate-300">Sources checked Sep 10, 2026:</strong> UpLead's official pricing page for the 7-day trial, credits and current plan prices; UpLead's support article for trial activation and cancellation mechanics; and UpLead's vendor-issued welcome email to COSHUMA for the exact referral URL. The dashboard/login URL is not used as a customer CTA.
+    </section>
+  </main>
+
+  <footer class="border-t border-white/10 bg-[#0c0e14] py-8 text-center text-xs text-slate-500">© 2026 COSHUMA. Independent AI & SaaS buyer guides.</footer>
+</body>
+</html>

--- a/projects/GlobalSaaSHub/scripts/apply_uplead_verified_tracking.py
+++ b/projects/GlobalSaaSHub/scripts/apply_uplead_verified_tracking.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 PAGE = Path(__file__).resolve().parents[1] / "public" / "best" / "b2b-email-list-providers.html"
 TRACKING_URL = "https://www.uplead.com?fp_ref=sangkwon-3af7dc"
+BUYER_GUIDE = "/best/uplead-free-trial-pricing.html"
 
 html = PAGE.read_text(encoding="utf-8")
 
@@ -16,7 +17,7 @@ if top_marker in html and 'best_b2b_email_list_providers_top_uplead' not in html
     html = html.replace(top_marker, top_cta, 1)
 
 old_detail = '<a href="https://www.uplead.com/pricing/" target="_blank" rel="noopener noreferrer" class="block rounded-xl bg-slate-700 px-5 py-4 text-center font-black text-white hover:bg-slate-600">Check UpLead pricing →</a>'
-new_detail = f'<a data-cta="affiliate" data-tool-id="uplead" data-cta-source="best_b2b_email_list_providers_uplead" href="{TRACKING_URL}" target="_blank" rel="sponsored noopener noreferrer" class="block rounded-xl bg-slate-700 px-5 py-4 text-center font-black text-white hover:bg-slate-600">Start UpLead via COSHUMA →</a>\n            <a href="https://www.uplead.com/pricing/" target="_blank" rel="noopener noreferrer" class="block rounded-xl border border-white/10 px-5 py-3 text-center text-sm font-bold text-slate-300 hover:bg-white/5">Check official pricing</a>'
+new_detail = f'<a data-cta="affiliate" data-tool-id="uplead" data-cta-source="best_b2b_email_list_providers_uplead" href="{TRACKING_URL}" target="_blank" rel="sponsored noopener noreferrer" class="block rounded-xl bg-slate-700 px-5 py-4 text-center font-black text-white hover:bg-slate-600">Start UpLead via COSHUMA →</a>\n            <a href="{BUYER_GUIDE}" class="block rounded-xl border border-emerald-400/20 bg-emerald-400/[0.05] px-5 py-3 text-center text-sm font-bold text-emerald-200 hover:bg-emerald-400/10">Read UpLead free-trial & pricing guide</a>\n            <a href="https://www.uplead.com/pricing/" target="_blank" rel="noopener noreferrer" class="block rounded-xl border border-white/10 px-5 py-3 text-center text-sm font-bold text-slate-300 hover:bg-white/5">Check official pricing</a>'
 if old_detail in html:
     html = html.replace(old_detail, new_detail, 1)
 
@@ -32,6 +33,7 @@ if disclosure_old in html:
 
 required = [
     TRACKING_URL,
+    BUYER_GUIDE,
     'best_b2b_email_list_providers_top_uplead',
     'best_b2b_email_list_providers_uplead',
     'best_b2b_email_list_providers_table_uplead',
@@ -46,4 +48,4 @@ if 'affiliates.uplead.com/login' in html:
     raise SystemExit('UpLead affiliate dashboard URL leaked into public buyer page')
 
 PAGE.write_text(html, encoding="utf-8")
-print('uplead-approved-tracking-v1')
+print('uplead-approved-tracking-v2')


### PR DESCRIPTION
## Revenue objective
Turn the newly vendor-verified UpLead revenue route into a dedicated high-intent buyer surface instead of leaving monetization only inside the broader B2B provider comparison.

## Verified basis
- UpLead sent `support@coshuma.com` Gmail message `1a08b7419d47b773`, explicitly identifying `https://www.uplead.com?fp_ref=sangkwon-3af7dc` as COSHUMA's shareable customer referral URL and separately identifying `https://affiliates.uplead.com/login` as the dashboard/login URL.
- UpLead's live pricing page was rechecked on 2026-09-10: $0 / 7-day trial / 5 credits; Essentials $99 monthly with 170 credits; current annual option $74/month billed annually with 2,040 credits; Plus $199 monthly or $149/month billed annually with 4,800 credits; Professional custom.
- UpLead's current support guidance says payment details are entered to activate full trial access and users should cancel before the trial ends to avoid paid billing; the new page tells buyers to confirm live checkout terms rather than assuming them.

## Changes
- Add `/best/uplead-free-trial-pricing.html` with two disclosed revenue CTAs using only the exact vendor-issued URL, separate official pricing evidence, current plan/trial context, and buyer-fit guidance.
- Link the existing B2B provider comparison's UpLead section to the dedicated guide during the existing build-time UpLead reconciliation.
- Extend the UpLead build guard so the dedicated guide link is required and the dashboard URL remains prohibited from the public buyer page.

## Guardrails
- No duplicate application or new account.
- No guessed pricing/deep-link affiliate URL.
- No dashboard/onboarding URL as a revenue CTA.
- No claim of click, signup, paid customer, commission, payout or revenue.
- No paid resource.