### PR TITLE
feat(coshuma): add HighLevel Voice AI revenue guide

### DIFF
--- a/projects/GlobalSaaSHub/data/browser_required_queue.d/highlevel-active-offer-links-2026-09-11.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.d/highlevel-active-offer-links-2026-09-11.json
@@ -1,0 +1,21 @@
+{
+  "id": "highlevel-active-offer-links-2026-09-11",
+  "tool_id": "gohighlevel",
+  "priority": "medium",
+  "status": "approved_tracking_offer_specific_links_browser_required",
+  "affiliate_status": "approved_tracking",
+  "cost": 0,
+  "verified_at": "2026-09-11T00:41:33+09:00",
+  "gmail_message_id": "1a08bf0ff5769cf6",
+  "gmail_thread_id": "1a08bf0ff5769cf6",
+  "reason": "HighLevel emailed support@coshuma.com that the Affiliate Offers Page is live and that affiliates should log in and enter their referral code to unlock ready-to-share campaigns and promotions. Public HighLevel pages verify that multiple active offers exist, including a current Voice AI Sales System workshop, but this run did not obtain a COSHUMA-specific customer-facing tracked URL for any individual offer.",
+  "exact_tracking_url": "https://www.gohighlevel.com/?fp_ref=sangkwon56",
+  "offer_specific_tracking_url": null,
+  "next_action": "In an authenticated HighLevel affiliate browser session, open the Affiliate Offers Page, use the existing COSHUMA referral identity, and recover the exact customer-facing tracked URL for any active offer only if the portal explicitly exposes it. Verify destination and retained attribution before replacing any general HighLevel CTA. Do not reapply to the affiliate program.",
+  "do_not": [
+    "Do not create or guess offer-specific referral URLs by adding fp_ref or other parameters to public offer pages.",
+    "Do not use affiliate portal, dashboard, login, email-redirect or onboarding URLs as public revenue links.",
+    "Do not change the existing verified account-level HighLevel referral URL unless newer authoritative account evidence supersedes it.",
+    "Do not infer clicks, trials, sales, commissions or revenue from the offer email or public offer page."
+  ]
+}

--- a/projects/GlobalSaaSHub/data/highlevel-voice-ai-revenue-evidence-2026-09-11.md
+++ b/projects/GlobalSaaSHub/data/highlevel-voice-ai-revenue-evidence-2026-09-11.md
@@ -1,0 +1,40 @@
+# HighLevel Voice AI revenue evidence — 2026-09-11
+
+## Triggering account evidence
+- Gmail account: `support@coshuma.com`
+- Vendor message id: `1a08bf0ff5769cf6`
+- Sender: HighLevel Affiliate Team (`noreply@gohighlevel.com`)
+- Subject: `Explore affiliate offers ready for you to promote`
+- Received: 2026-09-10 15:30:18 UTC
+- The message states that the HighLevel Affiliate Offers Page is live and tells the affiliate to log in and enter the referral code to unlock ready-to-share campaigns and promotions.
+- It also says new offers launch throughout the year and are intended to support recurring affiliate income.
+
+## Current public vendor evidence
+- Affiliate Resource Hub: https://www.gohighlevel.com/affiliate
+- Active Affiliate Offers: https://www.gohighlevel.com/affiliateoffers
+- HighLevel Pricing: https://www.gohighlevel.com/pricing
+- AI Product Pricing: https://help.gohighlevel.com/support/solutions/articles/155000006652
+
+As checked on 2026-09-11:
+- The public Active Affiliate Offers page includes a current `How to Build, Implement and Sell a Voice AI Sales System` offer described as a 2-day live workshop.
+- The same public page states HighLevel affiliates can earn 40% recurring/lifetime commission under the applicable program terms.
+- HighLevel's public pricing page lists Starter at $97/month, Unlimited at $297/month, Agency Pro at $497/month, with a 14-day free trial on those plans.
+- HighLevel's AI Product Pricing article, modified 2026-09-02, lists AI Employee Growth at $50/month per enabled location with 100 Voice AI minutes/month and AI Employee Unlimited at $97/month per enabled location with unlimited Voice AI subject to fair use. Pay-per-use is also available.
+- HighLevel explicitly warns that AI pricing/model availability can change and current in-app billing should be checked before quoting externally.
+- HighLevel's pricing/billing documentation notes that phone-system charges can still apply even when Voice AI usage is covered by an AI subscription.
+
+## COSHUMA tracking state
+- Existing verified HighLevel account-level customer referral URL remains: `https://www.gohighlevel.com/?fp_ref=sangkwon56`
+- This run does **not** claim a workshop-specific or Voice-AI-specific tracked deep link.
+- New buyer page uses only the already verified account-level referral URL for affiliate CTAs and official HighLevel pages for evidence/non-affiliate links.
+
+## Revenue action applied
+- Added `/best/highlevel-voice-ai-sales-system.html` to capture a current buyer-intent topic that HighLevel itself is actively promoting.
+- The page separates base HighLevel subscription cost, AI Employee pricing and phone-system charges so visitors can evaluate the real stack before converting.
+- Affiliate CTAs use only the previously verified HighLevel account-level customer URL.
+
+## Guardrails
+- Do not construct a Voice AI, workshop, pricing or campaign deep link by appending `fp_ref` unless HighLevel explicitly supplies or the authenticated affiliate portal exposes that exact customer-facing URL.
+- Do not treat the affiliate dashboard, offer-management page, onboarding page or email redirect as a customer revenue URL.
+- Do not claim clicks, trials, customers, commissions or revenue without dashboard/vendor evidence.
+- No paid resource was created or purchased in this run.

