### PR TITLE
fix(coshuma): repair Agorapulse comparison navigation

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/brand24-vs-agorapulse.html
+++ b/projects/GlobalSaaSHub/public/compare/brand24-vs-agorapulse.html
@@ -15,7 +15,7 @@
   <style>body{background:#0b0c10;color:#f1f5f9;font-family:Inter,Arial,sans-serif}</style>
 </head>
 <body>
-<header class="border-b border-slate-800 bg-[#07080c] py-4 px-6"><div class="max-w-5xl mx-auto flex justify-between"><a href="/" class="font-black text-white">COSHUMA</a><a href="/compare/index.html" class="text-sm text-purple-300">More comparisons</a></div></header>
+<header class="border-b border-slate-800 bg-[#07080c] py-4 px-6"><div class="max-w-5xl mx-auto flex justify-between"><a href="/" class="font-black text-white">COSHUMA</a><a href="/best/index.html" class="text-sm text-purple-300">Buyer guides</a></div></header>
 <main class="max-w-5xl mx-auto px-4 py-12 space-y-8">
   <section class="rounded-3xl border border-slate-800 bg-[#131520] p-8 space-y-5"><div class="text-xs uppercase tracking-widest text-purple-300 font-bold">Social listening buyer comparison</div><h1 class="text-4xl md:text-5xl font-black">Brand24 vs Agorapulse</h1><p class="text-lg text-slate-300 leading-relaxed"><strong>Brand24</strong> is the more focused choice when monitoring mentions, reputation, competitors and AI-search visibility is the main job. <strong>Agorapulse</strong> fits better when listening needs to sit beside publishing, inbox management, approvals and social reporting.</p><p class="text-sm text-slate-500">Current public product terms checked September 11, 2026.</p></section>
 


### PR DESCRIPTION
Fixes the only link-integrity failure from the Agorapulse expansion by replacing the nonexistent `/compare/index.html` navigation target with the existing `/best/index.html` buyer-guide hub. No product facts, affiliate URL, pricing, attribution state, application status or revenue claims are changed.