### PR TITLE
SEO: index Brand24 vs Mention comparison

### DIFF
--- a/projects/GlobalSaaSHub/public/llms.txt
+++ b/projects/GlobalSaaSHub/public/llms.txt
@@ -54,6 +54,7 @@ High-intent guides below prioritize concrete buying questions such as free trial
 - https://coshuma.com/compare/tagshop-ai-vs-creatify.html — Tagshop AI vs Creatify AI UGC-ad comparison; Tagshop uses COSHUMA's verified vendor-issued referral route while Creatify stays on official non-affiliate pricing links
 - https://coshuma.com/compare/tally-vs-typeform.html — Tally vs Typeform free-response, paid-entry and buyer-fit comparison; Tally uses COSHUMA's exact issued Cello referral route while Typeform stays on official non-affiliate pricing links
 - https://coshuma.com/compare/typedesk-vs-textexpander.html — Typedesk vs TextExpander free-plan, team-sharing and text-expansion workflow comparison; Typedesk uses COSHUMA's vendor-confirmed pricing attribution route while TextExpander stays on its official non-affiliate pricing page
+- https://coshuma.com/compare/brand24-vs-mention.html — Brand24 vs Mention social-listening, trial-route and buyer-fit comparison; Brand24 uses COSHUMA's verified PartnerStack customer route while Mention stays on its official non-affiliate pricing page
 - https://coshuma.com/best/crm-for-marketing-agencies.html — CRM options for marketing agencies
 - https://coshuma.com/best/landing-page-builders.html — Landing-page builder comparison
 - https://coshuma.com/best/ai-video-generators.html — AI video generator comparison


### PR DESCRIPTION
Adds the new production Brand24 vs Mention buyer comparison to COSHUMA's llms.txt comparison-hub discovery list. The entry preserves revenue-truth wording: Brand24 uses the already-verified PartnerStack customer route and Mention remains an official non-affiliate destination. No affiliate status, signup, commission, or revenue is inferred.