### PR TITLE
feat(coshuma): add HelpDesk trial conversion guide

### DIFF
--- a/projects/GlobalSaaSHub/data/helpdesk-trial-conversion-evidence-2026-09-11.md
+++ b/projects/GlobalSaaSHub/data/helpdesk-trial-conversion-evidence-2026-09-11.md
@@ -1,0 +1,66 @@
+# HelpDesk trial conversion evidence — 2026-09-11
+
+## Why this revenue action was selected
+
+Text/LiveChat Partner Program sent COSHUMA a campaign report for 2026-08-13 through 2026-09-10 to `support@coshuma.com`.
+
+Vendor-reported totals:
+- all campaigns: 28 clicks, 0 trials, 0 paid accounts, $0 earnings
+- `HelpDesk - default`: 11 clicks, 0 trials
+- `Text wins MarTech Awards`: 14 clicks, 0 trials
+
+The HelpDesk campaign therefore has verified click activity but no vendor-reported trial conversion in the report window. This is evidence of a conversion gap, not evidence of revenue.
+
+Gmail source:
+- incoming message id: `1a08c0544c56b5ac`
+- subject: `Check your last 4 week’s results: affiliate campaigns report`
+- sender: `partners@livechat.com`
+
+## Exact existing HelpDesk customer route
+
+COSHUMA already has the exact HelpDesk customer-facing campaign URL verified from the authenticated Text Partner App:
+
+`https://www.helpdesk.com/?a=8IetMhQvR&utm_campaign=pp_helpdesk-default&utm_source=PP&d=14`
+
+This change reuses that exact route. It does not construct a new HelpDesk deep link, dashboard URL, signup URL, or referral parameter.
+
+## Current official product evidence checked 2026-09-11
+
+Official HelpDesk pricing page:
+- https://www.helpdesk.com/pricing/
+- 14-day free trial
+- no credit card required
+- Essential: $19/user/month billed yearly; $25/user/month billed monthly
+- Growth: $79/user/month billed yearly; $99/user/month billed monthly
+- Enterprise: custom pricing
+- Essential includes 10 AI resolutions/month
+- Growth includes 200 AI resolutions/month
+- additional 50 AI resolutions auto-refill package listed at $49.50
+
+Official free-trial page:
+- https://www.helpdesk.com/free-help-desk/
+- 14-day free trial, no credit card
+- full help desk product during the trial
+- shared inbox, workflows, AI Agent and reporting are included in the trial description
+
+Official subscription guide:
+- https://www.helpdesk.com/help/how-to-subscribe/
+- paid subscription flow asks for plan, billing cycle, agent count and billing details
+- first billing cycle is charged when the trial ends after subscription
+
+## Revenue action
+
+Added `/best/helpdesk-free-trial-pricing.html` as a high-intent pre-trial buyer guide.
+
+The page:
+- uses only the exact verified HelpDesk partner campaign URL for affiliate CTAs
+- uses official non-affiliate HelpDesk pages only as evidence/price-check destinations
+- gives visitors a concrete four-question trial plan to reduce low-intent clicks
+- exposes distinct CTA source values for hero and bottom trial clicks so COSHUMA can separate this page's outbound behavior from other HelpDesk placements
+- does not claim trial signups, paid accounts, commissions, or revenue
+
+## Guardrails
+
+- Do not treat the partner dashboard or report links as customer affiliate links.
+- Do not infer a direct trial deep link by moving the existing attribution parameters to `/free-help-desk/` or `/pricing/` unless Text explicitly confirms that exact customer URL.
+- Do not claim that the new page has improved conversion until partner or analytics evidence proves it.

