### PR TITLE
Revenue: add Moosend vs Mailchimp free-trial buyer guide

### DIFF
--- a/projects/GlobalSaaSHub/public/best/moosend-vs-mailchimp-free-trial.html
+++ b/projects/GlobalSaaSHub/public/best/moosend-vs-mailchimp-free-trial.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Moosend vs Mailchimp Free Trial (2026): 30 Days vs 14 Days | COSHUMA</title>
+  <meta name="description" content="Compare Moosend's 30-day no-card trial with Mailchimp's current 14-day trial and basic Free plan. See the lowest-friction path for testing email marketing before paying." />
+  <link rel="canonical" href="https://coshuma.com/best/moosend-vs-mailchimp-free-trial.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/best/moosend-vs-mailchimp-free-trial.html" />
+  <meta property="og:title" content="Moosend vs Mailchimp Free Trial (2026): 30 Days vs 14 Days" />
+  <meta property="og:description" content="A buyer-focused comparison of Moosend and Mailchimp's current free-entry options, with COSHUMA's verified Moosend partner route." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"Moosend vs Mailchimp Free Trial (2026): 30 Days vs 14 Days",
+    "dateModified":"2026-09-12",
+    "publisher":{"@type":"Organization","name":"COSHUMA"},
+    "mainEntityOfPage":"https://coshuma.com/best/moosend-vs-mailchimp-free-trial.html"
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"Which free trial is longer, Moosend or Mailchimp?","acceptedAnswer":{"@type":"Answer","text":"Moosend currently provides a 30-day free trial, while Mailchimp currently advertises 14-day trials for Standard or Essentials."}},
+      {"@type":"Question","name":"Can I start without a credit card?","acceptedAnswer":{"@type":"Answer","text":"Moosend's current registration flow says no credit card is required to get started. Mailchimp's current pricing page also offers a risk-free no-card trial path, with limited sends until payment information is added."}},
+      {"@type":"Question","name":"Does Mailchimp have a free plan?","acceptedAnswer":{"@type":"Answer","text":"Yes. Mailchimp's current pricing page lists a basic Free plan for smaller lists, currently limited to 250 contacts."}},
+      {"@type":"Question","name":"Does COSHUMA use an affiliate link on this page?","acceptedAnswer":{"@type":"Answer","text":"COSHUMA uses its verified account-specific partner URL for Moosend. Mailchimp links on this page are official non-affiliate reference links."}}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="/affiliate-attribution.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family:'Inter',sans-serif; background:#0b0c10; color:#f1f5f9; }
+    h1,h2,h3 { font-family:'Outfit',sans-serif; }
+  </style>
+</head>
+<body class="min-h-screen bg-[#0b0c10] text-slate-100">
+  <header class="border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md sticky top-0 z-50">
+    <div class="max-w-5xl mx-auto px-5 py-4 flex items-center justify-between gap-4">
+      <a href="/" class="flex items-center gap-3 font-black text-white"><span class="h-8 w-8 rounded-lg bg-indigo-600 flex items-center justify-center">C</span>COSHUMA</a>
+      <a href="/best/moosend-free-trial.html" class="text-xs font-bold px-4 py-2 rounded-full border border-indigo-500/30 bg-indigo-500/10 text-indigo-200">Moosend trial guide →</a>
+    </div>
+  </header>
+
+  <main class="max-w-5xl mx-auto px-5 py-10 sm:py-14 space-y-8">
+    <section class="rounded-3xl border border-indigo-500/25 bg-gradient-to-b from-indigo-500/[0.10] to-[#131520] p-6 sm:p-9 shadow-2xl">
+      <div class="inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-xs font-black uppercase tracking-[0.15em] text-emerald-200">Current free-entry comparison · checked Sep 12, 2026</div>
+      <h1 class="mt-5 text-4xl sm:text-6xl font-black tracking-[-0.04em] text-white">Moosend vs Mailchimp: which is easier to test before paying?</h1>
+      <p class="mt-5 max-w-3xl text-lg leading-8 text-slate-300">If your first goal is to test a real email workflow with the least checkout friction, the current difference is simple: <strong class="text-white">Moosend offers a 30-day free trial with no credit card required to get started</strong>, while <strong class="text-white">Mailchimp currently advertises a 14-day trial</strong> and also keeps a basic Free plan for smaller lists.</p>
+
+      <div class="mt-7 grid gap-4 lg:grid-cols-2">
+        <div class="rounded-2xl border border-emerald-400/25 bg-emerald-400/[0.07] p-6">
+          <div class="text-xs uppercase tracking-[0.18em] text-emerald-200/80 font-black">Moosend</div>
+          <div class="mt-2 text-3xl font-black text-white">30-day trial</div>
+          <ul class="mt-4 space-y-2 text-sm leading-6 text-slate-300">
+            <li>✓ No credit card required to get started.</li>
+            <li>✓ Longer evaluation window than Mailchimp's current 14-day trial.</li>
+            <li>✓ Good fit if you want time to build, send and review a real campaign before deciding.</li>
+          </ul>
+          <a data-cta="affiliate" data-tool-id="moosend" data-cta-source="moosend-mailchimp-hero" href="https://trymoo.moosend.com/6eappdpw04pw" target="_blank" rel="sponsored noopener noreferrer" class="mt-6 inline-flex w-full justify-center rounded-xl bg-emerald-500 px-6 py-4 text-sm font-black text-slate-950 hover:brightness-110">Start Moosend's 30-day trial →</a>
+          <p class="mt-3 text-xs leading-5 text-slate-500">Verified COSHUMA partner route. COSHUMA may earn a commission on a qualifying purchase.</p>
+        </div>
+
+        <div class="rounded-2xl border border-sky-400/20 bg-sky-400/[0.05] p-6">
+          <div class="text-xs uppercase tracking-[0.18em] text-sky-200/80 font-black">Mailchimp</div>
+          <div class="mt-2 text-3xl font-black text-white">14-day trial + Free plan</div>
+          <ul class="mt-4 space-y-2 text-sm leading-6 text-slate-300">
+            <li>✓ Standard and Essentials currently advertise a 14-day trial.</li>
+            <li>✓ Current no-card trial path allows limited sends before payment information is added.</li>
+            <li>✓ Basic Free plan is available for smaller lists; the current page lists a 250-contact limit.</li>
+          </ul>
+          <a href="https://mailchimp.com/pricing/marketing/" target="_blank" rel="noopener noreferrer" class="mt-6 inline-flex w-full justify-center rounded-xl border border-sky-400/25 bg-sky-400/10 px-6 py-4 text-sm font-black text-sky-100 hover:bg-sky-400/15">Verify Mailchimp pricing →</a>
+          <p class="mt-3 text-xs leading-5 text-slate-500">Official Mailchimp link. COSHUMA has not verified a commission-bearing Mailchimp customer route, so no affiliate URL is invented here.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="rounded-3xl border border-[#222538] bg-[#131520] p-6 sm:p-8">
+      <h2 class="text-3xl font-black text-white">Fast decision table</h2>
+      <div class="mt-6 overflow-x-auto rounded-2xl border border-[#2b2f45]">
+        <table class="w-full min-w-[680px] text-sm">
+          <thead class="bg-[#181a29] text-left text-slate-300"><tr><th class="p-4">Question</th><th class="p-4">Moosend</th><th class="p-4">Mailchimp</th></tr></thead>
+          <tbody class="divide-y divide-[#2b2f45] text-slate-300">
+            <tr><td class="p-4 font-bold text-white">Current paid-plan trial window</td><td class="p-4">30 days</td><td class="p-4">14 days</td></tr>
+            <tr><td class="p-4 font-bold text-white">No-card entry</td><td class="p-4">Yes, current registration says no card required</td><td class="p-4">Yes for the current risk-free trial path, with limited sends until payment info is added</td></tr>
+            <tr><td class="p-4 font-bold text-white">Basic free plan</td><td class="p-4">Use the 30-day trial to evaluate current features before purchase</td><td class="p-4">Yes; current pricing lists a Free plan for up to 250 contacts</td></tr>
+            <tr><td class="p-4 font-bold text-white">COSHUMA verified revenue route</td><td class="p-4">Yes — exact PartnerStack customer URL verified</td><td class="p-4">No verified affiliate route; official links only</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="mt-4 text-xs leading-5 text-slate-500">Free-trial and plan terms can change. This comparison uses Moosend's current official registration/terms and Mailchimp's current official marketing pricing page checked on September 12, 2026.</p>
+    </section>
+
+    <section class="rounded-3xl border border-indigo-500/25 bg-indigo-500/[0.06] p-6 sm:p-8">
+      <h2 class="text-3xl font-black text-white">Choose based on the test you actually need</h2>
+      <div class="mt-5 grid gap-4 md:grid-cols-2 text-sm leading-7 text-slate-300">
+        <div class="rounded-2xl border border-emerald-400/20 bg-black/10 p-5">
+          <h3 class="font-black text-emerald-200">Choose Moosend first if...</h3>
+          <p class="mt-2">You want the longer no-card evaluation window and enough time to build a list segment, send a real campaign, test automation and inspect reporting before deciding whether to pay.</p>
+        </div>
+        <div class="rounded-2xl border border-sky-400/20 bg-black/10 p-5">
+          <h3 class="font-black text-sky-200">Check Mailchimp first if...</h3>
+          <p class="mt-2">You specifically want Mailchimp's ecosystem or want to keep a small list on its basic Free plan after the trial. Verify current contact and send limits before relying on the free tier.</p>
+        </div>
+      </div>
+      <div class="mt-6 rounded-2xl border border-amber-400/20 bg-amber-400/[0.06] p-5">
+        <h3 class="font-black text-amber-100">A better buying test than comparing feature counts</h3>
+        <p class="mt-2 text-sm leading-7 text-slate-300">Use the trial to recreate one workflow that matters: import a representative list, build one campaign, set one automation, create one signup path, then compare reporting and editing friction. That gives you a stronger buying signal than choosing from a long feature checklist.</p>
+      </div>
+    </section>
+
+    <section class="rounded-3xl border border-[#222538] bg-[#131520] p-6 sm:p-8 space-y-4">
+      <h2 class="text-3xl font-black text-white">FAQ</h2>
+      <details class="rounded-xl border border-[#222538] bg-[#181a29] p-4"><summary class="cursor-pointer font-bold text-white">Is Moosend's free trial longer than Mailchimp's?</summary><p class="mt-3 text-sm leading-6 text-slate-300">Yes based on the current official offers checked on September 12, 2026: Moosend's trial is 30 days and Mailchimp's current Standard/Essentials trial is 14 days.</p></details>
+      <details class="rounded-xl border border-[#222538] bg-[#181a29] p-4"><summary class="cursor-pointer font-bold text-white">Which one can I start without a card?</summary><p class="mt-3 text-sm leading-6 text-slate-300">Moosend's current registration page explicitly says no credit card is required to get started. Mailchimp currently advertises a risk-free no-card trial path as well, although its pricing page says adding payment information unlocks the plan's full send allowance during the trial.</p></details>
+      <details class="rounded-xl border border-[#222538] bg-[#181a29] p-4"><summary class="cursor-pointer font-bold text-white">Why is only Moosend marked as a partner route?</summary><p class="mt-3 text-sm leading-6 text-slate-300">COSHUMA has an exact, account-specific Moosend PartnerStack customer URL that has been verified. No commission-bearing Mailchimp customer URL has been verified for COSHUMA, so Mailchimp remains official-only on this page.</p></details>
+    </section>
+
+    <section class="rounded-3xl border border-emerald-500/20 bg-emerald-500/[0.05] p-6 sm:p-8 text-center">
+      <h2 class="text-3xl font-black text-white">If test time matters most, start with the longer trial</h2>
+      <p class="mx-auto mt-3 max-w-2xl text-sm leading-7 text-slate-300">Moosend currently gives you 30 days to test the workflow without entering a credit card at signup. Use that time to evaluate the work you would actually pay for rather than upgrading immediately.</p>
+      <a data-cta="affiliate" data-tool-id="moosend" data-cta-source="moosend-mailchimp-bottom" href="https://trymoo.moosend.com/6eappdpw04pw" target="_blank" rel="sponsored noopener noreferrer" class="mt-6 inline-flex rounded-xl bg-emerald-500 px-7 py-4 text-sm font-black text-slate-950 hover:brightness-110">Start Moosend free through COSHUMA →</a>
+      <div class="mt-4 flex flex-wrap justify-center gap-4 text-xs font-bold">
+        <a href="https://identity.moosend.com/register/" target="_blank" rel="noopener noreferrer" class="text-slate-400 hover:text-white">Verify Moosend registration</a>
+        <a href="https://mailchimp.com/pricing/marketing/" target="_blank" rel="noopener noreferrer" class="text-slate-400 hover:text-white">Verify Mailchimp pricing</a>
+      </div>
+      <p class="mt-4 text-xs text-slate-500">Affiliate disclosure: COSHUMA may earn a commission from qualifying Moosend purchases through the marked partner links. Mailchimp references are non-affiliate.</p>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Revenue-first, zero-cost conversion work based on current first-party evidence.

Changes:
- Adds `/best/moosend-vs-mailchimp-free-trial.html` to capture high-intent comparison traffic.
- Uses only COSHUMA's existing exact verified Moosend PartnerStack customer route: `https://trymoo.moosend.com/6eappdpw04pw`.
- Keeps Mailchimp official-only; no affiliate URL is guessed or invented.
- Grounds the comparison in current official terms checked 2026-09-12: Moosend 30-day free trial and no-card registration; Mailchimp 14-day Standard/Essentials trial and current basic Free plan up to 250 contacts.
- Includes explicit affiliate disclosure and unique CTA attribution sources.
- Existing build automation will surface new `/best/` pages from the buyer-guide hub and sitemap.

Guardrails:
- No new application/account.
- No paid subscription or purchase.
- No signup, sale, commission or payout is inferred.
- Mailchimp remains non-affiliate until an exact account-specific customer revenue route is actually verified.