### PR TITLE
fix(revenue): align UpLead buyer routes with current vendor evidence

### DIFF
--- a/projects/GlobalSaaSHub/public/best/verified-software-free-trials-deals.html
+++ b/projects/GlobalSaaSHub/public/best/verified-software-free-trials-deals.html
@@ -59,12 +59,12 @@
             <div><div class="text-xs font-black uppercase tracking-wider text-cyan-300">B2B lead data</div><h3 class="mt-1 text-2xl font-black text-white">UpLead</h3></div>
             <span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">7-day trial route</span>
           </div>
-          <p class="text-sm leading-6 text-slate-300">UpLead affiliate manager Dan confirmed COSHUMA's exact tracked 7-day signup destination and a separate tracked pricing destination. These links are used as supplied; no referral parameter has been invented.</p>
+          <p class="text-sm leading-6 text-slate-300">UpLead's Will Cannon confirmed COSHUMA's exact tracked 7-day trial destination and a separate tracked pricing destination for the existing affiliate account. These links are used exactly as supplied; no referral parameter has been invented.</p>
           <div class="grid gap-3 sm:grid-cols-2">
-            <a data-cta="affiliate" data-tool-id="uplead" data-cta-source="verified-deals-uplead-trial" data-cta-page="verified-software-free-trials-deals" href="https://www.uplead.com/sign-up/?fp_ref=sangkwon25" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl bg-cyan-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-cyan-500">Start UpLead's 7-day trial →</a>
-            <a data-cta="affiliate" data-tool-id="uplead" data-cta-source="verified-deals-uplead-pricing" data-cta-page="verified-software-free-trials-deals" href="https://www.uplead.com/pricing/?fp_ref=sangkwon25" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl border border-cyan-400/25 px-5 py-3.5 text-center text-sm font-bold text-cyan-100 hover:bg-cyan-400/10">Compare UpLead pricing →</a>
+            <a data-cta="affiliate" data-tool-id="uplead" data-cta-source="verified-deals-uplead-trial" data-cta-page="verified-software-free-trials-deals" href="https://app.uplead.com/trial-signup?fp_ref=sangkwon-3af7dc" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl bg-cyan-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-cyan-500">Start UpLead's 7-day trial →</a>
+            <a data-cta="affiliate" data-tool-id="uplead" data-cta-source="verified-deals-uplead-pricing" data-cta-page="verified-software-free-trials-deals" href="https://www.uplead.com/pricing/?fp_ref=sangkwon-3af7dc" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl border border-cyan-400/25 px-5 py-3.5 text-center text-sm font-bold text-cyan-100 hover:bg-cyan-400/10">Compare UpLead pricing →</a>
           </div>
-          <p class="text-[11px] leading-5 text-slate-500">COSHUMA tracking destinations confirmed directly by UpLead affiliate manager Dan on September 11, 2026. A valid tracked URL is not proof of a signup, paid customer or commission.</p>
+          <p class="text-[11px] leading-5 text-slate-500">COSHUMA tracking destinations confirmed directly by UpLead's Will Cannon on September 11, 2026. A valid tracked URL is not proof of a signup, paid customer or commission.</p>
         </article>
 
         <article class="rounded-2xl border border-amber-400/20 bg-amber-400/[0.04] p-6 space-y-4">


### PR DESCRIPTION
Corrects the newly added verified-offers hub to the latest direct UpLead evidence in support@coshuma.com Gmail.

UpLead's Will Cannon confirmed these exact customer-facing destinations for COSHUMA's existing affiliate account:
- 7-day trial: https://app.uplead.com/trial-signup?fp_ref=sangkwon-3af7dc
- Pricing: https://www.uplead.com/pricing/?fp_ref=sangkwon-3af7dc

This replaces conflicting stale candidate links and corrects the partner contact attribution. Jotform's exact vendor-confirmed pricing link remains unchanged. No signup, sale, or commission is inferred.