### PR TITLE
Revenue: add Brand24 vs Mention buyer comparison

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/brand24-vs-mention.html
+++ b/projects/GlobalSaaSHub/public/compare/brand24-vs-mention.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Brand24 vs Mention 2026: Social Listening, Trial & Buyer Fit | COSHUMA</title>
+  <meta name="description" content="Brand24 vs Mention in 2026: compare social-listening focus, trial routes, monitoring depth, pricing approach and which platform better fits your team before paying." />
+  <link rel="canonical" href="https://coshuma.com/compare/brand24-vs-mention.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/brand24-vs-mention.html" />
+  <meta property="og:title" content="Brand24 vs Mention 2026 | COSHUMA" />
+  <meta property="og:description" content="A buyer-focused comparison of Brand24 and Mention for social listening, media monitoring and competitive intelligence." />
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Brand24 vs Mention 2026: Social Listening, Trial & Buyer Fit","mainEntityOfPage":"https://coshuma.com/compare/brand24-vs-mention.html","dateModified":"2026-09-12","author":{"@type":"Organization","name":"COSHUMA"}}</script>
+  <script defer src="/affiliate-attribution.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&family=Outfit:wght@600;800;900&display=swap" rel="stylesheet">
+  <style>body{font-family:Inter,sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:Outfit,sans-serif}</style>
+</head>
+<body>
+<header class="border-b border-slate-800 bg-[#07080c]/90 px-6 py-4">
+  <div class="mx-auto flex max-w-6xl items-center justify-between">
+    <a href="/" class="font-black text-white">COSHUMA</a>
+    <a href="/best/brand24-free-trial.html" class="text-sm font-bold text-emerald-300">Brand24 free-trial guide →</a>
+  </div>
+</header>
+<main class="mx-auto max-w-5xl space-y-10 px-4 py-12">
+  <section class="space-y-5">
+    <div class="text-xs font-black uppercase tracking-[0.2em] text-purple-300">Social listening comparison · Updated Sep 12, 2026</div>
+    <h1 class="text-4xl font-black leading-tight md:text-5xl">Brand24 vs Mention: which social-listening route fits your team?</h1>
+    <p class="max-w-3xl text-lg leading-8 text-slate-300">Both products monitor online conversations, but the current buying paths are different. Brand24 publishes self-serve pricing and a 14-day trial with no credit card required. Mention currently presents a Company-focused pricing page with demo and free-trial entry points, while some older self-serve plans are now legacy products.</p>
+    <div class="grid gap-4 md:grid-cols-2">
+      <div class="rounded-3xl border border-emerald-500/30 bg-emerald-500/5 p-6">
+        <div class="text-sm font-black text-emerald-300">Brand24</div>
+        <h2 class="mt-2 text-2xl font-black">Best first test when you want transparent self-serve pricing</h2>
+        <p class="mt-3 text-sm leading-6 text-slate-300">Brand24 currently offers a 14-day free trial with no credit card required. Its Individual plan is listed at $249/month on monthly billing or $199/month when billed annually.</p>
+        <a data-cta="affiliate" data-tool-id="brand24" data-cta-source="compare-brand24-vs-mention-hero" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="mt-5 inline-flex rounded-xl bg-emerald-500 px-5 py-3 font-black text-slate-950">Start Brand24 via COSHUMA →</a>
+      </div>
+      <div class="rounded-3xl border border-purple-500/30 bg-purple-500/5 p-6">
+        <div class="text-sm font-black text-purple-300">Mention</div>
+        <h2 class="mt-2 text-2xl font-black">Best first step when you want a guided Company-plan evaluation</h2>
+        <p class="mt-3 text-sm leading-6 text-slate-300">Mention's current pricing page emphasizes an enterprise-grade Company plan and routes prospects to demo and free-trial entry points. COSHUMA does not currently have a verified Mention customer affiliate URL, so this page uses Mention's official pricing page only.</p>
+        <a data-cta="official" data-cta-source="compare-brand24-vs-mention-mention-official" href="https://mention.com/en/pricing/" target="_blank" rel="noopener noreferrer" class="mt-5 inline-flex rounded-xl bg-purple-600 px-5 py-3 font-black text-white">View Mention official pricing →</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="rounded-3xl border border-slate-800 bg-[#131520] p-7">
+    <h2 class="text-2xl font-black">Quick decision table</h2>
+    <div class="mt-5 overflow-x-auto">
+      <table class="w-full min-w-[720px] text-left text-sm">
+        <thead class="text-slate-400"><tr><th class="p-3">Decision point</th><th class="p-3">Brand24</th><th class="p-3">Mention</th></tr></thead>
+        <tbody class="divide-y divide-slate-800 text-slate-200">
+          <tr><td class="p-3 font-bold">Current buying path</td><td class="p-3">Published self-serve tiers plus free trial</td><td class="p-3">Company-focused pricing page with demo / free-trial entry points</td></tr>
+          <tr><td class="p-3 font-bold">Trial detail COSHUMA can verify</td><td class="p-3">14 days, no credit card required</td><td class="p-3">Official page exposes a free-trial route; this page does not assume an unverified duration</td></tr>
+          <tr><td class="p-3 font-bold">Monitoring focus</td><td class="p-3">Web and social mentions, sentiment, competitive monitoring and AI-assisted analysis</td><td class="p-3">Social and web monitoring, sentiment, competitive analysis, reporting and collaboration</td></tr>
+          <tr><td class="p-3 font-bold">COSHUMA revenue link</td><td class="p-3">Verified PartnerStack customer link</td><td class="p-3">None verified; official non-affiliate pricing link only</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="grid gap-5 md:grid-cols-2">
+    <div class="rounded-3xl border border-slate-800 bg-[#131520] p-7">
+      <h2 class="text-2xl font-black">Choose Brand24 if…</h2>
+      <ul class="mt-4 list-disc space-y-2 pl-5 text-sm leading-6 text-slate-300">
+        <li>You want to see published pricing before talking to sales.</li>
+        <li>You want a clearly documented 14-day trial before subscribing.</li>
+        <li>You need a straightforward way to test keyword volume, alerts, sentiment and reporting on your own brand.</li>
+      </ul>
+    </div>
+    <div class="rounded-3xl border border-slate-800 bg-[#131520] p-7">
+      <h2 class="text-2xl font-black">Choose Mention if…</h2>
+      <ul class="mt-4 list-disc space-y-2 pl-5 text-sm leading-6 text-slate-300">
+        <li>You prefer to evaluate a Company-oriented monitoring package with a vendor conversation.</li>
+        <li>You want social/web monitoring, Boolean search, sentiment, competitive analysis and team collaboration in one evaluation.</li>
+        <li>You are comfortable confirming final pricing and trial terms directly with Mention before purchase.</li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="rounded-3xl border border-amber-500/20 bg-amber-500/5 p-7">
+    <h2 class="text-2xl font-black">Lowest-risk way to decide</h2>
+    <p class="mt-3 text-sm leading-6 text-slate-300">Use the same real monitoring test in both products: one brand name, one competitor and one important category keyword. Compare coverage quality, noise, alert usefulness and reporting before paying. Do not choose based only on the number of sources or a single feature checkbox.</p>
+    <div class="mt-5 flex flex-col gap-3 sm:flex-row">
+      <a data-cta="affiliate" data-tool-id="brand24" data-cta-source="compare-brand24-vs-mention-bottom" href="https://try.brand24.com/8xqrjxybmsbt" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-emerald-500 px-5 py-3 text-center font-black text-slate-950">Test Brand24 for 14 days →</a>
+      <a href="https://mention.com/en/pricing/" target="_blank" rel="noopener noreferrer" class="rounded-xl bg-slate-800 px-5 py-3 text-center font-black">Check Mention's current route →</a>
+    </div>
+  </section>
+
+  <section class="rounded-3xl border border-slate-800 bg-[#10131c] p-7 text-sm leading-6 text-slate-400">
+    <h2 class="text-lg font-black text-white">Sources & revenue-truth note</h2>
+    <p class="mt-3">Brand24 facts were checked against Brand24's official pricing page and its June 12, 2026 trial help-center article. Mention facts were checked against Mention's current official pricing page and July 1, 2026 legacy-subscription update. Vendor terms can change, so confirm final checkout terms.</p>
+    <p class="mt-3">Affiliate disclosure: the Brand24 buttons use COSHUMA's previously verified PartnerStack customer tracking URL. COSHUMA may earn a commission if an eligible buyer later becomes a paying customer. Mention stays non-affiliate here because no exact COSHUMA customer tracking URL has been verified. Publishing or clicking this page is not treated as a signup, paid customer, commission or revenue event.</p>
+  </section>
+
+  <section class="rounded-3xl border border-slate-800 bg-[#131520] p-7">
+    <h2 class="text-xl font-black">Related COSHUMA buyer guides</h2>
+    <div class="mt-4 flex flex-col gap-3 sm:flex-row">
+      <a href="/best/brand24-free-trial.html" class="rounded-xl bg-slate-800 px-5 py-3 text-center font-black">Brand24 free-trial guide →</a>
+      <a href="/tool/brand24.html" class="rounded-xl bg-slate-800 px-5 py-3 text-center font-black">Brand24 pricing & review →</a>
+      <a href="/compare/brand24-vs-agorapulse.html" class="rounded-xl bg-slate-800 px-5 py-3 text-center font-black">Brand24 vs Agorapulse →</a>
+    </div>
+  </section>
+</main>
+<footer class="border-t border-slate-800 px-6 py-8 text-center text-xs text-slate-500">© 2026 COSHUMA · Independent AI & SaaS buyer guides</footer>
+</body>
+</html>


### PR DESCRIPTION
Adds a focused Brand24 vs Mention buyer comparison using only current official vendor facts. Brand24 uses COSHUMA's already-verified PartnerStack customer tracking URL. Mention remains an official non-affiliate route because no exact COSHUMA tracking URL is verified. No signup, paid customer, commission, or revenue is inferred. No paid action or duplicate affiliate application.