### PR TITLE
Revenue: surface Gamma and Time2book on verified deals

### DIFF
--- a/projects/GlobalSaaSHub/public/best/verified-software-free-trials-deals.html
+++ b/projects/GlobalSaaSHub/public/best/verified-software-free-trials-deals.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Verified SaaS Free Trials & Partner Offers (2026) | COSHUMA</title>
-  <meta name="description" content="Compare verified SaaS free trials and partner offers including UpLead, Jotform, Unbounce, Pictory, Brand24 and Bookyourdata. COSHUMA separates customer-facing tracking links from product claims." />
+  <meta name="description" content="Compare verified SaaS free trials and partner offers from Gamma, Time2book, UpLead, Jotform, Unbounce, Pictory, Brand24 and Bookyourdata. COSHUMA separates customer-facing tracking links from product claims." />
   <link rel="canonical" href="https://coshuma.com/best/verified-software-free-trials-deals.html" />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://coshuma.com/best/verified-software-free-trials-deals.html" />
@@ -17,12 +17,14 @@
     "name":"Verified SaaS Free Trials & Partner Offers",
     "url":"https://coshuma.com/best/verified-software-free-trials-deals.html",
     "itemListElement":[
-      {"@type":"ListItem","position":1,"name":"Unbounce","url":"https://coshuma.com/tool/unbounce.html"},
-      {"@type":"ListItem","position":2,"name":"Pictory","url":"https://coshuma.com/best/pictory-free-trial-pricing.html"},
-      {"@type":"ListItem","position":3,"name":"Bookyourdata","url":"https://coshuma.com/best/bookyourdata-free-trial.html"},
-      {"@type":"ListItem","position":4,"name":"Brand24","url":"https://coshuma.com/best/brand24-free-trial.html"},
-      {"@type":"ListItem","position":5,"name":"UpLead","url":"https://coshuma.com/tool/uplead.html"},
-      {"@type":"ListItem","position":6,"name":"Jotform","url":"https://coshuma.com/tool/jotform.html"}
+      {"@type":"ListItem","position":1,"name":"Gamma","url":"https://coshuma.com/best/gamma-free-plan-pricing.html"},
+      {"@type":"ListItem","position":2,"name":"Time2book","url":"https://coshuma.com/best/time2book-free-trial-pricing.html"},
+      {"@type":"ListItem","position":3,"name":"UpLead","url":"https://coshuma.com/tool/uplead.html"},
+      {"@type":"ListItem","position":4,"name":"Jotform","url":"https://coshuma.com/tool/jotform.html"},
+      {"@type":"ListItem","position":5,"name":"Unbounce","url":"https://coshuma.com/tool/unbounce.html"},
+      {"@type":"ListItem","position":6,"name":"Pictory","url":"https://coshuma.com/best/pictory-free-trial-pricing.html"},
+      {"@type":"ListItem","position":7,"name":"Bookyourdata","url":"https://coshuma.com/best/bookyourdata-free-trial.html"},
+      {"@type":"ListItem","position":8,"name":"Brand24","url":"https://coshuma.com/best/brand24-free-trial.html"}
     ]
   }
   </script>
