### PR TITLE
Revenue deploy: publish Gamma-to-Canva contextual path

### DIFF
--- a/projects/GlobalSaaSHub/public/llms.txt
+++ b/projects/GlobalSaaSHub/public/llms.txt
@@ -13,7 +13,7 @@ High-intent guides below prioritize concrete buying questions such as free trial
 - https://coshuma.com/best/tally-referral-program-guide.html — Tally personal referral-program guide covering the current eligible new-user 50% three-month benefit, program restrictions, Free/Pro/Business plan fit and COSHUMA's exact issued Cello referral route; not a public sale
 - https://coshuma.com/best/brand24-free-trial.html — Brand24 14-day no-card trial, current pricing and buyer-fit guide using COSHUMA's verified partner route
 - https://coshuma.com/best/getgenie-free-vs-paid.html — GetGenie Free vs paid plan guide using the vendor-confirmed pricing-page affiliate route
-- https://coshuma.com/best/gamma-free-plan-pricing.html — Gamma Free vs Plus vs Pro vs Ultra buyer guide using COSHUMA's verified PartnerStack route
+- https://coshuma.com/best/gamma-free-plan-pricing.html — Gamma Free vs Plus vs Pro vs Ultra buyer guide using COSHUMA's verified PartnerStack route, with a contextual path to the dedicated Gamma vs Canva comparison
 - https://coshuma.com/best/murf-ai-free-trial.html — Murf AI 10-minute no-card free trial and Creator-plan pricing guide using COSHUMA's verified PartnerStack route
 - https://coshuma.com/best/kittl-commercial-use-license.html — Kittl Free vs paid commercial-license guide for POD, client work and digital products using COSHUMA's verified Impact route
 - https://coshuma.com/best/krater-ai-pricing.html — Krater Pro vs Ultra vs Max pricing and credit-fit buyer guide using COSHUMA's verified Dub partner route


### PR DESCRIPTION
## Revenue objective
Trigger the normal production pipeline for the Gamma buyer-guide contextual link added on main, while also making the LLM index describe that buyer path accurately.

## Changes
- Update `public/llms.txt` to state that the Gamma free-plan guide has a contextual path to the dedicated Gamma vs Canva comparison.
- Because this is under `public/**`, the existing COSHUMA Site Build & Deploy path filter will run. The build already executes `ensure_best_internal_links.py`, which now inserts the same marker-based contextual link into the Gamma guide.

## Safety
- No affiliate URL change.
- Gamma keeps the verified PartnerStack route.
- Canva remains official non-affiliate.
- No sale, signup or commission is inferred.
- No paid action.