--- a/projects/GlobalSaaSHub/public/best/helpdesk-free-trial-pricing.html
+++ b/projects/GlobalSaaSHub/public/best/helpdesk-free-trial-pricing.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>HelpDesk Free Trial 2026: 14 Days, No Credit Card + Pricing | COSHUMA</title>
+  <meta name="description" content="HelpDesk free-trial buyer guide for 2026: what the 14-day no-card trial includes, Essential vs Growth pricing, AI allowances, and when HelpDesk is worth testing." />
+  <link rel="canonical" href="https://coshuma.com/best/helpdesk-free-trial-pricing.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="COSHUMA" />
+  <meta property="og:url" content="https://coshuma.com/best/helpdesk-free-trial-pricing.html" />
+  <meta property="og:title" content="HelpDesk Free Trial 2026: 14 Days, No Credit Card + Pricing | COSHUMA" />
+  <meta property="og:description" content="A practical pre-trial guide to HelpDesk's 14-day trial, current paid plans and AI usage limits." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"Does HelpDesk have a free trial?","acceptedAnswer":{"@type":"Answer","text":"Yes. HelpDesk currently offers a 14-day free trial with no credit card required."}},
+      {"@type":"Question","name":"What does the HelpDesk free trial include?","acceptedAnswer":{"@type":"Answer","text":"HelpDesk says the trial provides the full product, including shared inbox ticketing, website chat, messaging, workflows, reporting and AI features, and allows teams to add multiple agents during the trial."}},
+      {"@type":"Question","name":"How much does HelpDesk cost after the trial?","acceptedAnswer":{"@type":"Answer","text":"HelpDesk currently lists Essential at $19 per user per month when billed yearly or $25 month to month, Growth at $79 yearly or $99 monthly, and Enterprise at custom pricing."}},
+      {"@type":"Question","name":"Are extra AI resolutions included?","acceptedAnswer":{"@type":"Answer","text":"Essential currently includes 10 AI resolutions per month and Growth includes 200. HelpDesk lists an automatic 50-resolution refill at $49.50 when the included allowance is exhausted."}}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="/affiliate-attribution.js"></script>
+  <style>body{background:#0b0c10;color:#f1f5f9;font-family:Inter,Arial,sans-serif}</style>
+</head>
+<body>
+<header class="border-b border-slate-800 bg-[#07080c] py-4 px-6"><div class="max-w-5xl mx-auto flex justify-between gap-4"><a href="/" class="font-black text-white">COSHUMA</a><a href="/best/index.html" class="text-sm font-bold text-purple-300">Buyer Guides →</a></div></header>
+<main class="max-w-5xl mx-auto px-4 py-12 space-y-8">
+  <section class="rounded-3xl border border-purple-500/30 bg-[#131520] p-7 md:p-9 space-y-6">
+    <div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Help desk trial decision</div>
+    <h1 class="text-4xl md:text-5xl font-black">HelpDesk 14-day free trial: what to test before you pay</h1>
+    <p class="text-lg text-slate-300 leading-relaxed">HelpDesk is easiest to evaluate when you test it on real support work rather than comparing feature lists. The current trial lasts 14 days, requires no credit card, and gives access to the core support workspace so you can judge ticket handling, team workflow and AI usage before choosing a paid plan.</p>
+    <div class="grid md:grid-cols-3 gap-4">
+      <div class="rounded-2xl border border-emerald-500/20 bg-emerald-500/5 p-5"><div class="text-xs uppercase font-bold text-emerald-300">Trial length</div><div class="text-2xl font-black mt-2">14 days</div><p class="text-sm text-slate-400 mt-2">No credit card required to start the current free trial.</p></div>
+      <div class="rounded-2xl border border-slate-700 bg-[#0e1119] p-5"><div class="text-xs uppercase font-bold text-slate-400">Paid entry</div><div class="text-2xl font-black mt-2">$19/user/mo</div><p class="text-sm text-slate-400 mt-2">Essential on annual billing; $25/user/month month to month.</p></div>
+      <div class="rounded-2xl border border-slate-700 bg-[#0e1119] p-5"><div class="text-xs uppercase font-bold text-slate-400">Growth</div><div class="text-2xl font-black mt-2">$79/user/mo</div><p class="text-sm text-slate-400 mt-2">Annual billing; $99/user/month month to month.</p></div>
+    </div>
+    <div class="flex flex-col sm:flex-row gap-3">
+      <a data-cta="affiliate" data-tool-id="helpdesk" data-cta-source="best-helpdesk-trial-hero" href="https://www.helpdesk.com/?a=8IetMhQvR&utm_campaign=pp_helpdesk-default&utm_source=PP&d=14" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-purple-600 hover:bg-purple-500 px-6 py-4 text-center font-black text-white">Start with HelpDesk's 14-day trial →</a>
+      <a data-cta="official" data-tool-id="helpdesk" data-cta-source="best-helpdesk-trial-pricing-evidence" href="https://www.helpdesk.com/pricing/" target="_blank" rel="noopener noreferrer" class="rounded-xl border border-slate-600 bg-slate-800 hover:bg-slate-700 px-6 py-4 text-center font-bold text-white">Check current pricing →</a>
+    </div>
+    <p class="text-xs leading-5 text-slate-500">Affiliate disclosure: the trial button uses a customer-facing HelpDesk partner campaign link verified for COSHUMA. COSHUMA may earn a commission from an eligible attributed purchase, at no added cost to you. Pricing and trial terms are controlled by HelpDesk and can change.</p>
+  </section>
+
+  <section class="rounded-3xl border border-slate-800 bg-[#131520] p-7 md:p-8 space-y-5">
+    <h2 class="text-3xl font-black">Use the trial to answer these four questions</h2>
+    <div class="grid md:grid-cols-2 gap-4">
+      <div class="rounded-2xl border border-slate-800 bg-[#0e1119] p-5"><h3 class="font-black text-white">1. Can your team clear real tickets faster?</h3><p class="text-sm leading-6 text-slate-400 mt-2">Import or forward a representative set of support messages. Test assignment, statuses, canned replies and shared ownership instead of judging an empty demo inbox.</p></div>
+      <div class="rounded-2xl border border-slate-800 bg-[#0e1119] p-5"><h3 class="font-black text-white">2. Are the channels you need in one place?</h3><p class="text-sm leading-6 text-slate-400 mt-2">HelpDesk currently combines email ticketing with website chat, Messenger and SMS options. Confirm your actual customer channels fit the workflow before paying for seats.</p></div>
+      <div class="rounded-2xl border border-slate-800 bg-[#0e1119] p-5"><h3 class="font-black text-white">3. Does the AI save enough work?</h3><p class="text-sm leading-6 text-slate-400 mt-2">Test AI replies and resolutions on common questions. Essential currently includes 10 AI resolutions per month; Growth includes 200, so expected usage matters to the real cost.</p></div>
+      <div class="rounded-2xl border border-slate-800 bg-[#0e1119] p-5"><h3 class="font-black text-white">4. Which paid tier matches your workload?</h3><p class="text-sm leading-6 text-slate-400 mt-2">Choose Essential if the core inbox and light AI allowance are enough. Growth is the more relevant comparison when you need higher AI limits, more rules, custom fields and team structure.</p></div>
+    </div>
+  </section>
+
+  <section class="rounded-3xl border border-slate-800 bg-[#131520] p-7 md:p-8 space-y-5">
+    <h2 class="text-3xl font-black">Current HelpDesk pricing snapshot</h2>
+    <p class="text-sm text-slate-400">Checked against HelpDesk's official pricing page on September 11, 2026. Annual prices are displayed per user per month but are billed for the annual term.</p>
+    <div class="overflow-x-auto"><table class="w-full min-w-[680px] text-sm"><thead><tr class="border-b border-slate-700 text-left text-slate-400"><th class="py-3">Plan</th><th class="py-3">Yearly rate</th><th class="py-3">Monthly rate</th><th class="py-3">Included AI resolutions</th></tr></thead><tbody class="divide-y divide-slate-800 text-slate-300"><tr><td class="py-4 font-bold text-white">Essential</td><td class="py-4">$19/user/mo</td><td class="py-4">$25/user/mo</td><td class="py-4">10/month</td></tr><tr><td class="py-4 font-bold text-white">Growth</td><td class="py-4">$79/user/mo</td><td class="py-4">$99/user/mo</td><td class="py-4">200/month</td></tr><tr><td class="py-4 font-bold text-white">Enterprise</td><td class="py-4">Custom</td><td class="py-4">Custom</td><td class="py-4">Custom</td></tr></tbody></table></div>
+    <div class="rounded-2xl border border-amber-500/20 bg-amber-500/5 p-5 text-sm leading-6 text-slate-300"><strong class="text-amber-200">AI overage check:</strong> HelpDesk currently lists an automatic refill of 50 additional AI resolutions for $49.50 after the included allowance is exhausted. Estimate expected AI-resolved conversations before deciding between tiers.</div>
+  </section>
+
+  <section class="rounded-3xl border border-emerald-500/20 bg-emerald-500/5 p-7 md:p-8 space-y-5">
+    <h2 class="text-3xl font-black">What happens after the trial?</h2>
+    <p class="text-slate-300 leading-relaxed">The free trial itself does not require a credit card. If you decide to subscribe, HelpDesk asks you to choose a plan, billing cycle and agent count, then add billing details. HelpDesk's subscription guide says the first billing cycle is charged when the trial ends after you subscribe.</p>
+    <div class="flex flex-col sm:flex-row gap-3"><a data-cta="affiliate" data-tool-id="helpdesk" data-cta-source="best-helpdesk-trial-bottom" href="https://www.helpdesk.com/?a=8IetMhQvR&utm_campaign=pp_helpdesk-default&utm_source=PP&d=14" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-emerald-600 hover:bg-emerald-500 px-6 py-4 text-center font-black text-white">Test HelpDesk before choosing a plan →</a><a href="/best/helpdesk-vs-freshdesk.html" class="rounded-xl bg-slate-800 hover:bg-slate-700 px-6 py-4 text-center font-bold text-white">Compare HelpDesk vs Freshdesk →</a></div>
+  </section>
+</main>
+<footer class="border-t border-slate-800 py-8 text-center text-xs text-slate-500">COSHUMA — evidence-first AI & SaaS buyer guides</footer>
+</body>
+</html>


### PR DESCRIPTION
Adds a high-intent HelpDesk 14-day free-trial/pricing buyer guide after Text Partner Program reported 11 HelpDesk campaign clicks and 0 trials for Aug 13–Sep 10. Reuses only the exact verified HelpDesk customer campaign URL; official pricing/trial pages remain non-affiliate evidence links. No invented deep link, no new application, no paid resource, and no revenue claim.