@@ -30,41 +32,74 @@
   <style>body{font-family:Inter,system-ui,sans-serif;background:#08090d;color:#f1f5f9}</style>
 </head>
 <body class="min-h-screen bg-[#08090d] text-slate-100">
-  <header class="border-b border-white/10 bg-[#08090d]/90 backdrop-blur sticky top-0 z-40">
+  <header class="sticky top-0 z-40 border-b border-white/10 bg-[#08090d]/90 backdrop-blur">
     <div class="mx-auto flex max-w-6xl items-center justify-between px-5 py-4">
       <a href="/" class="font-black tracking-tight text-white">COSHUMA</a>
       <a href="/best/index.html" class="rounded-full border border-violet-400/30 bg-violet-500/10 px-4 py-2 text-xs font-bold text-violet-200">All buyer guides</a>
     </div>
   </header>
 
-  <main class="mx-auto max-w-6xl px-5 py-12 space-y-8">
+  <main class="mx-auto max-w-6xl space-y-8 px-5 py-12">
     <section class="rounded-3xl border border-violet-400/25 bg-gradient-to-br from-violet-500/10 to-cyan-500/5 p-7 md:p-11">
-      <div class="text-xs font-black uppercase tracking-[0.18em] text-violet-300">Checked September 8, 2026</div>
+      <div class="text-xs font-black uppercase tracking-[0.18em] text-violet-300">Checked September 11, 2026</div>
       <h1 class="mt-3 max-w-4xl text-4xl font-black tracking-[-0.04em] text-white md:text-6xl">Software free trials and partner offers worth testing before you pay</h1>
-      <p class="mt-5 max-w-3xl text-base leading-7 text-slate-300 md:text-lg">This page prioritizes offers with a low-risk first step and a customer-facing path COSHUMA has actually verified. A dashboard, onboarding page or generic homepage is never treated as an affiliate link unless the program issued it for customer referrals.</p>
+      <p class="mt-5 max-w-3xl text-base leading-7 text-slate-300 md:text-lg">This page prioritizes low-risk first steps and customer-facing routes COSHUMA has actually verified. A dashboard, onboarding page or generic homepage is never treated as an affiliate link unless the program issued or confirmed it for customer referrals.</p>
       <div class="mt-6 flex flex-wrap gap-2 text-xs font-bold">
         <span class="rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1.5 text-emerald-200">No invented discounts</span>
         <span class="rounded-full border border-cyan-400/20 bg-cyan-400/10 px-3 py-1.5 text-cyan-200">Verified customer links</span>
-        <span class="rounded-full border border-amber-400/20 bg-amber-400/10 px-3 py-1.5 text-amber-100">Final terms controlled by vendor</span>
+        <span class="rounded-full border border-amber-400/20 bg-amber-400/10 px-3 py-1.5 text-amber-100">Vendor terms control checkout</span>
       </div>
     </section>
 
-    <section class="rounded-3xl border border-cyan-400/25 bg-[#11131a] p-7 md:p-9" aria-labelledby="fresh-verified-routes">
-      <div class="text-xs font-black uppercase tracking-[0.18em] text-cyan-300">Newly verified September 11, 2026</div>
-      <h2 id="fresh-verified-routes" class="mt-2 text-3xl font-black text-white">Fresh partner-issued buyer routes</h2>
-      <p class="mt-3 max-w-3xl text-sm leading-6 text-slate-300">These destinations were confirmed in direct partner correspondence. COSHUMA publishes the exact customer-facing URLs supplied by the programs instead of constructing deep links from generic homepages, dashboards or guessed parameters.</p>
+    <section class="rounded-3xl border border-emerald-400/25 bg-[#11131a] p-7 md:p-9" aria-labelledby="latest-low-risk">
+      <div class="text-xs font-black uppercase tracking-[0.18em] text-emerald-300">New low-risk routes surfaced September 11</div>
+      <h2 id="latest-low-risk" class="mt-2 text-3xl font-black text-white">Start free before considering an upgrade</h2>
+      <p class="mt-3 max-w-3xl text-sm leading-6 text-slate-300">Gamma and Time2book now have dedicated buyer guides and verified COSHUMA referral routes. Their free entry points are exposed here so visitors do not need to discover them only through individual tool pages.</p>
+      <div class="mt-6 grid gap-5 lg:grid-cols-2">
+        <article class="rounded-2xl border border-emerald-400/20 bg-emerald-400/[0.04] p-6 space-y-4">
+          <div class="flex items-start justify-between gap-4">
+            <div><div class="text-xs font-black uppercase tracking-wider text-emerald-300">AI presentations & docs</div><h3 class="mt-1 text-2xl font-black text-white">Gamma</h3></div>
+            <span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">Free plan · no card</span>
+          </div>
+          <p class="text-sm leading-6 text-slate-300">Gamma currently offers a Free plan and says no credit card is required. Test one real presentation, document or lightweight site before deciding whether paid branding, analytics, domains or higher AI usage are worth the upgrade.</p>
+          <div class="grid gap-3 sm:grid-cols-2">
+            <a data-cta="affiliate" data-tool-id="gamma" data-cta-source="verified-deals-gamma-free" data-cta-page="verified-software-free-trials-deals" href="https://try.gamma.app/pu20lusdpn1j" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl bg-emerald-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-emerald-500">Start Gamma Free →</a>
+            <a href="/best/gamma-free-plan-pricing.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Compare Gamma plans</a>
+          </div>
+          <p class="text-[11px] leading-5 text-slate-500">The first button uses the exact customer-facing PartnerStack route previously verified for COSHUMA. A click or signup is not treated as revenue without partner-side evidence.</p>
+        </article>
+
+        <article class="rounded-2xl border border-cyan-400/20 bg-cyan-400/[0.04] p-6 space-y-4">
+          <div class="flex items-start justify-between gap-4">
+            <div><div class="text-xs font-black uppercase tracking-wider text-cyan-300">Bookings & studio operations</div><h3 class="mt-1 text-2xl font-black text-white">Time2book</h3></div>
+            <span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">7 days · no card</span>
+          </div>
+          <p class="text-sm leading-6 text-slate-300">Time2book currently advertises a free 7-day trial with no credit card required. For a meaningful test, publish one real class or appointment, complete a booking and verify notifications and payment setup before paying.</p>
+          <div class="grid gap-3 sm:grid-cols-2">
+            <a data-cta="affiliate" data-tool-id="time2book" data-cta-source="verified-deals-time2book-trial" data-cta-page="verified-software-free-trials-deals" href="https://time2book.me?aff=9TzesqKi" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl bg-cyan-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-cyan-500">Start 7-day trial →</a>
+            <a href="/best/time2book-free-trial-pricing.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Compare Time2book plans</a>
+          </div>
+          <p class="text-[11px] leading-5 text-slate-500">The first button uses the exact customer-facing Time2book referral route previously verified for COSHUMA. A trial is not treated as revenue without partner-side evidence.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="rounded-3xl border border-cyan-400/25 bg-[#11131a] p-7 md:p-9" aria-labelledby="fresh-partner-routes">
+      <div class="text-xs font-black uppercase tracking-[0.18em] text-cyan-300">Direct partner confirmation · September 11</div>
+      <h2 id="fresh-partner-routes" class="mt-2 text-3xl font-black text-white">Exact partner-issued buyer routes</h2>
+      <p class="mt-3 max-w-3xl text-sm leading-6 text-slate-300">UpLead and Jotform supplied exact customer-facing destinations in partner correspondence. COSHUMA uses those URLs as provided rather than guessing referral parameters.</p>
       <div class="mt-6 grid gap-5 lg:grid-cols-2">
         <article class="rounded-2xl border border-cyan-400/20 bg-cyan-400/[0.04] p-6 space-y-4">
           <div class="flex items-start justify-between gap-4">
             <div><div class="text-xs font-black uppercase tracking-wider text-cyan-300">B2B lead data</div><h3 class="mt-1 text-2xl font-black text-white">UpLead</h3></div>
             <span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">7-day trial route</span>
           </div>
-          <p class="text-sm leading-6 text-slate-300">UpLead's Will Cannon confirmed COSHUMA's exact tracked 7-day trial destination and a separate tracked pricing destination for the existing affiliate account. These links are used exactly as supplied; no referral parameter has been invented.</p>
+          <p class="text-sm leading-6 text-slate-300">UpLead confirmed COSHUMA's exact tracked 7-day trial destination and a separate tracked pricing destination for the existing affiliate account.</p>
           <div class="grid gap-3 sm:grid-cols-2">
-            <a data-cta="affiliate" data-tool-id="uplead" data-cta-source="verified-deals-uplead-trial" data-cta-page="verified-software-free-trials-deals" href="https://app.uplead.com/trial-signup?fp_ref=sangkwon-3af7dc" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl bg-cyan-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-cyan-500">Start UpLead's 7-day trial →</a>
+            <a data-cta="affiliate" data-tool-id="uplead" data-cta-source="verified-deals-uplead-trial" data-cta-page="verified-software-free-trials-deals" href="https://app.uplead.com/trial-signup?fp_ref=sangkwon-3af7dc" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl bg-cyan-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-cyan-500">Start UpLead 7-day trial →</a>
             <a data-cta="affiliate" data-tool-id="uplead" data-cta-source="verified-deals-uplead-pricing" data-cta-page="verified-software-free-trials-deals" href="https://www.uplead.com/pricing/?fp_ref=sangkwon-3af7dc" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl border border-cyan-400/25 px-5 py-3.5 text-center text-sm font-bold text-cyan-100 hover:bg-cyan-400/10">Compare UpLead pricing →</a>
           </div>
-          <p class="text-[11px] leading-5 text-slate-500">COSHUMA tracking destinations confirmed directly by UpLead's Will Cannon on September 11, 2026. A valid tracked URL is not proof of a signup, paid customer or commission.</p>
+          <a href="/tool/uplead.html" class="inline-block text-xs font-bold text-cyan-200 hover:text-white">Read UpLead guide →</a>
         </article>
 
         <article class="rounded-2xl border border-amber-400/20 bg-amber-400/[0.04] p-6 space-y-4">
@@ -72,77 +107,44 @@
             <div><div class="text-xs font-black uppercase tracking-wider text-amber-200">Forms & workflows</div><h3 class="mt-1 text-2xl font-black text-white">Jotform</h3></div>
             <span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">Exact pricing route</span>
           </div>
-          <p class="text-sm leading-6 text-slate-300">Jotform's affiliate team supplied the exact COSHUMA pricing-page affiliate URL below. Use it to compare current plans rather than appending an unverified partner parameter to other Jotform pages.</p>
+          <p class="text-sm leading-6 text-slate-300">Jotform's affiliate team supplied the exact COSHUMA pricing-page affiliate URL below. COSHUMA does not append that partner tag to other Jotform pages without verification.</p>
           <div class="grid gap-3 sm:grid-cols-2">
             <a data-cta="affiliate" data-tool-id="jotform" data-cta-source="verified-deals-jotform-pricing" data-cta-page="verified-software-free-trials-deals" href="https://www.jotform.com/pricing/?partner=coshuma" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl bg-amber-500 px-5 py-3.5 text-center text-sm font-black text-slate-950 hover:bg-amber-400">Compare Jotform plans →</a>
             <a href="/tool/jotform.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Read Jotform guide</a>
           </div>
-          <p class="text-[11px] leading-5 text-slate-500">Exact partner-tagged pricing destination verified in Jotform affiliate correspondence. COSHUMA does not claim revenue until a partner system reports it.</p>
         </article>
       </div>
     </section>
 
     <section class="grid gap-5 lg:grid-cols-2">
       <article class="rounded-3xl border border-violet-400/30 bg-[#11131a] p-7 space-y-5">
-        <div class="flex items-start justify-between gap-4">
-          <div><div class="text-xs font-black uppercase tracking-wider text-violet-300">Best partner discount</div><h2 class="mt-1 text-3xl font-black text-white">Unbounce</h2></div>
-          <span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">14-day trial</span>
-        </div>
-        <p class="text-sm leading-6 text-slate-300">Unbounce currently offers a 14-day free trial with no credit card required. COSHUMA's issued partner route also carries the verified customer offer described in our Unbounce guide: 20% off the first 3 months or 35% off the first annual subscription. Confirm the invitation and final checkout before relying on the discount.</p>
-        <div class="rounded-2xl border border-white/10 bg-white/[0.03] p-4 text-sm text-slate-300"><strong class="text-white">Good fit:</strong> marketers and agencies that need landing pages, A/B testing and conversion optimization rather than a broad website builder.</div>
-        <div class="grid gap-3 sm:grid-cols-2">
-          <a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="verified_offers_unbounce" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-violet-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-violet-500">Start Unbounce trial + offer →</a>
-          <a href="/tool/unbounce.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Read exact offer details</a>
-        </div>
-        <p class="text-[11px] leading-5 text-slate-500">Official trial source: Unbounce pricing. Partner tracking cookie is 90 days according to Unbounce's current partner-program page.</p>
+        <div class="flex items-start justify-between gap-4"><div><div class="text-xs font-black uppercase tracking-wider text-violet-300">Landing page optimization</div><h2 class="mt-1 text-3xl font-black text-white">Unbounce</h2></div><span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">14-day trial</span></div>
+        <p class="text-sm leading-6 text-slate-300">Unbounce currently offers a 14-day free trial with no credit card required. COSHUMA's issued partner route also carries the verified customer offer documented in our guide: 20% off the first 3 months or 35% off the first annual subscription. Confirm the invitation and final checkout before relying on the discount.</p>
+        <div class="grid gap-3 sm:grid-cols-2"><a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="verified-deals-unbounce" data-cta-page="verified-software-free-trials-deals" href="https://unbounce.partnerlinks.io/5ubjnt8lluqi" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-violet-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-violet-500">Start Unbounce trial + offer →</a><a href="/tool/unbounce.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Read offer details</a></div>
       </article>
 
       <article class="rounded-3xl border border-fuchsia-400/25 bg-[#11131a] p-7 space-y-5">
-        <div class="flex items-start justify-between gap-4">
-          <div><div class="text-xs font-black uppercase tracking-wider text-fuchsia-300">AI video trial + active code</div><h2 class="mt-1 text-3xl font-black text-white">Pictory</h2></div>
-          <span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">14 days free</span>
-        </div>
-        <p class="text-sm leading-6 text-slate-300">Pictory's current pricing page lists a 14-day free trial and annual pricing that can save up to 40%. Pictory's affiliate manager separately reconfirmed to COSHUMA that the existing affiliate link and promo code <strong class="text-white">COSHUMA20</strong> remain active. The affiliate link remains the primary attribution method.</p>
-        <div class="rounded-2xl border border-amber-400/20 bg-amber-400/[0.06] p-4 text-sm text-amber-100"><strong>Use code:</strong> COSHUMA20 · Verify the code and final price at checkout because vendor promotions can change.</div>
-        <div class="grid gap-3 sm:grid-cols-2">
-          <a data-cta="affiliate" data-tool-id="pictory" data-cta-source="verified_offers_pictory" href="https://pictory.ai?fpr=sangkwon-an23" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-fuchsia-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-fuchsia-500">Try Pictory via verified link →</a>
-          <a href="/best/pictory-discount-code.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Check Pictory offer guide</a>
-        </div>
-        <p class="text-[11px] leading-5 text-slate-500">Payout setup status is separate from referral tracking. COSHUMA does not claim a commission unless the affiliate system confirms it.</p>
+        <div class="flex items-start justify-between gap-4"><div><div class="text-xs font-black uppercase tracking-wider text-fuchsia-300">AI video creation</div><h2 class="mt-1 text-3xl font-black text-white">Pictory</h2></div><span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">14 days free</span></div>
+        <p class="text-sm leading-6 text-slate-300">Pictory's current pricing page lists a 14-day free trial. Its affiliate manager separately reconfirmed to COSHUMA that the existing affiliate link and promo code <strong class="text-white">COSHUMA20</strong> remain active. Verify the code and final checkout price because vendor promotions can change.</p>
+        <div class="grid gap-3 sm:grid-cols-2"><a data-cta="affiliate" data-tool-id="pictory" data-cta-source="verified-deals-pictory" data-cta-page="verified-software-free-trials-deals" href="https://pictory.ai?fpr=sangkwon-an23" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-fuchsia-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-fuchsia-500">Try Pictory via verified link →</a><a href="/best/pictory-discount-code.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Check Pictory offer</a></div>
       </article>
 
       <article class="rounded-3xl border border-cyan-400/25 bg-[#11131a] p-7 space-y-5">
-        <div class="flex items-start justify-between gap-4">
-          <div><div class="text-xs font-black uppercase tracking-wider text-cyan-300">Best zero-cost B2B data test</div><h2 class="mt-1 text-3xl font-black text-white">Bookyourdata</h2></div>
-          <span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">10 free leads</span>
-        </div>
-        <p class="text-sm leading-6 text-slate-300">Bookyourdata's current official pricing page offers 10 free credits with no subscription and no credit card required. Its paid model is pay-as-you-go rather than a mandatory recurring subscription.</p>
-        <div class="rounded-2xl border border-white/10 bg-white/[0.03] p-4 text-sm text-slate-300"><strong class="text-white">Lowest-risk test:</strong> define one narrow ICP, export the free sample, then check CRM fit and deliverability before buying a larger pack.</div>
-        <div class="grid gap-3 sm:grid-cols-2">
-          <a data-cta="affiliate" data-tool-id="bookyourdata" data-cta-source="verified_offers_bookyourdata" href="https://join.bookyourdata.com/swcyqmumr3s5" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-cyan-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-cyan-500">Get 10 free leads →</a>
-          <a href="/best/bookyourdata-free-trial.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Read free-lead guide</a>
-        </div>
-        <p class="text-[11px] leading-5 text-slate-500">Official source checked September 8, 2026: Bookyourdata pricing page.</p>
+        <div class="flex items-start justify-between gap-4"><div><div class="text-xs font-black uppercase tracking-wider text-cyan-300">B2B data sample</div><h2 class="mt-1 text-3xl font-black text-white">Bookyourdata</h2></div><span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">10 free leads</span></div>
+        <p class="text-sm leading-6 text-slate-300">Bookyourdata's current official pricing page offers 10 free credits with no subscription and no credit card required. Use the free sample to check ICP fit and deliverability before buying a larger pack.</p>
+        <div class="grid gap-3 sm:grid-cols-2"><a data-cta="affiliate" data-tool-id="bookyourdata" data-cta-source="verified-deals-bookyourdata" data-cta-page="verified-software-free-trials-deals" href="https://join.bookyourdata.com/swcyqmumr3s5" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-cyan-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-cyan-500">Get 10 free leads →</a><a href="/best/bookyourdata-free-trial.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Read free-lead guide</a></div>
       </article>
 
       <article class="rounded-3xl border border-emerald-400/25 bg-[#11131a] p-7 space-y-5">
-        <div class="flex items-start justify-between gap-4">
-          <div><div class="text-xs font-black uppercase tracking-wider text-emerald-300">Brand monitoring trial</div><h2 class="mt-1 text-3xl font-black text-white">Brand24</h2></div>
-          <span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">No card</span>
-        </div>
-        <p class="text-sm leading-6 text-slate-300">Brand24's current pricing page says the first 14 days are free and no credit card is required. That makes the trial the safer first step before committing to its relatively high paid entry price.</p>
-        <div class="rounded-2xl border border-white/10 bg-white/[0.03] p-4 text-sm text-slate-300"><strong class="text-white">Good fit:</strong> teams that need social listening, reputation monitoring, competitor intelligence or AI-visibility signals and can validate real keyword volume during the trial.</div>
-        <div class="grid gap-3 sm:grid-cols-2">
-          <a data-cta="affiliate" data-tool-id="brand24" data-cta-source="verified_offers_brand24" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-emerald-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-emerald-500">Start Brand24 free trial →</a>
-          <a href="/best/brand24-free-trial.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Read Brand24 trial guide</a>
-        </div>
-        <p class="text-[11px] leading-5 text-slate-500">Official source checked September 8, 2026: Brand24 pricing page.</p>
+        <div class="flex items-start justify-between gap-4"><div><div class="text-xs font-black uppercase tracking-wider text-emerald-300">Brand monitoring</div><h2 class="mt-1 text-3xl font-black text-white">Brand24</h2></div><span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">14 days · no card</span></div>
+        <p class="text-sm leading-6 text-slate-300">Brand24's current pricing page says the first 14 days are free and no credit card is required. Use the trial to validate real monitoring volume, alerts and reporting before committing to a paid plan.</p>
+        <div class="grid gap-3 sm:grid-cols-2"><a data-cta="affiliate" data-tool-id="brand24" data-cta-source="verified-deals-brand24" data-cta-page="verified-software-free-trials-deals" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-emerald-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-emerald-500">Start Brand24 free trial →</a><a href="/best/brand24-free-trial.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Read Brand24 guide</a></div>
       </article>
     </section>
 
     <section class="rounded-3xl border border-white/10 bg-[#11131a] p-7 md:p-9">
       <h2 class="text-2xl font-black text-white">How this list is gated</h2>
-      <div class="mt-5 grid gap-4 md:grid-cols-3 text-sm leading-6 text-slate-300">
+      <div class="mt-5 grid gap-4 text-sm leading-6 text-slate-300 md:grid-cols-3">
         <div class="rounded-2xl border border-white/10 p-5"><strong class="text-white">1. Public product claim</strong><br/>Trial, pricing or offer facts are checked against current vendor information where possible.</div>
         <div class="rounded-2xl border border-white/10 p-5"><strong class="text-white">2. Customer-facing route</strong><br/>The affiliate URL must be specifically issued or otherwise verified as a referral path. Admin and dashboard URLs are excluded.</div>
         <div class="rounded-2xl border border-white/10 p-5"><strong class="text-white">3. Revenue is separate</strong><br/>A valid link is not proof of a signup, sale or commission. COSHUMA reports revenue only when a partner system confirms it.</div>


### PR DESCRIPTION
## What changed
- Surface Gamma's verified PartnerStack route and free no-card entry point on the central verified-deals page.
- Surface Time2book's verified referral route and 7-day no-card trial on the same high-intent page.
- Keep UpLead/Jotform exact partner-issued routes and the existing Unbounce, Pictory, Bookyourdata and Brand24 verified offers.
- Expand ItemList structured data from 6 to 8 buyer paths and refresh the page check date to 2026-09-11.

## Evidence used
- Gamma buyer guide already on main: exact COSHUMA PartnerStack customer route `https://try.gamma.app/pu20lusdpn1j`; Free plan / no-card claim rechecked 2026-09-11.
- Time2book buyer guide already on main: exact COSHUMA referral route `https://time2book.me?aff=9TzesqKi`; free 7-day / no-card claim rechecked 2026-09-11.
- Existing central-page claims/links for the other six tools remain conservative: a valid referral URL is not treated as signup, sale or commission evidence.

No paid resource or unverified tracking parameter was introduced.