### PR TITLE
feat(coshuma): add Claap sales follow-up buyer guide

### DIFF
--- a/projects/GlobalSaaSHub/data/claap-followup-promotion-evidence-2026-09-10.md
+++ b/projects/GlobalSaaSHub/data/claap-followup-promotion-evidence-2026-09-10.md
@@ -1,0 +1,23 @@
+# Claap follow-up promotion evidence — 2026-09-10
+
+## Human partner signal
+
+- Gmail account: `support@coshuma.com`
+- Message ID: `1a08bba193693cd5`
+- Sender: Lamia Karmaly, Claap Affiliates & Influencer Manager
+- Received: 2026-09-10 14:30:22 UTC
+- Claap explicitly suggested sales follow-up as an initial affiliate content angle, centered on the problem of reps losing objections, next steps, stakeholder details and other call context before writing the follow-up.
+- This message is treated as promotion/topic guidance only. It does not prove clicks, signups, customers, commission or revenue.
+
+## First-party product validation rechecked 2026-09-10
+
+- `https://www.claap.io/` currently describes Claap as capturing sales conversations and turning them into follow-ups, CRM updates, forecasts and coaching; it also describes built-in agents that can draft follow-ups and surface risks.
+- `https://www.claap.io/automatic-note-taker` currently describes sales notes around discovery questions, objections, MEDDIC fields and next steps, plus AI summaries, action items and follow-up emails.
+- `https://www.claap.io/pricing-v2` currently states that every plan starts with a 14-day full-access trial and that no credit card is required.
+
+## Revenue-route guardrail
+
+- The new buyer guide uses only the already verified COSHUMA Claap customer-facing route: `https://get.claap.io/rc9nqme16a9q-gfvrqk`.
+- The pricing link remains a separate official non-affiliate source URL.
+- No generic homepage, dashboard or onboarding URL is represented as a tracked revenue link.
+- No conversion or revenue is inferred from this content rollout.

