### PR TITLE
feat(revenue): add newly verified UpLead and Jotform buyer routes

### DIFF
--- a/projects/GlobalSaaSHub/public/best/verified-software-free-trials-deals.html
+++ b/projects/GlobalSaaSHub/public/best/verified-software-free-trials-deals.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Verified SaaS Free Trials & Partner Offers (2026) | COSHUMA</title>
-  <meta name="description" content="Compare currently verified SaaS free trials and partner offers from Unbounce, Pictory, Brand24 and Bookyourdata. COSHUMA checks customer-facing links separately from product claims." />
+  <meta name="description" content="Compare verified SaaS free trials and partner offers including UpLead, Jotform, Unbounce, Pictory, Brand24 and Bookyourdata. COSHUMA separates customer-facing tracking links from product claims." />
   <link rel="canonical" href="https://coshuma.com/best/verified-software-free-trials-deals.html" />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://coshuma.com/best/verified-software-free-trials-deals.html" />
@@ -20,7 +20,9 @@
       {"@type":"ListItem","position":1,"name":"Unbounce","url":"https://coshuma.com/tool/unbounce.html"},
       {"@type":"ListItem","position":2,"name":"Pictory","url":"https://coshuma.com/best/pictory-free-trial-pricing.html"},
       {"@type":"ListItem","position":3,"name":"Bookyourdata","url":"https://coshuma.com/best/bookyourdata-free-trial.html"},
-      {"@type":"ListItem","position":4,"name":"Brand24","url":"https://coshuma.com/best/brand24-free-trial.html"}
+      {"@type":"ListItem","position":4,"name":"Brand24","url":"https://coshuma.com/best/brand24-free-trial.html"},
+      {"@type":"ListItem","position":5,"name":"UpLead","url":"https://coshuma.com/tool/uplead.html"},
+      {"@type":"ListItem","position":6,"name":"Jotform","url":"https://coshuma.com/tool/jotform.html"}
     ]
   }
   </script>
@@ -44,6 +46,39 @@
         <span class="rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1.5 text-emerald-200">No invented discounts</span>
         <span class="rounded-full border border-cyan-400/20 bg-cyan-400/10 px-3 py-1.5 text-cyan-200">Verified customer links</span>
         <span class="rounded-full border border-amber-400/20 bg-amber-400/10 px-3 py-1.5 text-amber-100">Final terms controlled by vendor</span>
+      </div>
+    </section>
+
+    <section class="rounded-3xl border border-cyan-400/25 bg-[#11131a] p-7 md:p-9" aria-labelledby="fresh-verified-routes">
+      <div class="text-xs font-black uppercase tracking-[0.18em] text-cyan-300">Newly verified September 11, 2026</div>
+      <h2 id="fresh-verified-routes" class="mt-2 text-3xl font-black text-white">Fresh partner-issued buyer routes</h2>
+      <p class="mt-3 max-w-3xl text-sm leading-6 text-slate-300">These destinations were confirmed in direct partner correspondence. COSHUMA publishes the exact customer-facing URLs supplied by the programs instead of constructing deep links from generic homepages, dashboards or guessed parameters.</p>
+      <div class="mt-6 grid gap-5 lg:grid-cols-2">
+        <article class="rounded-2xl border border-cyan-400/20 bg-cyan-400/[0.04] p-6 space-y-4">
+          <div class="flex items-start justify-between gap-4">
+            <div><div class="text-xs font-black uppercase tracking-wider text-cyan-300">B2B lead data</div><h3 class="mt-1 text-2xl font-black text-white">UpLead</h3></div>
+            <span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">7-day trial route</span>
+          </div>
+          <p class="text-sm leading-6 text-slate-300">UpLead affiliate manager Dan confirmed COSHUMA's exact tracked 7-day signup destination and a separate tracked pricing destination. These links are used as supplied; no referral parameter has been invented.</p>
+          <div class="grid gap-3 sm:grid-cols-2">
+            <a data-cta="affiliate" data-tool-id="uplead" data-cta-source="verified-deals-uplead-trial" data-cta-page="verified-software-free-trials-deals" href="https://www.uplead.com/sign-up/?fp_ref=sangkwon25" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl bg-cyan-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-cyan-500">Start UpLead's 7-day trial →</a>
+            <a data-cta="affiliate" data-tool-id="uplead" data-cta-source="verified-deals-uplead-pricing" data-cta-page="verified-software-free-trials-deals" href="https://www.uplead.com/pricing/?fp_ref=sangkwon25" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl border border-cyan-400/25 px-5 py-3.5 text-center text-sm font-bold text-cyan-100 hover:bg-cyan-400/10">Compare UpLead pricing →</a>
+          </div>
+          <p class="text-[11px] leading-5 text-slate-500">COSHUMA tracking destinations confirmed directly by UpLead affiliate manager Dan on September 11, 2026. A valid tracked URL is not proof of a signup, paid customer or commission.</p>
+        </article>
+
+        <article class="rounded-2xl border border-amber-400/20 bg-amber-400/[0.04] p-6 space-y-4">
+          <div class="flex items-start justify-between gap-4">
+            <div><div class="text-xs font-black uppercase tracking-wider text-amber-200">Forms & workflows</div><h3 class="mt-1 text-2xl font-black text-white">Jotform</h3></div>
+            <span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">Exact pricing route</span>
+          </div>
+          <p class="text-sm leading-6 text-slate-300">Jotform's affiliate team supplied the exact COSHUMA pricing-page affiliate URL below. Use it to compare current plans rather than appending an unverified partner parameter to other Jotform pages.</p>
+          <div class="grid gap-3 sm:grid-cols-2">
+            <a data-cta="affiliate" data-tool-id="jotform" data-cta-source="verified-deals-jotform-pricing" data-cta-page="verified-software-free-trials-deals" href="https://www.jotform.com/pricing/?partner=coshuma" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl bg-amber-500 px-5 py-3.5 text-center text-sm font-black text-slate-950 hover:bg-amber-400">Compare Jotform plans →</a>
+            <a href="/tool/jotform.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Read Jotform guide</a>
+          </div>
+          <p class="text-[11px] leading-5 text-slate-500">Exact partner-tagged pricing destination verified in Jotform affiliate correspondence. COSHUMA does not claim revenue until a partner system reports it.</p>
+        </article>
       </div>
     </section>
 


### PR DESCRIPTION
Revenue-focused, zero-cost update to the existing verified offers buyer hub.

- Adds UpLead's exact vendor-confirmed 7-day trial tracking URL: https://www.uplead.com/sign-up/?fp_ref=sangkwon25
- Adds UpLead's exact vendor-confirmed pricing tracking URL: https://www.uplead.com/pricing/?fp_ref=sangkwon25
- Adds Jotform's exact affiliate-team-confirmed pricing URL: https://www.jotform.com/pricing/?partner=coshuma
- Marks all monetized routes as sponsored affiliate CTAs with unique attribution sources.
- Does not invent deep links or treat dashboards/onboarding/generic URLs as revenue links.
- Makes no signup, commission, or revenue claim from the existence of the links.