### PR TITLE
Revenue: surface verified Typedesk pricing route on buyer hub

### DIFF
--- a/projects/GlobalSaaSHub/scripts/surface_tally_referral_offer.py
+++ b/projects/GlobalSaaSHub/scripts/surface_tally_referral_offer.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import runpy
 
 ROOT = Path(__file__).resolve().parents[1]
 PAGE = ROOT / "public" / "best" / "verified-software-free-trials-deals.html"
@@ -16,59 +17,62 @@ if MARKER in html:
     if REFERRAL_URL not in html:
         raise SystemExit("Tally referral block exists but exact verified URL is missing")
     print("Tally verified referral offer already surfaced")
-    raise SystemExit(0)
+else:
+    old_meta = (
+        "Compare verified SaaS free trials and partner offers from Gamma, Time2book, "
+        "UpLead, Jotform, Unbounce, Pictory, Brand24 and Bookyourdata. COSHUMA separates "
+        "customer-facing tracking links from product claims."
+    )
+    new_meta = (
+        "Compare verified SaaS free trials and partner offers from Gamma, Time2book, "
+        "UpLead, Jotform, Unbounce, Pictory, Brand24, Bookyourdata and Tally. COSHUMA "
+        "separates customer-facing tracking links from product claims."
+    )
+    if old_meta not in html:
+        raise SystemExit("Buyer-hub meta description changed; refusing blind patch")
+    html = html.replace(old_meta, new_meta, 1)
 
-old_meta = (
-    "Compare verified SaaS free trials and partner offers from Gamma, Time2book, "
-    "UpLead, Jotform, Unbounce, Pictory, Brand24 and Bookyourdata. COSHUMA separates "
-    "customer-facing tracking links from product claims."
-)
-new_meta = (
-    "Compare verified SaaS free trials and partner offers from Gamma, Time2book, "
-    "UpLead, Jotform, Unbounce, Pictory, Brand24, Bookyourdata and Tally. COSHUMA "
-    "separates customer-facing tracking links from product claims."
-)
-if old_meta not in html:
-    raise SystemExit("Buyer-hub meta description changed; refusing blind patch")
-html = html.replace(old_meta, new_meta, 1)
+    item8 = (
+        '      {"@type":"ListItem","position":8,"name":"Brand24",'
+        '"url":"https://coshuma.com/best/brand24-free-trial.html"}\n'
+        "    ]"
+    )
+    item9 = (
+        '      {"@type":"ListItem","position":8,"name":"Brand24",'
+        '"url":"https://coshuma.com/best/brand24-free-trial.html"},\n'
+        '      {"@type":"ListItem","position":9,"name":"Tally",'
+        '"url":"https://coshuma.com/tool/tally.html"}\n'
+        "    ]"
+    )
+    if item8 not in html:
+        raise SystemExit("Buyer-hub ItemList tail changed; refusing blind patch")
+    html = html.replace(item8, item9, 1)
 
-item8 = (
-    '      {"@type":"ListItem","position":8,"name":"Brand24",'
-    '"url":"https://coshuma.com/best/brand24-free-trial.html"}\n'
-    "    ]"
-)
-item9 = (
-    '      {"@type":"ListItem","position":8,"name":"Brand24",'
-    '"url":"https://coshuma.com/best/brand24-free-trial.html"},\n'
-    '      {"@type":"ListItem","position":9,"name":"Tally",'
-    '"url":"https://coshuma.com/tool/tally.html"}\n'
-    "    ]"
-)
-if item8 not in html:
-    raise SystemExit("Buyer-hub ItemList tail changed; refusing blind patch")
-html = html.replace(item8, item9, 1)
+    html = html.replace("Checked September 11, 2026", "Checked September 12, 2026", 1)
 
-html = html.replace("Checked September 11, 2026", "Checked September 12, 2026", 1)
+    closing = '''    </section>\n\n    <section class="rounded-3xl border border-white/10 bg-[#11131a] p-7 md:p-9">\n      <h2 class="text-2xl font-black text-white">How this list is gated</h2>'''
+    if closing not in html:
+        raise SystemExit("Buyer-hub final grid boundary changed; refusing blind patch")
 