--- a/projects/GlobalSaaSHub/public/best/claap-sales-follow-up-ai.html
+++ b/projects/GlobalSaaSHub/public/best/claap-sales-follow-up-ai.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Claap for Sales Follow-Up: AI Notes, Objections & Next Steps (2026) | COSHUMA</title>
+  <meta name="description" content="A buyer guide to using Claap for sales follow-up: capture objections, next steps and CRM context from calls, then decide whether its AI meeting workflow fits your revenue team." />
+  <link rel="canonical" href="https://coshuma.com/best/claap-sales-follow-up-ai.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/best/claap-sales-follow-up-ai.html" />
+  <meta property="og:title" content="Claap for Sales Follow-Up: AI Notes, Objections & Next Steps" />
+  <meta property="og:description" content="How Claap turns sales conversations into follow-up emails, CRM updates, objections, action items and coaching context." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"Claap for Sales Follow-Up: AI Notes, Objections & Next Steps (2026)",
+    "mainEntityOfPage":"https://coshuma.com/best/claap-sales-follow-up-ai.html",
+    "author":{"@type":"Organization","name":"COSHUMA"},
+    "publisher":{"@type":"Organization","name":"COSHUMA"},
+    "dateModified":"2026-09-10",
+    "description":"A buyer guide to evaluating Claap for sales follow-up automation, objection capture, next-step tracking and CRM context."
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="/affiliate-attribution.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen flex flex-col justify-between">
+<header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+  <div class="max-w-6xl mx-auto flex items-center justify-between">
+    <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white">C</div><span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span></a>
+    <a href="/best/index.html" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">Buyer guides →</a>
+  </div>
+</header>
+
+<main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
+  <section class="p-8 rounded-3xl bg-[#131520] border border-[#222538] shadow-2xl space-y-6">
+    <div class="inline-flex px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">Sales follow-up workflow</div>
+    <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">Claap for Sales Follow-Up: AI Notes, Objections & Next Steps</h1>
+    <p class="text-slate-300 text-base md:text-lg leading-relaxed">A weak follow-up is often a context problem before it is a copywriting problem. Claap is designed to capture sales conversations, turn them into structured notes and follow-up emails, update CRM context, and surface objections or next steps so reps do not have to reconstruct the call from memory.</p>
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+      <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-xs uppercase text-slate-400 font-bold">Best fit</div><div class="font-black text-white mt-1">Sales teams</div><p class="text-xs text-slate-400 mt-2">Teams where calls, objections and next steps need to flow into CRM and follow-up work.</p></div>
+      <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-xs uppercase text-slate-400 font-bold">Current trial</div><div class="font-black text-white mt-1">14 days</div><p class="text-xs text-slate-400 mt-2">Claap's current revenue-team pricing page states a 14-day full-access trial with no credit card required.</p></div>
+      <div class="p-4 rounded-2xl bg-[#181a29] border border-[#222538]"><div class="text-xs uppercase text-slate-400 font-bold">Core decision</div><div class="font-black text-white mt-1">Notes → action</div><p class="text-xs text-slate-400 mt-2">The value is not recording alone; it is whether captured context improves follow-up and CRM execution.</p></div>
+    </div>
+    <div class="flex flex-col sm:flex-row gap-3">
+      <a data-cta="affiliate" data-tool-id="claap" data-cta-source="claap_sales_followup_guide" href="https://get.claap.io/rc9nqme16a9q-gfvrqk" target="_blank" rel="sponsored noopener noreferrer" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center hover:brightness-110">Start Claap with verified tracking →</a>
+      <a data-cta="official" data-tool-id="claap" href="https://www.claap.io/pricing-v2" target="_blank" rel="noopener noreferrer" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-[#181a29] border border-[#30344c] text-white text-center">Check live Claap pricing →</a>
+    </div>
+    <p class="text-[11px] text-slate-500 leading-relaxed"><strong class="text-slate-300">Affiliate disclosure:</strong> COSHUMA may earn a commission if you purchase through the verified Claap partner link, at no extra cost to you. This page does not claim that a click, signup, sale or commission has occurred.</p>
+  </section>
+
+  <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+    <h2 class="text-2xl font-black text-white">Where sales follow-up usually breaks</h2>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm text-slate-300">
+      <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><h3 class="font-bold text-white">Objections get blurred</h3><p class="text-xs text-slate-400 mt-2 leading-relaxed">A rep remembers the topic but not the exact concern, so the reply addresses the wrong problem.</p></div>
+      <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><h3 class="font-bold text-white">Next steps disappear</h3><p class="text-xs text-slate-400 mt-2 leading-relaxed">Owners, deadlines or promised actions stay in the call instead of becoming clear follow-up tasks.</p></div>
+      <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]"><h3 class="font-bold text-white">CRM context lags</h3><p class="text-xs text-slate-400 mt-2 leading-relaxed">Manual updates are delayed or incomplete, so the next touch starts with stale deal context.</p></div>
+    </div>
+  </section>
+
+  <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+    <h2 class="text-2xl font-black text-white">What Claap can automate after a call</h2>
+    <p class="text-sm text-slate-300 leading-relaxed">Claap's current first-party product pages describe a workflow that records conversations, creates AI notes and summaries, drafts follow-up emails, and pushes structured call context into CRM systems. Its automatic note-taker page specifically highlights discovery questions, objections and next steps as sales-note context.</p>
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-slate-300">
+      <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Capture and transcribe meetings across common sales-call workflows</div>
+      <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Generate summaries, action items and follow-up email drafts</div>
+      <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Surface objections and other sales-call insights from meeting context</div>
+      <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Auto-log summaries and structured fields into supported CRM workflows</div>
+      <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Use call scoring and AI coaching on plans that include those capabilities</div>
+      <div class="p-4 rounded-xl bg-[#181a29] border border-[#222538]">✓ Expose meeting context to compatible AI-agent workflows through Claap MCP</div>
+    </div>
+  </section>
+
+  <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+    <h2 class="text-2xl font-black text-white">A practical 3-call test before paying</h2>
+    <ol class="space-y-3 text-sm text-slate-300 list-decimal list-inside">
+      <li><strong class="text-white">Use real calls.</strong> Test discovery, demo and follow-up conversations rather than a scripted sample.</li>
+      <li><strong class="text-white">Check the output.</strong> Compare Claap's objections, action items and follow-up draft with what your rep would have written manually.</li>
+      <li><strong class="text-white">Check the handoff.</strong> Confirm that the CRM fields and next steps your team actually uses can be updated without creating more cleanup work.</li>
+    </ol>
+    <div class="p-4 rounded-xl bg-amber-500/5 border border-amber-500/20 text-xs text-slate-400 leading-relaxed">Do not judge the product only on transcription quality. For a sales team, the higher-value question is whether the captured context makes the next email, CRM record and manager review more accurate or faster.</div>
+  </section>
+
+  <section class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-5">
+    <h2 class="text-2xl font-black text-white">Who should test Claap for follow-up?</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div class="p-5 rounded-2xl bg-emerald-500/5 border border-emerald-500/20"><h3 class="font-bold text-emerald-300">Strong fit</h3><ul class="text-sm text-slate-300 space-y-2 list-disc list-inside mt-3"><li>Sales reps run enough calls that manual notes are a recurring burden.</li><li>Follow-up quality depends on remembering objections, stakeholders or commitments.</li><li>Your CRM needs timely call context for pipeline review or coaching.</li><li>You want meeting context available to AI workflows beyond a standalone transcript.</li></ul></div>
+      <div class="p-5 rounded-2xl bg-rose-500/5 border border-rose-500/20"><h3 class="font-bold text-rose-300">Probably unnecessary</h3><ul class="text-sm text-slate-300 space-y-2 list-disc list-inside mt-3"><li>You only need occasional transcription and do not use CRM-driven sales processes.</li><li>Your team rarely follows up after calls or has no structured deal workflow.</li><li>You already have a meeting tool that reliably handles notes, CRM updates and coaching at a lower total cost.</li></ul></div>
+    </div>
+  </section>
+
+  <section class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
+    <h2 class="text-2xl font-black text-white">COSHUMA verdict</h2>
+    <p class="text-sm text-slate-300 leading-relaxed">Claap is worth testing when the expensive part of a sales call happens after the meeting: reconstructing objections, writing the follow-up, updating CRM fields and preparing the next rep or manager touch. Its current 14-day no-card trial gives teams a low-friction way to test that workflow on real deals before committing.</p>
+    <div class="flex flex-col sm:flex-row gap-3">
+      <a data-cta="affiliate" data-tool-id="claap" data-cta-source="claap_sales_followup_guide_bottom" href="https://get.claap.io/rc9nqme16a9q-gfvrqk" target="_blank" rel="sponsored noopener noreferrer" class="flex-1 px-7 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center hover:brightness-110">Try Claap with verified tracking →</a>
+      <a href="/tool/claap.html" class="flex-1 px-7 py-4 rounded-xl font-extrabold text-sm bg-[#181a29] border border-[#30344c] text-white text-center">Read the full Claap pricing review →</a>
+    </div>
+  </section>
+
+  <section class="p-5 rounded-2xl bg-[#0f1119] border border-[#222538] space-y-2">
+    <h2 class="text-lg font-black text-white">Sources checked Sep 10, 2026</h2>
+    <p class="text-xs text-slate-400 leading-relaxed">Claap official homepage and automatic note-taker pages were used for product capabilities; Claap's current revenue-team pricing page was used for the 14-day full-access, no-credit-card trial statement. Final plan limits and pricing remain controlled by Claap.</p>
+    <div class="flex flex-wrap gap-3 text-xs">
+      <a href="https://www.claap.io/" target="_blank" rel="noopener noreferrer" class="text-purple-300 underline">Official Claap product page</a>
+      <a href="https://www.claap.io/automatic-note-taker" target="_blank" rel="noopener noreferrer" class="text-purple-300 underline">Official automatic note-taker page</a>
+      <a href="https://www.claap.io/pricing-v2" target="_blank" rel="noopener noreferrer" class="text-purple-300 underline">Official current pricing page</a>
+    </div>
+  </section>
+</main>
+
+<footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500"><div class="max-w-6xl mx-auto px-4">&copy; 2026 COSHUMA. Independent AI & SaaS decision support.</div></footer>
+</body>
+</html>


