### PR TITLE
Revenue truth: record Tagshop site-wide attribution and dashboard metrics queue

### DIFF
--- a/projects/GlobalSaaSHub/data/browser_required_queue.d/tagshop-revenue-stats-2026-09-12.json
+++ b/projects/GlobalSaaSHub/data/browser_required_queue.d/tagshop-revenue-stats-2026-09-12.json
@@ -1,0 +1,25 @@
+{
+  "id": "tagshop-revenue-stats-2026-09-12",
+  "tool_id": "tagshop-ai",
+  "priority": "high",
+  "status": "approved_tracking_stats_browser_required",
+  "affiliate_status": "approved_tracking",
+  "cost": 0,
+  "verified_at": "2026-09-12T17:42:40+09:00",
+  "gmail_message_id": "1a094c8ab5fa3379",
+  "gmail_thread_id": "1a0829e45df98eb7",
+  "reason": "Tagshop's Priyanka Sain directly confirmed that COSHUMA's exact issued referral URL https://tagshop.ai?via=coshuma-22501e automatically tracks referrals and conversions across the site. She also confirmed that the existing FirstPromoter dashboard contains real-time totals for clicks, referred signups, paying customers, pending/earned commissions and payout status. The email contains no numeric totals, so the revenue metrics remain unknown until the authenticated dashboard is read.",
+  "dashboard_login_url": "https://tagshop.firstpromoter.com/login",
+  "verified_customer_urls": {
+    "issued_referral_entry": "https://tagshop.ai?via=coshuma-22501e"
+  },
+  "separate_pricing_or_trial_deeplink": null,
+  "next_action": "Reuse the existing authenticated Tagshop/FirstPromoter session and read the current totals for clicks, referred signups, paying customers, pending/earned commission, payout status and the visible reporting period. Record only values actually shown by the dashboard. If no authenticated session is available, keep this item queued rather than creating another account or application.",
+  "do_not": [
+    "Do not publish or use the FirstPromoter dashboard/login URL as a customer CTA.",
+    "Do not construct Tagshop pricing or trial affiliate deep links by appending via=coshuma-22501e to arbitrary paths; the vendor did not issue a separate deep link.",
+    "Do not reapply to Tagshop or create a second affiliate account.",
+    "Do not infer clicks, signups, paying customers, commission, payout or revenue from the vendor's site-wide attribution confirmation.",
+    "Do not pay for any plan or subscription to access statistics."
+  ]
+}

--- a/projects/GlobalSaaSHub/data/tagshop-approved-tracking-2026-09-09.md
+++ b/projects/GlobalSaaSHub/data/tagshop-approved-tracking-2026-09-09.md
@@ -1,24 +1,44 @@
-# Tagshop AI approved tracking evidence — 2026-09-09
+# Tagshop AI approved tracking evidence — updated 2026-09-12
 
 - Account/mailbox: `support@coshuma.com`
-- Gmail message ID: `1a0829e45df98eb7`
-- Sender: Tagshop / FirstPromoter (`promoter@firstpromoter.com`)
-- Subject: `Welcome to Tagshop - Partner Program!`
-- Message timestamp: 2026-09-08 20:03:24 UTC
+- Original Gmail message ID: `1a0829e45df98eb7`
+- Original sender: Tagshop / FirstPromoter (`promoter@firstpromoter.com`)
+- Original subject: `Welcome to Tagshop - Partner Program!`
+- Original message timestamp: 2026-09-08 20:03:24 UTC
 - Exact customer-facing referral URL issued in the welcome message: `https://tagshop.ai?via=coshuma-22501e`
 - Dashboard/login URL in the same message: `https://tagshop.firstpromoter.com/login`
 
-## Verification decision
+## Original verification decision
 
 The welcome message explicitly thanks COSHUMA for joining the Tagshop referral program, says to share the issued link, and states COSHUMA will be rewarded when referred users subscribe to a paid account. Therefore the `via=coshuma-22501e` URL is customer-facing revenue attribution, while the FirstPromoter login URL is only an administrative dashboard and must never be used as a customer CTA.
 