-closing = '''    </section>\n\n    <section class="rounded-3xl border border-white/10 bg-[#11131a] p-7 md:p-9">\n      <h2 class="text-2xl font-black text-white">How this list is gated</h2>'''
-if closing not in html:
-    raise SystemExit("Buyer-hub final grid boundary changed; refusing blind patch")
+    card = f'''      {MARKER}\n      <article class="rounded-3xl border border-sky-400/25 bg-[#11131a] p-7 space-y-5">\n        <div class="flex items-start justify-between gap-4"><div><div class="text-xs font-black uppercase tracking-wider text-sky-300">Forms & surveys</div><h2 class="mt-1 text-3xl font-black text-white">Tally</h2></div><span class="rounded-full bg-sky-400/10 px-3 py-1 text-xs font-bold text-sky-200">Verified referral benefit</span></div>\n        <p class="text-sm leading-6 text-slate-300">Tally's current referral program says new users who sign up through a referral link and later become paying customers receive <strong class="text-white">50% off their subscription for 3 months</strong>. This is a referral benefit, not a public sale. COSHUMA uses only the exact personal invite URL issued through Tally's Cello-powered referral system.</p>\n        <div class="grid gap-3 sm:grid-cols-2"><a data-cta="affiliate" data-tool-id="tally" data-cta-source="verified-deals-tally-referral" data-cta-page="verified-software-free-trials-deals" href="{REFERRAL_URL}" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl bg-sky-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-sky-500">Start Tally via verified referral →</a><a href="/tool/tally.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Read Tally guide</a></div>\n        <p class="text-[11px] leading-5 text-slate-500">Tally prohibits self-referrals and paid ads using the referral link. COSHUMA may earn 20% of eligible subscription payments, up to $150 per referred paid user. A link view is not treated as a signup, paid customer, commission or revenue event.</p>\n      </article>\n'''
 
-card = f'''      {MARKER}\n      <article class="rounded-3xl border border-sky-400/25 bg-[#11131a] p-7 space-y-5">\n        <div class="flex items-start justify-between gap-4"><div><div class="text-xs font-black uppercase tracking-wider text-sky-300">Forms & surveys</div><h2 class="mt-1 text-3xl font-black text-white">Tally</h2></div><span class="rounded-full bg-sky-400/10 px-3 py-1 text-xs font-bold text-sky-200">Verified referral benefit</span></div>\n        <p class="text-sm leading-6 text-slate-300">Tally's current referral program says new users who sign up through a referral link and later become paying customers receive <strong class="text-white">50% off their subscription for 3 months</strong>. This is a referral benefit, not a public sale. COSHUMA uses only the exact personal invite URL issued through Tally's Cello-powered referral system.</p>\n        <div class="grid gap-3 sm:grid-cols-2"><a data-cta="affiliate" data-tool-id="tally" data-cta-source="verified-deals-tally-referral" data-cta-page="verified-software-free-trials-deals" href="{REFERRAL_URL}" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl bg-sky-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-sky-500">Start Tally via verified referral →</a><a href="/tool/tally.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Read Tally guide</a></div>\n        <p class="text-[11px] leading-5 text-slate-500">Tally prohibits self-referrals and paid ads using the referral link. COSHUMA may earn 20% of eligible subscription payments, up to $150 per referred paid user. A link view is not treated as a signup, paid customer, commission or revenue event.</p>\n      </article>\n'''
+    html = html.replace(closing, card + closing, 1)
 
-html = html.replace(closing, card + closing, 1)
+    # Final hard guards: the exact URL and disclosure semantics must survive.
+    required = [
+        REFERRAL_URL,
+        'data-cta-source="verified-deals-tally-referral"',
+        "50% off their subscription for 3 months",
+        "not a public sale",
+        "A link view is not treated as a signup",
+    ]
+    for token in required:
+        if token not in html:
+            raise SystemExit(f"Tally buyer-hub patch lost required token: {token}")
 
-# Final hard guards: the exact URL and disclosure semantics must survive.
-required = [
-    REFERRAL_URL,
-    'data-cta-source="verified-deals-tally-referral"',
-    "50% off their subscription for 3 months",
-    "not a public sale",
-    "A link view is not treated as a signup",
-]
-for token in required:
-    if token not in html:
-        raise SystemExit(f"Tally buyer-hub patch lost required token: {token}")
+    PAGE.write_text(html, encoding="utf-8")
+    print("Surfaced verified Tally referral offer on buyer hub")
 
-PAGE.write_text(html, encoding="utf-8")
-print("Surfaced verified Tally referral offer on buyer hub")
+# This step intentionally runs after Tally because the Typedesk patch extends the
+# generated ItemList from position 9 to 10 and requires Tally's verified build state.
+runpy.run_path(str(ROOT / "scripts" / "surface_typedesk_verified_offer.py"), run_name="__main__")

