### PR TITLE
Revenue: surface verified Tally referral on homepage

### DIFF
--- a/projects/GlobalSaaSHub/scripts/add_home_verified_offer_strip.py
+++ b/projects/GlobalSaaSHub/scripts/add_home_verified_offer_strip.py
@@ -18,13 +18,13 @@ section = r'''
           <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
             <div className="max-w-2xl">
               <div className="text-xs font-black uppercase tracking-[0.18em] text-emerald-300">Verified low-friction buyer routes</div>
-              <h2 className="mt-2 text-2xl font-black text-white sm:text-3xl">Start with a tracked trial or pricing page we have actually verified</h2>
+              <h2 className="mt-2 text-2xl font-black text-white sm:text-3xl">Start with a tracked trial, pricing page or referral benefit we have actually verified</h2>
               <p className="mt-3 text-sm leading-6 text-slate-400">These customer-facing destinations were supplied directly by the partner programs. COSHUMA does not invent referral parameters, and a click is never treated as a signup or sale.</p>
             </div>
             <a href="/best/verified-software-free-trials-deals.html" data-cta-source="home-verified-offers-all" className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-white/10 px-5 py-3 text-sm font-bold text-slate-200 hover:bg-white/5">See all verified offers <ArrowRight className="h-4 w-4" /></a>
           </div>
 
-          <div className="mt-6 grid gap-4 md:grid-cols-2">
+          <div className="mt-6 grid gap-4 md:grid-cols-3">
             <article className="rounded-2xl border border-cyan-400/20 bg-[#0d1118]/80 p-5">
               <div className="flex items-start justify-between gap-3">
                 <div>
@@ -48,9 +48,21 @@ section = r'''
               <p className="mt-3 text-sm leading-6 text-slate-400">Compare current Jotform plans through the partner-tagged pricing URL its affiliate team explicitly approved for COSHUMA.</p>
               <a data-cta="affiliate" data-tool-id="jotform" data-cta-source="home-verified-offers-jotform-pricing" data-cta-page="home" href="https://www.jotform.com/pricing/?partner=coshuma" target="_blank" rel="sponsored nofollow noopener noreferrer" className="mt-4 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-xl bg-amber-500 px-5 py-3 text-sm font-black text-slate-950 hover:bg-amber-400">Compare Jotform plans <ArrowUpRight className="h-4 w-4" /></a>
             </article>
+
+            <article className="rounded-2xl border border-violet-400/20 bg-[#0d1118]/80 p-5">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-xs font-black uppercase tracking-wider text-violet-300">Forms & surveys</div>
+                  <h3 className="mt-1 text-xl font-black text-white">Tally</h3>
+                </div>
+                <span className="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">Personal referral</span>
+              </div>
+              <p className="mt-3 text-sm leading-6 text-slate-400">Tally says eligible new users who sign up through a personal referral and later become paying customers receive 50% off their subscription for 3 months.</p>
+              <a data-cta="affiliate" data-tool-id="tally" data-cta-source="home-verified-offers-tally-referral" data-cta-page="home" href="https://tally.cello.so/ub0qUbuKk2f" target="_blank" rel="sponsored nofollow noopener noreferrer" className="mt-4 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-black text-white hover:bg-violet-500">Open Tally referral benefit <ArrowUpRight className="h-4 w-4" /></a>
+            </article>
           </div>
 
-          <p className="mt-4 text-[11px] leading-5 text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if an eligible purchase later occurs through these tracked links, at no extra cost to you. Trial eligibility, pricing and final terms are controlled by each vendor.</p>
+          <p className="mt-4 text-[11px] leading-5 text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if an eligible purchase later occurs through these tracked links, at no extra cost to you. Tally's offer is a personal referral benefit for eligible new users, not a public sale. Trial eligibility, pricing, referral terms and final purchase terms are controlled by each vendor.</p>
         </div>
       </section>
 '''
@@ -61,12 +73,14 @@ required = (
     marker,
     'https://app.uplead.com/trial-signup?fp_ref=sangkwon-3af7dc',
     'https://www.jotform.com/pricing/?partner=coshuma',
+    'https://tally.cello.so/ub0qUbuKk2f',
     'data-cta-source="home-verified-offers-uplead-trial"',
     'data-cta-source="home-verified-offers-jotform-pricing"',
+    'data-cta-source="home-verified-offers-tally-referral"',
 )
 for value in required:
     if value not in text:
         raise SystemExit(f"Homepage verified offer safety check failed: {value}")
 
 app.write_text(text, encoding="utf-8")
-print("Homepage verified offer strip applied: UpLead trial + Jotform pricing + verified-offers hub")
+print("Homepage verified offer strip applied: UpLead trial + Jotform pricing + Tally personal referral + verified-offers hub")


### PR DESCRIPTION
## Revenue objective
Increase exposure to an already verified zero-cost monetization route without creating a new account, application, or guessed referral URL.

## Evidence
- Tally/Cello issued COSHUMA the exact customer-facing personal referral URL `https://tally.cello.so/ub0qUbuKk2f`.
- Tally's referral system reported the first link view on 2026-09-11; this is click/view evidence only, not a signup or sale.
- Tally's current official referral terms say eligible new users who sign up through a personal referral and later become paying customers receive 50% off their subscription for 3 months; the referrer can earn 20% up to $150 per referred user.

## Change
Add Tally as a third card in the existing homepage `Verified low-friction buyer routes` section alongside UpLead and Jotform. The CTA uses only the exact vendor-issued Cello URL and includes clear personal-referral / affiliate disclosure.

## Guardrails
- No duplicate application/account.
- No paid subscription or self-referral.
- No generic dashboard/onboarding URL used as a revenue link.
- No click → signup → paid customer → commission inference.
- Tally benefit is described as a personal referral benefit, not a public sale.