--- a/projects/GlobalSaaSHub/public/best/highlevel-voice-ai-sales-system.html
+++ b/projects/GlobalSaaSHub/public/best/highlevel-voice-ai-sales-system.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>HighLevel Voice AI 2026: Pricing, Sales Use Cases & Trial | COSHUMA</title>
+  <meta name="description" content="HighLevel Voice AI buyer guide for 2026: compare the 14-day HighLevel trial, Voice AI usage options, AI Employee pricing, phone charges and the safest way to test a sales workflow before paying." />
+  <link rel="canonical" href="https://coshuma.com/best/highlevel-voice-ai-sales-system.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/best/highlevel-voice-ai-sales-system.html" />
+  <meta property="og:title" content="HighLevel Voice AI 2026: Pricing & Sales System Guide | COSHUMA" />
+  <meta property="og:description" content="A buyer-focused guide to HighLevel Voice AI, AI Employee pricing, phone charges and the 14-day HighLevel trial." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"HighLevel Voice AI 2026: Pricing, Sales Use Cases & Trial",
+    "dateModified":"2026-09-11",
+    "author":{"@type":"Organization","name":"COSHUMA"},
+    "publisher":{"@type":"Organization","name":"COSHUMA","url":"https://coshuma.com/"},
+    "mainEntityOfPage":"https://coshuma.com/best/highlevel-voice-ai-sales-system.html",
+    "about":{"@type":"SoftwareApplication","name":"HighLevel","applicationCategory":"BusinessApplication","operatingSystem":"Web"}
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"Does HighLevel include Voice AI?","acceptedAnswer":{"@type":"Answer","text":"HighLevel lists Voice AI as part of its AI product suite. Voice AI can be billed pay-per-use or covered by AI Employee Growth or AI Employee Unlimited, depending on the location's setup."}},
+      {"@type":"Question","name":"How much does HighLevel Voice AI cost?","acceptedAnswer":{"@type":"Answer","text":"HighLevel currently lists AI Employee Growth at $50 per month per enabled location with 100 Voice AI minutes per month, and AI Employee Unlimited at $97 per month per enabled location with unlimited Voice AI subject to fair use. Phone system charges can still apply."}},
+      {"@type":"Question","name":"Can I test HighLevel before paying?","acceptedAnswer":{"@type":"Answer","text":"Yes. HighLevel's official pricing page currently advertises a 14-day free trial for Starter, Unlimited and Agency Pro."}}
+    ]
+  }
+  </script>
+  <script defer src="/affiliate-attribution.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>body{font-family:Inter,Arial,sans-serif;background:#080a10;color:#eef2ff}</style>
+</head>
+<body>
+  <header class="border-b border-white/10 bg-[#080a10]/90 py-4 px-6">
+    <div class="mx-auto flex max-w-6xl items-center justify-between">
+      <a href="/" class="font-black tracking-tight text-white">COSHUMA</a>
+      <a href="/best/highlevel-free-trial.html" class="text-sm font-bold text-violet-300">HighLevel trial guide →</a>
+    </div>
+  </header>
+
+  <main class="mx-auto max-w-5xl px-5 py-12 space-y-10">
+    <section class="rounded-3xl border border-violet-400/25 bg-[#11131a] p-7 md:p-10 space-y-6">
+      <div class="text-xs font-extrabold uppercase tracking-wider text-violet-300">Voice AI buyer guide · updated Sep 11, 2026</div>
+      <h1 class="text-4xl md:text-6xl font-black leading-tight">HighLevel Voice AI: What to Test Before You Pay</h1>
+      <p class="max-w-4xl text-lg leading-8 text-slate-300">HighLevel is actively promoting Voice AI sales systems to agencies and business owners, but the buying decision is not just “does it have Voice AI?” The practical question is whether one real inbound or outbound workflow can justify the base HighLevel plan, AI usage and phone charges together.</p>
+      <div class="flex flex-col gap-3 sm:flex-row">
+        <a data-cta="affiliate" data-tool-id="gohighlevel" data-cta-source="highlevel_voice_ai_hero" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-violet-600 px-7 py-4 text-center font-black text-white hover:bg-violet-500">Start the 14-day HighLevel trial →</a>
+        <a data-cta="official" href="https://help.gohighlevel.com/support/solutions/articles/155000006652" target="_blank" rel="noopener noreferrer" class="rounded-xl border border-white/15 bg-white/[0.04] px-7 py-4 text-center font-bold text-slate-200">Check official AI pricing →</a>
+      </div>
+      <p class="text-[11px] leading-5 text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if you become a paying HighLevel customer through the verified partner link. The AI-pricing link is an official non-affiliate source.</p>
+    </section>
+
+    <section class="grid gap-5 md:grid-cols-3">
+      <article class="rounded-2xl border border-white/10 bg-[#11131a] p-6">
+        <div class="text-xs font-bold uppercase text-slate-500">Base platform</div>
+        <div class="mt-2 text-3xl font-black">$97/mo</div>
+        <p class="mt-3 text-sm leading-6 text-slate-300">HighLevel Starter is the lowest listed base plan. The official pricing page currently advertises a 14-day free trial.</p>
+      </article>
+      <article class="rounded-2xl border border-violet-400/30 bg-violet-950/20 p-6">
+        <div class="text-xs font-bold uppercase text-violet-300">AI Employee Growth</div>
+        <div class="mt-2 text-3xl font-black">$50/mo</div>
+        <p class="mt-3 text-sm leading-6 text-slate-300">Per enabled location. HighLevel currently lists 100 Voice AI agent minutes per month, then applicable usage charges after the allowance.</p>
+      </article>
+      <article class="rounded-2xl border border-white/10 bg-[#11131a] p-6">
+        <div class="text-xs font-bold uppercase text-slate-500">AI Employee Unlimited</div>
+        <div class="mt-2 text-3xl font-black">$97/mo</div>
+        <p class="mt-3 text-sm leading-6 text-slate-300">Per enabled location. HighLevel currently lists unlimited Voice AI subject to fair use; phone system charges can still apply.</p>
+      </article>
+    </section>
+
+    <section class="rounded-3xl border border-white/10 bg-[#11131a] p-7 md:p-8 space-y-5">
+      <div class="text-xs font-extrabold uppercase tracking-wider text-emerald-300">Current vendor emphasis</div>
+      <h2 class="text-3xl font-black">Why Voice AI is a live HighLevel buying topic now</h2>
+      <p class="text-slate-300 leading-7">HighLevel's current public Affiliate Offers page features a two-day “Voice AI Sales System” workshop. The vendor describes the workflow around identifying high-impact Voice AI opportunities, deploying a system, packaging it as an agency offer and using it to qualify leads and close deals. That makes Voice AI a current sales-and-agency use case, not just a buried feature.</p>
+      <p class="text-sm leading-6 text-slate-400">COSHUMA does not publish an unverified workshop-specific tracking URL. The revenue button on this page uses only COSHUMA's already verified general HighLevel referral route.</p>
+    </section>
+
+    <section class="rounded-3xl border border-white/10 bg-[#11131a] p-7 md:p-8 space-y-5">
+      <h2 class="text-3xl font-black">Three costs to check together</h2>
+      <div class="grid gap-4 md:grid-cols-3">
+        <div class="rounded-2xl bg-black/20 p-5"><h3 class="font-black text-white">1. HighLevel plan</h3><p class="mt-2 text-sm leading-6 text-slate-300">Starter is currently $97/month; Unlimited is $297/month; Agency Pro is $497/month.</p></div>
+        <div class="rounded-2xl bg-black/20 p-5"><h3 class="font-black text-white">2. AI usage</h3><p class="mt-2 text-sm leading-6 text-slate-300">Choose pay-per-use, AI Employee Growth or AI Employee Unlimited based on expected Voice AI usage at each enabled location.</p></div>
+        <div class="rounded-2xl bg-black/20 p-5"><h3 class="font-black text-white">3. Phone costs</h3><p class="mt-2 text-sm leading-6 text-slate-300">HighLevel notes that phone-system charges can still apply even when Voice AI usage is covered by an AI subscription.</p></div>
+      </div>
+    </section>
+
+    <section class="rounded-3xl border border-emerald-400/20 bg-emerald-500/5 p-7 md:p-8 space-y-5">
+      <div class="text-xs font-extrabold uppercase tracking-wider text-emerald-300">14-day test plan</div>
+      <h2 class="text-3xl font-black">Prove one sales workflow before scaling</h2>
+      <ol class="grid gap-4 md:grid-cols-2">
+        <li class="rounded-2xl bg-black/20 p-5"><strong class="text-white">1. Pick one call type</strong><p class="mt-2 text-sm leading-6 text-slate-300">Use one narrow inbound lead-qualification or outbound follow-up scenario instead of trying every AI feature.</p></li>
+        <li class="rounded-2xl bg-black/20 p-5"><strong class="text-white">2. Define the handoff</strong><p class="mt-2 text-sm leading-6 text-slate-300">Decide what the AI should collect and when a human, calendar or pipeline stage takes over.</p></li>
+        <li class="rounded-2xl bg-black/20 p-5"><strong class="text-white">3. Measure the result</strong><p class="mt-2 text-sm leading-6 text-slate-300">Track qualified conversations, booked calls or completed follow-ups rather than call volume alone.</p></li>
+        <li class="rounded-2xl bg-black/20 p-5"><strong class="text-white">4. Price the real stack</strong><p class="mt-2 text-sm leading-6 text-slate-300">Before the trial ends, check the base plan, AI option and phone usage required for the workflow you actually tested.</p></li>
+      </ol>
+      <div class="pt-2">
+        <a data-cta="affiliate" data-tool-id="gohighlevel" data-cta-source="highlevel_voice_ai_test_plan" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="inline-flex rounded-xl bg-emerald-600 px-7 py-4 font-black text-white hover:bg-emerald-500">Test HighLevel for 14 days →</a>
+      </div>
+    </section>
+
+    <section class="rounded-3xl border border-white/10 bg-black/20 p-6 text-sm leading-7 text-slate-400">
+      <h2 class="text-xl font-black text-white">Sources & verification</h2>
+      <p class="mt-3">This guide was checked on September 11, 2026 against HighLevel's official pricing page, its current AI Product Pricing support article and its public Affiliate Offers page. Because HighLevel states that AI pricing and model availability can change, verify the current in-app billing settings before committing to a paid setup.</p>
+      <div class="mt-4 flex flex-wrap gap-3 text-xs font-bold">
+        <a href="https://www.gohighlevel.com/pricing" target="_blank" rel="noopener noreferrer" class="text-violet-300">Official HighLevel pricing →</a>
+        <a href="https://help.gohighlevel.com/support/solutions/articles/155000006652" target="_blank" rel="noopener noreferrer" class="text-violet-300">Official AI pricing →</a>
+        <a href="https://www.gohighlevel.com/affiliateoffers" target="_blank" rel="noopener noreferrer" class="text-violet-300">Current HighLevel offers →</a>
+        <a href="/best/highlevel-free-trial.html" class="text-violet-300">HighLevel trial guide →</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-white/10 py-8 text-center text-xs text-slate-500">© 2026 COSHUMA · Independent AI & SaaS buying guides</footer>
+</body>
+</html>


### PR DESCRIPTION
Adds a new HighLevel Voice AI buyer-intent page using only COSHUMA's already verified account-level HighLevel referral URL. The page is grounded in current HighLevel public pricing, AI pricing, and active affiliate-offer evidence. It does not invent a Voice-AI/workshop deep link; exact offer-specific link recovery is recorded as browser-required instead. No new application, no paid resource, and no click/signup/revenue claim.