### PR TITLE
feat(coshuma): add GetGenie vs Surfer SEO revenue comparison

### DIFF
--- a/projects/GlobalSaaSHub/data/getgenie-vs-surfer-revenue-evidence-2026-09-11.md
+++ b/projects/GlobalSaaSHub/data/getgenie-vs-surfer-revenue-evidence-2026-09-11.md
@@ -1,0 +1,45 @@
+# GetGenie vs Surfer SEO buyer evidence — 2026-09-11
+
+## Revenue objective
+Create a distinct SEO-content buyer comparison that can send qualified buyers through COSHUMA's already verified GetGenie customer referral URL while keeping Surfer SEO strictly non-affiliate until its submitted application produces an exact issued tracking URL.
+
+## Verified GetGenie revenue evidence
+- Human vendor reply to `support@coshuma.com`: Gmail message `1a089dd50b6495b5` from GetGenie Support on 2026-09-10.
+- The vendor explicitly supplied COSHUMA's customer-facing affiliate URL: `https://getgenie.ai?rui=3921`.
+- Current COSHUMA GetGenie buyer page already uses this exact URL and marks it as a sponsored affiliate CTA.
+- No click, signup, paid customer, commission, payout or revenue is inferred from link issuance.
+
+## Current GetGenie product/pricing evidence
+- Official pricing page: `https://getgenie.ai/pricing/`.
+- Rechecked 2026-09-11.
+- Free plan: $0, no credit card required, 2.5K AI words/month, 5 SERP competitor analyses/month.
+- Listed monthly prices: Starter $9.99/month, Writer $19/month, Pro $49/month, Agency $99/month.
+- Annual/promotional effective prices can differ; COSHUMA should direct buyers to verify live checkout totals.
+- Product scope includes AI writing, keyword analysis, competitor SERP analysis, topical maps, SEO insights/tracking and WordPress-oriented workflows.
+
+## Current Surfer SEO evidence
+- Official pricing page: `https://surferseo.com/pricing/`.
+- Official AI description/instructions page: `https://surferseo.com/ai-instructions/`.
+- Rechecked 2026-09-11.
+- Current annual-billing view lists Discovery $49/month, Standard $99/month, Pro $182/month and Peace of Mind $299/month; Enterprise is separately listed.
+- Discovery includes 120 documents and tracking for 10 pages.
+- Standard includes 360 documents and AI visibility tracking with 25 AI prompts refreshed weekly.
+- Higher plans add broader AI-search tracking, brand workspaces, content ideas, cannibalization reporting and other advanced capabilities.
+
+## Surfer affiliate state guardrail
+- Current `data/tools.json` state: `affiliate_verified: false`, `affiliate_status: application_submitted` for `surfer-seo`.
+- Therefore no Surfer customer tracking URL is currently verified.
+- Use only official Surfer URLs until the submitted application yields an exact customer-facing affiliate URL.
+- Do not reapply while the submitted application remains active/pending.
+
+## Comparison positioning
+- GetGenie: lower-cost, free-first path for AI writing + SEO research/analysis, especially attractive when WordPress is part of the publishing workflow.
+- Surfer SEO: stronger fit when the primary buying problem is structured on-page content optimization and AI-search visibility/tracking at a higher starting price.
+- Avoid unsupported winner claims; recommend by use case and budget.
+
+## Safety
+- No guessed Surfer referral parameter.
+- No dashboard, onboarding or application URL used as a customer CTA.
+- No duplicate affiliate application.
+- No paid subscription or payment action.
+- No revenue/conversion claim without partner-side evidence.