### PR DESCRIPTION
## Revenue objective
Turn a fresh human partner promotion signal into a distinct, high-intent buyer surface around sales follow-up pain instead of creating another generic Claap review.

## Verified basis
- Claap Affiliates & Influencer Manager Lamia Karmaly emailed `support@coshuma.com` on 2026-09-10 (Gmail message `1a08bba193693cd5`) and explicitly recommended sales follow-up as a content angle, centered on lost objections, next steps and call context.
- Claap's current first-party homepage says it turns sales conversations into follow-ups, CRM updates, forecasts and coaching.
- Claap's current automatic note-taker page specifically highlights discovery questions, objections and next steps, plus AI summaries and follow-up emails.
- Claap's current revenue-team pricing page states a 14-day full-access trial with no credit card required.
- COSHUMA's already verified customer-facing Claap route remains `https://get.claap.io/rc9nqme16a9q-gfvrqk`.

## Changes
- Add `/best/claap-sales-follow-up-ai.html` targeting a distinct follow-up/objection/next-step decision intent.
- Use two disclosed revenue CTAs with only the existing verified Claap tracking URL.
- Keep live pricing as a separate official non-affiliate source link.
- Record the human partner signal and first-party validation in repository evidence.

## Guardrails
- No new or duplicate affiliate application.
- No guessed deep link, dashboard or onboarding URL.
- No claim of click, signup, paying customer, commission, payout or revenue.
- No paid resource.