--- a/projects/GlobalSaaSHub/scripts/surface_typedesk_verified_offer.py
+++ b/projects/GlobalSaaSHub/scripts/surface_typedesk_verified_offer.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGE = ROOT / "public" / "best" / "verified-software-free-trials-deals.html"
+MARKER = "<!-- COSHUMA_TYPEDESK_VERIFIED_OFFER -->"
+TRACKING_URL = "https://www.typedesk.com/pricing?via=sangkwon"
+
+if not PAGE.exists():
+    raise SystemExit(f"Missing buyer hub: {PAGE}")
+
+html = PAGE.read_text(encoding="utf-8")
+
+# Idempotence + attribution safety: this buyer-hub card may only use the exact
+# vendor-confirmed Typedesk pricing deep link that preserves via=sangkwon.
+if MARKER in html:
+    if TRACKING_URL not in html:
+        raise SystemExit("Typedesk verified block exists but exact tracking URL is missing")
+    print("Typedesk verified buyer offer already surfaced")
+    raise SystemExit(0)
+
+old_meta = (
+    "Compare verified SaaS free trials and partner offers from Gamma, Time2book, "
+    "UpLead, Jotform, Unbounce, Pictory, Brand24, Bookyourdata and Tally. COSHUMA "
+    "separates customer-facing tracking links from product claims."
+)
+new_meta = (
+    "Compare verified SaaS free trials and partner offers from Gamma, Time2book, "
+    "UpLead, Jotform, Unbounce, Pictory, Brand24, Bookyourdata, Tally and Typedesk. "
+    "COSHUMA separates customer-facing tracking links from product claims."
+)
+if old_meta not in html:
+    raise SystemExit("Buyer-hub meta description changed; refusing blind patch")
+html = html.replace(old_meta, new_meta, 1)
+
+item9 = (
+    '      {"@type":"ListItem","position":9,"name":"Tally",'
+    '"url":"https://coshuma.com/tool/tally.html"}\n'
+    "    ]"
+)
+item10 = (
+    '      {"@type":"ListItem","position":9,"name":"Tally",'
+    '"url":"https://coshuma.com/tool/tally.html"},\n'
+    '      {"@type":"ListItem","position":10,"name":"Typedesk",'
+    '"url":"https://coshuma.com/best/typedesk-pricing-free-plan.html"}\n'
+    "    ]"
+)
+if item9 not in html:
+    raise SystemExit("Tally ItemList tail missing; Typedesk patch requires the verified Tally build step first")
+html = html.replace(item9, item10, 1)
+
+closing = '''    </section>\n\n    <section class="rounded-3xl border border-white/10 bg-[#11131a] p-7 md:p-9">\n      <h2 class="text-2xl font-black text-white">How this list is gated</h2>'''
+if closing not in html:
+    raise SystemExit("Buyer-hub final grid boundary changed; refusing blind patch")
+
+card = f'''      {MARKER}\n      <article class="rounded-3xl border border-indigo-400/25 bg-[#11131a] p-7 space-y-5">\n        <div class="flex items-start justify-between gap-4"><div><div class="text-xs font-black uppercase tracking-wider text-indigo-300">Text expansion & support workflows</div><h2 class="mt-1 text-3xl font-black text-white">Typedesk</h2></div><span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">Free forever plan</span></div>\n        <p class="text-sm leading-6 text-slate-300">Typedesk's current official pricing page lists a Free plan for personal use with unlimited templates and up to 50 uses per week. The affiliate team also confirmed that COSHUMA may preserve its issued <code class="text-indigo-200">via=sangkwon</code> attribution on the pricing page, so the buyer-intent destination below is not a guessed deep link.</p>\n        <div class="grid gap-3 sm:grid-cols-2"><a data-cta="affiliate" data-tool-id="typedesk" data-cta-source="verified-deals-typedesk-pricing" data-cta-page="verified-software-free-trials-deals" href="{TRACKING_URL}" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl bg-indigo-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-indigo-500">Check Typedesk plans →</a><a href="/best/typedesk-pricing-free-plan.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Compare free vs paid</a></div>\n        <p class="text-[11px] leading-5 text-slate-500">Typedesk told COSHUMA it currently provides no affiliate coupon code. COSHUMA therefore makes no coupon or discount claim here. A visit, signup, upgrade, commission or payout is not counted without partner-side evidence.</p>\n      </article>\n'''
+
+html = html.replace(closing, card + closing, 1)
+
+required = [
+    TRACKING_URL,
+    'data-cta-source="verified-deals-typedesk-pricing"',
+    "Free plan for personal use",
+    "no affiliate coupon code",
+    "not counted without partner-side evidence",
+]
+for token in required:
+    if token not in html:
+        raise SystemExit(f"Typedesk buyer-hub patch lost required token: {token}")
+
+PAGE.write_text(html, encoding="utf-8")
+print("Surfaced verified Typedesk pricing route on buyer hub")


### PR DESCRIPTION
## Revenue goal
Expose an already-approved, vendor-confirmed Typedesk buyer-intent route on COSHUMA's verified trials/offers hub without creating a new account, reapplying, or inventing attribution.

## Evidence and safety
- Existing human vendor evidence: `data/typedesk-approved-tracking-2026-09-09.md`.
- Uses only `https://www.typedesk.com/pricing?via=sangkwon`, which Typedesk explicitly confirmed can preserve COSHUMA attribution on any Typedesk page.
- Current official Typedesk pricing page shows a Free plan for personal use with unlimited templates and up to 50 uses/week.
- Publishes no coupon/discount claim; vendor explicitly said no affiliate coupon is currently provided.
- Does not infer visits, signups, upgrades, commissions, payouts, or revenue.

## Implementation
- Adds an idempotent `surface_typedesk_verified_offer.py` build step.
- Chains it after the existing Tally buyer-hub step so JSON-LD ItemList positions remain deterministic.
- Adds a tracked buyer CTA and internal link to the existing Typedesk pricing/free-plan guide.

No paid services, secrets, or browser-only actions are required.