### PR TITLE
CI: deploy COSHUMA when build scripts change

### DIFF
--- a/.github/workflows/coshuma-site-deploy.yml
+++ b/.github/workflows/coshuma-site-deploy.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'projects/GlobalSaaSHub/src/**'
       - 'projects/GlobalSaaSHub/public/**'
+      - 'projects/GlobalSaaSHub/scripts/**'
       - 'projects/GlobalSaaSHub/data/approved-tracking-2026-09-08.json'
       - 'projects/GlobalSaaSHub/data/pictory-attribution-verification-2026-09-09.md'
       - 'projects/GlobalSaaSHub/scripts/approved_tracking_evidence.mjs'


### PR DESCRIPTION
Revenue-safety fix. The production workflow previously watched only a hand-picked subset of build scripts, so changes to active build-time monetization scripts such as `ensure_best_internal_links.py` could be merged without triggering COSHUMA deployment. This adds `projects/GlobalSaaSHub/scripts/**` to the existing push path filter so any build/generation script change reliably runs the normal build, affiliate validation, CTA checks, and production deploy. No affiliate URL, pricing, payout, or revenue state is changed.