-The current official Tagshop affiliate page (`https://tagshop.ai/affiliate`) states 30% recurring commission for 6 months, no joining fee, and a 90-day cookie window. These program terms were rechecked on 2026-09-09. They describe the general program and do not prove a COSHUMA sale or commission.
+The current official Tagshop affiliate page (`https://tagshop.ai/affiliate`) stated 30% recurring commission for 6 months, no joining fee, and a 90-day cookie window when rechecked on 2026-09-09. Those general program terms do not prove a COSHUMA sale or commission.
+
+## New human vendor confirmation — 2026-09-12
+
+- Gmail message ID: `1a094c8ab5fa3379`
+- Sender: Priyanka Sain (`priyanka@tagshop.ai`)
+- Message received: 2026-09-12 08:42:40 UTC
+- Thread: the existing `Welcome to Tagshop - Partner Program!` conversation.
+
+Priyanka directly confirmed that COSHUMA's issued referral URL `https://tagshop.ai?via=coshuma-22501e` **automatically tracks referrals and conversions across the site**. This strengthens the attribution evidence for the already-issued entry URL: customers may enter through that exact referral URL and continue navigating Tagshop without COSHUMA inventing a separate pricing/trial affiliate URL.
+
+Priyanka did **not** issue a separate pricing or trial deep-link URL and did not instruct COSHUMA to construct `?via=coshuma-22501e` variants on arbitrary Tagshop paths. Therefore COSHUMA must continue using only the exact issued referral URL unless Tagshop later supplies or explicitly approves a distinct deep link.
+
+The same reply states that the existing FirstPromoter dashboard exposes real-time totals for total clicks, referred signups, paying customers, pending/earned commissions, and payout status. The email itself contains no numeric totals. Those metrics therefore remain unknown until the authenticated dashboard is read.
 
 ## Operational status
 
 - `affiliate_status`: `approved_tracking`
 - `affiliate_verified`: `true`
 - `exact_tracking_url`: `https://tagshop.ai?via=coshuma-22501e`
+- Site-wide referral/conversion attribution from the issued entry link: **vendor-confirmed** on 2026-09-12.
+- Separate Tagshop pricing/trial affiliate deep link: **not issued / unverified**.
+- Clicks: **unknown**.
+- Referred signups: **unknown**.
+- Paying customers: **unknown**.
+- Pending/earned commission: **unknown**.
+- Payout status: **unknown**.
 - Do not reapply or create another Tagshop affiliate account.
-- Do not substitute a generic Tagshop homepage, affiliate application page, FirstPromoter dashboard/login page, or onboarding URL for the issued customer link.
-- No customer signup, paid conversion, commission, payout, or revenue is inferred from this approval/link issuance.
+- Do not substitute a generic Tagshop homepage, affiliate application page, FirstPromoter dashboard/login page, onboarding URL, or guessed deep-link parameter for the issued customer link.
+- Do not infer customer signup, paid conversion, commission, payout, or revenue from approval, link issuance, site-wide attribution confirmation, page publication, or successful link loading.


### PR DESCRIPTION
Records new human vendor evidence from Tagshop without inventing revenue or deep links.

Evidence:
- Priyanka Sain at Tagshop confirmed on 2026-09-12 that COSHUMA's exact issued referral URL `https://tagshop.ai?via=coshuma-22501e` automatically tracks referrals and conversions across the site.
- She confirmed the existing FirstPromoter dashboard exposes real-time clicks, referred signups, paying customers, pending/earned commissions and payout status.
- The email itself supplied no numeric totals and no separate pricing/trial affiliate deep link.

Changes:
- Updates the existing Tagshop approved-tracking evidence with the new human confirmation and strict revenue-truth boundaries.
- Adds a zero-cost `browser_required_queue.d` item for authenticated dashboard metric recovery.

Guardrails:
- Keep only the exact issued referral URL as customer revenue entry.
- Do not construct pricing/trial deep links from the `via` parameter.
- Do not reapply or create another account.
- Do not infer clicks, signups, paid customers, commission, payout or revenue from attribution confirmation.