--- a/projects/GlobalSaaSHub/public/compare/getgenie-vs-surfer-seo.html
+++ b/projects/GlobalSaaSHub/public/compare/getgenie-vs-surfer-seo.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>GetGenie vs Surfer SEO 2026: Pricing, Free Plan & Best Fit | COSHUMA</title>
+  <meta name="description" content="Compare GetGenie vs Surfer SEO in 2026 by free access, price, AI writing, SEO research, content optimization and AI-search visibility. See which workflow fits before paying." />
+  <link rel="canonical" href="https://coshuma.com/compare/getgenie-vs-surfer-seo.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/getgenie-vs-surfer-seo.html" />
+  <meta property="og:title" content="GetGenie vs Surfer SEO 2026 | COSHUMA" />
+  <meta property="og:description" content="A buyer-focused comparison of GetGenie and Surfer SEO for content creation, on-page optimization and AI-search visibility." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"WebPage",
+    "name":"GetGenie vs Surfer SEO 2026",
+    "url":"https://coshuma.com/compare/getgenie-vs-surfer-seo.html",
+    "description":"Compare GetGenie and Surfer SEO by current public pricing, free access and SEO workflow fit.",
+    "isPartOf":{"@type":"WebSite","name":"COSHUMA","url":"https://coshuma.com/"},
+    "about":[
+      {"@type":"SoftwareApplication","name":"GetGenie","url":"https://coshuma.com/tool/getgenie.html"},
+      {"@type":"SoftwareApplication","name":"Surfer SEO","url":"https://coshuma.com/tool/surfer-seo.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"Which is cheaper, GetGenie or Surfer SEO?","acceptedAnswer":{"@type":"Answer","text":"GetGenie has a free plan and lists Starter at $9.99 per month. Surfer SEO currently lists Discovery at $49 per month on its annual-billing view."}},
+      {"@type":"Question","name":"Which is better for WordPress content workflows?","acceptedAnswer":{"@type":"Answer","text":"GetGenie is a practical fit when AI writing, keyword research, SERP analysis and WordPress publishing need to live in one lower-cost workflow."}},
+      {"@type":"Question","name":"Which is better for structured content optimization and AI-search tracking?","acceptedAnswer":{"@type":"Answer","text":"Surfer SEO is the stronger fit when structured content optimization, internal linking and AI-search visibility tracking are the primary buying requirements."}}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen">
+  <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
+    <div class="max-w-6xl mx-auto flex items-center justify-between">
+      <a href="/" class="flex items-center gap-3"><div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white">C</div><span class="font-extrabold text-lg text-white">COSHUMA</span></a>
+      <a href="/best/index.html" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300">Buyer guides</a>
+    </div>
+  </header>
+
+  <main class="max-w-5xl mx-auto px-4 py-12 space-y-8">
+    <section class="rounded-3xl bg-[#131520] border border-[#222538] p-7 md:p-9 space-y-5">
+      <div class="text-xs uppercase tracking-[0.18em] font-bold text-purple-300">SEO content workflow comparison</div>
+      <h1 class="text-4xl md:text-5xl font-black tracking-tight text-white">GetGenie vs Surfer SEO</h1>
+      <p class="text-lg leading-relaxed text-slate-300 max-w-4xl">Choose <strong>GetGenie</strong> when you want a low-cost, free-first stack that combines AI writing, keyword research and SERP analysis. Choose <strong>Surfer SEO</strong> when your main priority is structured content optimization and broader AI-search visibility tracking.</p>
+      <p class="text-sm text-slate-500">Pricing and product scope checked against official vendor pages on September 11, 2026. Promotions and checkout totals can change.</p>
+    </section>
+
+    <section class="grid md:grid-cols-2 gap-5">
+      <div class="rounded-3xl bg-purple-500/5 border border-purple-500/30 p-7 space-y-5">
+        <div><div class="text-xs uppercase font-bold text-purple-300">Lower-cost starting path</div><h2 class="text-3xl font-black text-white mt-2">GetGenie</h2></div>
+        <div class="grid grid-cols-2 gap-3 text-sm">
+          <div class="rounded-xl bg-[#10121b] border border-[#222538] p-4"><div class="text-slate-500 text-xs">Free plan</div><div class="font-black text-emerald-400 mt-1">$0</div><div class="text-slate-400 mt-1">No card required</div></div>
+          <div class="rounded-xl bg-[#10121b] border border-[#222538] p-4"><div class="text-slate-500 text-xs">Starter</div><div class="font-black text-white mt-1">$9.99/mo</div><div class="text-slate-400 mt-1">20K AI words</div></div>
+        </div>
+        <ul class="list-disc pl-5 text-sm text-slate-300 space-y-2"><li>AI writing plus keyword and competitor research.</li><li>SERP analysis and topical-map workflows.</li><li>Useful fit when WordPress is part of publishing.</li><li>Free plan makes it easier to test before paying.</li></ul>
+        <a data-cta="affiliate" data-tool-id="getgenie" data-cta-source="compare-getgenie-surfer-hero" href="https://getgenie.ai?rui=3921" target="_blank" rel="sponsored noopener noreferrer" class="block rounded-xl bg-purple-600 hover:bg-purple-500 px-6 py-3.5 text-center font-extrabold text-white">Start GetGenie free →</a>
+        <p class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if you later become a paying GetGenie customer through this verified customer link, at no added cost to you.</p>
+      </div>
+
+      <div class="rounded-3xl bg-[#131520] border border-[#222538] p-7 space-y-5">
+        <div><div class="text-xs uppercase font-bold text-blue-300">Optimization & AI visibility</div><h2 class="text-3xl font-black text-white mt-2">Surfer SEO</h2></div>
+        <div class="grid grid-cols-2 gap-3 text-sm">
+          <div class="rounded-xl bg-[#10121b] border border-[#222538] p-4"><div class="text-slate-500 text-xs">Discovery</div><div class="font-black text-white mt-1">$49/mo</div><div class="text-slate-400 mt-1">Billed yearly</div></div>
+          <div class="rounded-xl bg-[#10121b] border border-[#222538] p-4"><div class="text-slate-500 text-xs">Standard</div><div class="font-black text-white mt-1">$99/mo</div><div class="text-slate-400 mt-1">Billed yearly</div></div>
+        </div>
+        <ul class="list-disc pl-5 text-sm text-slate-300 space-y-2"><li>Content optimization with SEO guidance.</li><li>Internal linking and content workflow tools.</li><li>AI-search visibility tracking on paid plans.</li><li>Higher tiers add broader brand and AI-search analysis.</li></ul>
+        <a data-cta="official" data-tool-id="surfer-seo" data-cta-source="compare-getgenie-surfer-surfer" href="https://surferseo.com/pricing/" target="_blank" rel="noopener noreferrer" class="block rounded-xl bg-slate-800 hover:bg-slate-700 border border-slate-600 px-6 py-3.5 text-center font-extrabold text-white">Check Surfer SEO pricing →</a>
+        <p class="text-[11px] leading-relaxed text-slate-500">Official non-affiliate link. COSHUMA does not currently use an unverified Surfer SEO referral URL.</p>
+      </div>
+    </section>
+
+    <section class="rounded-3xl bg-[#131520] border border-[#222538] p-7 space-y-5 overflow-x-auto">
+      <h2 class="text-3xl font-black text-white">Side-by-side buying decision</h2>
+      <table class="w-full min-w-[720px] text-sm">
+        <thead class="border-b border-[#2c3044] text-slate-400"><tr><th class="text-left py-3 pr-4">Decision point</th><th class="text-left py-3 pr-4">GetGenie</th><th class="text-left py-3">Surfer SEO</th></tr></thead>
+        <tbody class="divide-y divide-[#222538] text-slate-300">
+          <tr><td class="py-4 pr-4 font-bold text-white">Lowest-cost test</td><td class="py-4 pr-4">Free plan, no credit card required</td><td class="py-4">Discovery starts at $49/mo on annual billing</td></tr>
+          <tr><td class="py-4 pr-4 font-bold text-white">AI writing</td><td class="py-4 pr-4">Core part of the product</td><td class="py-4">Available inside a broader optimization workflow</td></tr>
+          <tr><td class="py-4 pr-4 font-bold text-white">Keyword & SERP research</td><td class="py-4 pr-4">Built into plan quotas</td><td class="py-4">Optimization is the stronger buying reason</td></tr>
+          <tr><td class="py-4 pr-4 font-bold text-white">WordPress fit</td><td class="py-4 pr-4">Strong fit for WordPress-oriented content teams</td><td class="py-4">WordPress integration available on supported plans</td></tr>
+          <tr><td class="py-4 pr-4 font-bold text-white">AI-search visibility</td><td class="py-4 pr-4">SEO tracking and answer-first content tools</td><td class="py-4">Dedicated AI visibility tracking is a major differentiator</td></tr>
+          <tr><td class="py-4 pr-4 font-bold text-white">Budget sensitivity</td><td class="py-4 pr-4">Better first look for smaller budgets</td><td class="py-4">Better fit when optimization depth justifies the higher starting price</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="rounded-3xl bg-[#131520] border border-[#222538] p-7 space-y-5">
+      <h2 class="text-3xl font-black text-white">Which one should you choose?</h2>
+      <div class="grid md:grid-cols-2 gap-5">
+        <div class="rounded-2xl bg-[#10121b] border border-purple-500/25 p-5"><h3 class="text-xl font-extrabold text-purple-300">Choose GetGenie if…</h3><p class="mt-3 text-sm leading-7 text-slate-300">You publish SEO content regularly but want to keep software cost low, you value a no-card free plan, or you want writing, keyword research and SERP analysis in one workflow before paying for a more specialized optimization platform.</p></div>
+        <div class="rounded-2xl bg-[#10121b] border border-blue-500/25 p-5"><h3 class="text-xl font-extrabold text-blue-300">Choose Surfer SEO if…</h3><p class="mt-3 text-sm leading-7 text-slate-300">Your team already has a writing workflow and the bigger problem is consistent on-page optimization, internal linking and measuring brand visibility across AI-search environments.</p></div>
+      </div>
+      <div class="flex flex-col sm:flex-row gap-3">
+        <a href="/tool/getgenie.html" class="rounded-xl bg-slate-800 px-5 py-3 text-center font-bold text-white">GetGenie buyer guide →</a>
+        <a href="/tool/surfer-seo.html" class="rounded-xl bg-slate-800 px-5 py-3 text-center font-bold text-white">Surfer SEO overview →</a>
+      </div>
+    </section>
+
+    <section class="rounded-3xl border border-emerald-500/25 bg-emerald-500/5 p-7 space-y-4">
+      <h2 class="text-2xl font-black text-white">Lowest-risk path</h2>
+      <p class="text-slate-300 leading-relaxed">If you are unsure, test the actual content workflow before buying. GetGenie's free plan lets you validate writing, keyword research and SERP analysis without a card. If the real bottleneck is content optimization and AI visibility rather than generation volume, compare Surfer's live plan limits before committing.</p>
+      <a data-cta="affiliate" data-tool-id="getgenie" data-cta-source="compare-getgenie-surfer-bottom" href="https://getgenie.ai?rui=3921" target="_blank" rel="sponsored noopener noreferrer" class="inline-block rounded-xl bg-emerald-600 hover:bg-emerald-500 px-6 py-3.5 text-center font-extrabold text-white">Test GetGenie free →</a>
+    </section>
+  </main>
+
+  <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">© 2026 COSHUMA · Independent AI & SaaS buyer guides</footer>
+</body>
+</html>


### PR DESCRIPTION
## Revenue objective
Add a distinct SEO-content buyer comparison that can route qualified buyers through COSHUMA's already verified GetGenie customer referral URL while Surfer SEO remains official-only until its submitted affiliate application produces an exact issued customer URL.

## Verified basis
- GetGenie human support reply to support@coshuma.com (Gmail message 1a089dd50b6495b5) explicitly supplied `https://getgenie.ai?rui=3921` as COSHUMA's affiliate link.
- GetGenie's current official pricing page was rechecked on 2026-09-11: free plan with no credit card, Starter $9.99/mo, Writer $19/mo, Pro $49/mo, Agency $99/mo; annual/promotional effective prices can differ.
- Surfer SEO's current official pricing page was rechecked on 2026-09-11: Discovery $49/mo, Standard $99/mo, Pro $182/mo, Peace of Mind $299/mo on the annual-billing view.
- Current `surfer-seo` affiliate state in canonical data remains `application_submitted` with `affiliate_verified: false`, so no Surfer referral URL is guessed or published.

## Changes
- Add `/compare/getgenie-vs-surfer-seo.html` with buyer-fit, pricing and workflow comparison.
- Use two disclosed GetGenie revenue CTAs with only the exact vendor-issued link.
- Keep Surfer SEO strictly on its official pricing URL.
- Record evidence and guardrails in a dedicated data note.

## Guardrails
- No duplicate affiliate application.
- No dashboard/onboarding URL as a customer CTA.
- No guessed Surfer referral parameter.
- No paid resource or subscription.
- No click, signup, commission, payout or revenue claim.