### PR TITLE
Revenue: surface verified Tagshop trial route on buyer hub

### DIFF
--- a/projects/GlobalSaaSHub/data/tagshop-buyer-hub-evidence-2026-09-12.md
+++ b/projects/GlobalSaaSHub/data/tagshop-buyer-hub-evidence-2026-09-12.md
@@ -1,0 +1,34 @@
+# Tagshop AI buyer-hub evidence — 2026-09-12
+
+## Customer revenue route
+
+- Existing human/vendor evidence file: `data/tagshop-approved-tracking-2026-09-09.md`
+- Exact customer-facing URL issued to COSHUMA: `https://tagshop.ai?via=coshuma-22501e`
+- Tagshop contact Priyanka Sain confirmed on 2026-09-12 that this exact issued entry URL automatically tracks referrals and conversions across the site.
+- No separate pricing or trial affiliate deep link was issued. COSHUMA must not construct one by copying the `via` parameter onto arbitrary Tagshop paths.
+- `https://tagshop.firstpromoter.com/login` is an administrative dashboard and must never be exposed as a customer CTA.
+
+## Current product/trial fact used on the buyer hub
+
+Official source checked 2026-09-12:
+- `https://help.tagshop.ai/en/articles/13262607-tagshop-ai-pricing-plans-explained`
+
+The official Tagshop help article currently states that the Free Trial provides:
+- 14-day free trial,
+- full platform access,
+- no credit card required.
+
+The buyer-hub card uses only these current first-party trial facts plus the exact issued COSHUMA referral entry URL.
+
+## Revenue-truth boundary
+
+Tagshop's vendor reply confirms where the real FirstPromoter dashboard exposes clicks, referred signups, paying customers, commissions and payout status, but the email itself did not provide any numeric totals. Until the authenticated dashboard is read:
+
+- clicks: unknown,
+- referred signups: unknown,
+- paying customers: unknown,
+- commission: unknown,
+- payout: unknown,
+- actual revenue: unknown.
+
+Publishing or clicking the buyer-hub CTA does not prove any downstream conversion or revenue event.

--- a/projects/GlobalSaaSHub/scripts/surface_tagshop_verified_offer.py
+++ b/projects/GlobalSaaSHub/scripts/surface_tagshop_verified_offer.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGE = ROOT / "public" / "best" / "verified-software-free-trials-deals.html"
+MARKER = "<!-- COSHUMA_TAGSHOP_VERIFIED_OFFER -->"
+TRACKING_URL = "https://tagshop.ai?via=coshuma-22501e"
+ADMIN_URL = "https://tagshop.firstpromoter.com/login"
+
+if not PAGE.exists():
+    raise SystemExit(f"Missing buyer hub: {PAGE}")
+
+html = PAGE.read_text(encoding="utf-8")
+
+# Idempotence + attribution safety: the vendor confirmed that this exact issued
+# entry URL tracks referrals/conversions site-wide. Do not invent pricing/trial
+# deep links by moving the via parameter onto arbitrary Tagshop URLs.
+if MARKER in html:
+    if TRACKING_URL not in html:
+        raise SystemExit("Tagshop verified block exists but exact issued referral URL is missing")
+    if ADMIN_URL in html:
+        raise SystemExit("Tagshop admin dashboard URL leaked into the public buyer hub")
+    print("Tagshop verified buyer offer already surfaced")
+    raise SystemExit(0)
+
+old_meta = (
+    "Compare verified SaaS free trials and partner offers from Gamma, Time2book, "
+    "UpLead, Jotform, Unbounce, Pictory, Brand24, Bookyourdata, Tally and Typedesk. "
+    "COSHUMA separates customer-facing tracking links from product claims."
+)
+new_meta = (
+    "Compare verified SaaS free trials and partner offers from Gamma, Time2book, "
+    "UpLead, Jotform, Unbounce, Pictory, Brand24, Bookyourdata, Tally, Typedesk and "
+    "Tagshop AI. COSHUMA separates customer-facing tracking links from product claims."
+)
+if old_meta not in html:
+    raise SystemExit("Buyer-hub meta description changed; refusing blind Tagshop patch")
+html = html.replace(old_meta, new_meta, 1)
+
+item10 = (
+    '      {"@type":"ListItem","position":10,"name":"Typedesk",'
+    '"url":"https://coshuma.com/best/typedesk-pricing-free-plan.html"}\n'
+    "    ]"
+)
+item11 = (
+    '      {"@type":"ListItem","position":10,"name":"Typedesk",'
+    '"url":"https://coshuma.com/best/typedesk-pricing-free-plan.html"},\n'
+    '      {"@type":"ListItem","position":11,"name":"Tagshop AI",'
+    '"url":"https://coshuma.com/best/tagshop-ai-free-trial-pricing.html"}\n'
+    "    ]"
+)
+if item10 not in html:
+    raise SystemExit("Typedesk ItemList tail missing; Tagshop patch requires the verified Typedesk build step first")
+html = html.replace(item10, item11, 1)
+
+closing = '''    </section>\n\n    <section class="rounded-3xl border border-white/10 bg-[#11131a] p-7 md:p-9">\n      <h2 class="text-2xl font-black text-white">How this list is gated</h2>'''
+if closing not in html:
+    raise SystemExit("Buyer-hub final grid boundary changed; refusing blind Tagshop patch")
+
+card = f'''      {MARKER}\n      <article class="rounded-3xl border border-fuchsia-400/25 bg-[#11131a] p-7 space-y-5">\n        <div class="flex items-start justify-between gap-4"><div><div class="text-xs font-black uppercase tracking-wider text-fuchsia-300">AI UGC video ads</div><h2 class="mt-1 text-3xl font-black text-white">Tagshop AI</h2></div><span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">14-day trial · no card</span></div>\n        <p class="text-sm leading-6 text-slate-300">Tagshop's current official help center lists a <strong class="text-white">14-day free trial with full platform access and no credit card required</strong>. Tagshop also directly confirmed to COSHUMA on September 12, 2026 that the exact issued referral URL below automatically tracks referrals and conversions across the site.</p>\n        <div class="grid gap-3 sm:grid-cols-2"><a data-cta="affiliate" data-tool-id="tagshop-ai" data-cta-source="verified-deals-tagshop-issued-referral" data-cta-page="verified-software-free-trials-deals" href="{TRACKING_URL}" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl bg-fuchsia-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-fuchsia-500">Start Tagshop trial via verified referral →</a><a href="/best/tagshop-ai-free-trial-pricing.html" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Read trial & pricing guide</a></div>\n        <p class="text-[11px] leading-5 text-slate-500">COSHUMA uses only Tagshop's exact issued referral entry URL; no separate pricing/trial affiliate deep link has been issued or inferred. A click, referred signup, paying customer, commission or payout is not counted without partner-side evidence.</p>\n      </article>\n'''
+
+html = html.replace(closing, card + closing, 1)
+
+required = [
+    TRACKING_URL,
+    'data-cta-source="verified-deals-tagshop-issued-referral"',
+    "14-day free trial with full platform access and no credit card required",
+    "no separate pricing/trial affiliate deep link has been issued or inferred",
+    "not counted without partner-side evidence",
+]
+for token in required:
+    if token not in html:
+        raise SystemExit(f"Tagshop buyer-hub patch lost required token: {token}")
+if ADMIN_URL in html:
+    raise SystemExit("Tagshop admin dashboard URL leaked into the public buyer hub")
+
+PAGE.write_text(html, encoding="utf-8")
+print("Surfaced verified Tagshop referral route on buyer hub")

--- a/projects/GlobalSaaSHub/scripts/surface_tally_referral_offer.py
+++ b/projects/GlobalSaaSHub/scripts/surface_tally_referral_offer.py
@@ -73,6 +73,15 @@ else:
     PAGE.write_text(html, encoding="utf-8")
     print("Surfaced verified Tally referral offer on buyer hub")
 
-# This step intentionally runs after Tally because the Typedesk patch extends the
-# generated ItemList from position 9 to 10 and requires Tally's verified build state.
-runpy.run_path(str(ROOT / "scripts" / "surface_typedesk_verified_offer.py"), run_name="__main__")
+# Typedesk extends the generated ItemList from position 9 to 10. On repeated
+# builds its idempotence guard exits with code 0, so catch only that normal stop
+# and continue to the Tagshop step. Any non-zero safety failure still aborts.
+try:
+    runpy.run_path(str(ROOT / "scripts" / "surface_typedesk_verified_offer.py"), run_name="__main__")
+except SystemExit as exc:
+    if exc.code not in (None, 0):
+        raise
+
+# Tagshop runs after Typedesk because it extends the generated ItemList from 10
+# to 11 and must see the exact verified Typedesk state first.
+runpy.run_path(str(ROOT / "scripts" / "surface_tagshop_verified_offer.py"), run_name="__main__")


### PR DESCRIPTION
## Revenue objective
Increase exposure to an already approved, vendor-confirmed Tagshop revenue route on COSHUMA's central verified trials/offers hub without creating a new account, reapplying, or inventing a deep link.

## Evidence
- Exact COSHUMA customer referral URL already issued by Tagshop: `https://tagshop.ai?via=coshuma-22501e`.
- Priyanka Sain confirmed on 2026-09-12 that this exact entry URL automatically tracks referrals and conversions across the site.
- Tagshop did **not** issue a separate pricing/trial affiliate deep link, so this change keeps the exact issued entry URL unchanged.
- Tagshop's official help center currently states a 14-day free trial with full platform access and no credit card required.

## Changes
- Adds an idempotent `surface_tagshop_verified_offer.py` build patch.
- Chains it after the existing Tally → Typedesk verified-offer steps.
- Adds Tagshop AI as ItemList position 11 on the central verified offers hub.
- Adds a distinct tracked CTA source and links to the existing Tagshop free-trial/pricing guide.
- Records the source/evidence and strict revenue-truth boundary in repository data.

## Guardrails
- No paid action.
- No duplicate application/account.
- No generic dashboard/onboarding URL used as a customer revenue link.
- FirstPromoter admin URL is explicitly blocked from the public hub.
- No pricing/trial deep link is guessed from the `via` parameter.
- No click, signup, paying customer, commission, payout, or revenue is inferred from publication or attribution confirmation.