### PR TITLE
Revenue: surface verified Kittl free plan on buyer hub

### DIFF
--- a/projects/GlobalSaaSHub/data/kittl-buyer-hub-revenue-route-2026-09-12.md
+++ b/projects/GlobalSaaSHub/data/kittl-buyer-hub-revenue-route-2026-09-12.md
@@ -1,0 +1,35 @@
+# Kittl buyer-hub revenue route — 2026-09-12
+
+## Existing COSHUMA tracking evidence
+
+- Affiliate state: `approved_tracking`.
+- Exact customer-facing tracking URL already verified in the authenticated Impact account: `https://kittl.pxf.io/0GMrXY`.
+- Destination: official Kittl customer site.
+- Existing repository evidence says the Kittl program was already approved and the Impact **Create a link** tool issued this exact URL; the resulting customer page retained Impact attribution parameters.
+- This work does not create a second account or application and does not alter the issued tracking URL.
+
+## Fresh first-party Kittl facts rechecked 2026-09-12
+
+- Free-plan help: https://help.kittl.com/subscription-billing/about-free-plan/
+  - Free forever with no expiry.
+  - 5 active projects and 500 MB uploaded-file storage.
+  - 200 one-time AI tokens.
+  - PNG/JPG export up to 800 px / 72 dpi.
+  - Free-plan designs are for personal use only; commercial use requires an eligible paid plan.
+- Pricing: https://www.kittl.com/pricing
+  - Kittl still offers a Free plan and says paid plans add commercial licensing, high-resolution/vector export, premium content and larger AI/storage allowances.
+- Affiliate program: https://www.kittl.com/partners/affiliates
+  - Kittl states affiliates can earn up to $72 for a new Kittl Expert subscriber.
+  - Kittl states affiliate commission applies to payments during the first 12 months.
+  - Tracking/reporting and automatic payouts are described by Kittl.
+
+## Revenue decision
+
+Surface the already verified Kittl customer tracking route on COSHUMA's verified buyer-offer hub and link to the existing commercial-use guide. Present the Free plan as a low-risk test, but clearly preserve the personal-use limitation so a free-plan visitor is not encouraged to use it commercially.
+
+## Guardrails
+
+- Do not invent a Kittl pricing/trial deep link.
+- Do not use Impact login, dashboard or onboarding URLs as customer CTAs.
+- Do not infer clicks, signups, paid customers, commission, payout or revenue from publication, HTTP success or the Free plan.
+- No paid subscription, test purchase, self-referral or payout-setting change.

--- a/projects/GlobalSaaSHub/scripts/normalize_sponsorship_offer.py
+++ b/projects/GlobalSaaSHub/scripts/normalize_sponsorship_offer.py
@@ -132,6 +132,7 @@ def main() -> None:
         "surface_claap_verified_offer.py",
         "surface_writesonic_verified_offer.py",
         "surface_moosend_verified_offer.py",
+        "surface_kittl_verified_offer.py",
     ):
         try:
             runpy.run_path(str(ROOT / "scripts" / script_name), run_name="__main__")

--- a/projects/GlobalSaaSHub/scripts/surface_kittl_verified_offer.py
+++ b/projects/GlobalSaaSHub/scripts/surface_kittl_verified_offer.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGE = ROOT / "public" / "best" / "verified-software-free-trials-deals.html"
+MARKER = "<!-- COSHUMA_KITTL_VERIFIED_OFFER -->"
+TRACKING_URL = "https://kittl.pxf.io/0GMrXY"
+GUIDE_URL = "/best/kittl-commercial-use-license.html"
+OFFICIAL_AFFILIATE = "https://www.kittl.com/partners/affiliates"
+ADMIN_HOSTS = (
+    "app.impact.com",
+    "impact.com/login",
+    "impact.com/dashboard",
+)
+
+if not PAGE.exists():
+    raise SystemExit(f"Missing buyer hub: {PAGE}")
+
+html = PAGE.read_text(encoding="utf-8")
+
+# Evidence guard:
+# - Repository approved-tracking evidence records the exact customer-facing Impact
+#   route above for COSHUMA's already-approved Kittl relationship.
+# - Kittl first-party help/pricing pages rechecked 2026-09-12 say Free is free
+#   forever, allows 5 active projects and 200 one-time AI tokens, and is limited to
+#   personal use. Paid plans provide commercial licensing and stronger exports.
+# - Kittl's first-party affiliate page says affiliates can earn up to $72 for a new
+#   Expert subscriber and earn commission on payments during the first 12 months.
+# - We do not manufacture a pricing deep link or reuse any Impact admin URL.
+if MARKER in html:
+    if TRACKING_URL not in html:
+        raise SystemExit("Kittl verified block exists but exact approved tracking URL is missing")
+    if any(host in html for host in ADMIN_HOSTS):
+        raise SystemExit("Kittl affiliate admin URL leaked into the public buyer hub")
+    print("Kittl verified offer already surfaced")
+    raise SystemExit(0)
+
+old_meta = (
+    "Compare verified SaaS free trials and partner offers from Gamma, Time2book, "
+    "UpLead, Jotform, Unbounce, Pictory, Brand24, Bookyourdata, Tally, Typedesk, "
+    "Tagshop AI, RGE Studio, BoldSign, Teachable, Murf AI, Claap, Writesonic and Moosend. COSHUMA separates customer-facing tracking links from product claims."
+)
+new_meta = (
+    "Compare verified SaaS free trials and partner offers from Gamma, Time2book, "
+    "UpLead, Jotform, Unbounce, Pictory, Brand24, Bookyourdata, Tally, Typedesk, "
+    "Tagshop AI, RGE Studio, BoldSign, Teachable, Murf AI, Claap, Writesonic, Moosend and Kittl. COSHUMA separates customer-facing tracking links from product claims."
+)
+if old_meta not in html:
+    raise SystemExit("Buyer-hub meta description changed; refusing blind Kittl patch")
+html = html.replace(old_meta, new_meta, 1)
+
+item18 = (
+    '      {"@type":"ListItem","position":18,"name":"Moosend",'
+    '"url":"https://coshuma.com/best/moosend-free-trial.html"}\n'
+    "    ]"
+)
+item19 = (
+    '      {"@type":"ListItem","position":18,"name":"Moosend",'
+    '"url":"https://coshuma.com/best/moosend-free-trial.html"},\n'
+    '      {"@type":"ListItem","position":19,"name":"Kittl",'
+    '"url":"https://coshuma.com/best/kittl-commercial-use-license.html"}\n'
+    "    ]"
+)
+if item18 not in html:
+    raise SystemExit("Moosend ItemList tail missing; Kittl patch requires the verified Moosend build step first")
+html = html.replace(item18, item19, 1)
+
+closing = '''    </section>\n\n    <section class="rounded-3xl border border-white/10 bg-[#11131a] p-7 md:p-9">\n      <h2 class="text-2xl font-black text-white">How this list is gated</h2>'''
+if closing not in html:
+    raise SystemExit("Buyer-hub final grid boundary changed; refusing blind Kittl patch")
+
+card = f'''      {MARKER}\n      <article class="rounded-3xl border border-emerald-400/25 bg-[#11131a] p-7 space-y-5">\n        <div class="flex items-start justify-between gap-4"><div><div class="text-xs font-black uppercase tracking-wider text-emerald-300">AI design & commercial licensing</div><h2 class="mt-1 text-3xl font-black text-white">Kittl</h2></div><span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">Free forever</span></div>\n        <p class="text-sm leading-6 text-slate-300">Kittl's current Free plan has <strong class="text-white">no expiry</strong>, includes <strong class="text-white">5 active projects</strong> and <strong class="text-white">200 one-time AI tokens</strong>, and is designed for testing and personal projects. Kittl explicitly limits Free-plan designs to <strong class="text-white">personal use</strong>; use the licensing guide before client, POD or other commercial work.</p>\n        <p class="text-sm leading-6 text-slate-300">COSHUMA uses the exact customer-facing Impact route already verified for its existing Kittl affiliate account. Kittl's current affiliate page says partners can earn up to <strong class="text-white">$72</strong> for a new Expert subscriber and commission on payments during the first <strong class="text-white">12 months</strong>. Those are partner terms, not a buyer discount or a revenue claim.</p>\n        <div class="grid gap-3 sm:grid-cols-2"><a data-cta="affiliate" data-tool-id="kittl" data-cta-source="verified-deals-kittl-approved-link" data-cta-page="verified-software-free-trials-deals" href="{TRACKING_URL}" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl bg-emerald-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-emerald-500">Try Kittl Free →</a><a href="{GUIDE_URL}" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Check commercial-use license</a></div>\n        <a href="{OFFICIAL_AFFILIATE}" target="_blank" rel="noopener noreferrer" class="inline-block text-xs font-bold text-emerald-200 hover:text-white">Verify Kittl affiliate terms →</a>\n        <p class="text-[11px] leading-5 text-slate-500">The first button preserves the exact Kittl customer-facing Impact URL already verified for COSHUMA. COSHUMA does not guess a pricing deep link. A click, free account, paid customer, commission, payout or revenue is not counted without partner-side evidence.</p>\n      </article>\n'''
+
+html = html.replace(closing, card + closing, 1)
+
+required = [
+    TRACKING_URL,
+    GUIDE_URL,
+    'data-cta-source="verified-deals-kittl-approved-link"',
+    "Free plan has <strong class=\"text-white\">no expiry</strong>",
+    "5 active projects",
+    "200 one-time AI tokens",
+    "personal use",
+    "up to <strong class=\"text-white\">$72</strong>",
+    "first <strong class=\"text-white\">12 months</strong>",
+    "not a buyer discount or a revenue claim",
+    "not counted without partner-side evidence",
+]
+for token in required:
+    if token not in html:
+        raise SystemExit(f"Kittl buyer-hub patch lost required token: {token}")
+if any(host in html for host in ADMIN_HOSTS):
+    raise SystemExit("Kittl affiliate admin URL leaked into the public buyer hub")
+
+PAGE.write_text(html, encoding="utf-8")
+print("Surfaced verified Kittl free-plan route on buyer hub")


### PR DESCRIPTION
## Revenue objective
Increase exposure of an already-approved Kittl revenue path at zero additional cost.

## Evidence
- Existing repository state already verifies the exact COSHUMA customer-facing Impact URL: `https://kittl.pxf.io/0GMrXY`.
- Kittl first-party pages rechecked 2026-09-12 confirm the Free plan is free forever, includes 5 active projects and 200 one-time AI tokens, and is personal-use only.
- Kittl's current affiliate page states affiliates can earn up to $72 for a new Expert subscriber and commission on payments during the first 12 months.

## Change
- Add a Kittl card to the verified buyer-offer hub after the existing Moosend build step.
- Keep the exact issued Impact URL; do not manufacture a pricing deep link.
- Link to the existing COSHUMA Kittl commercial-use guide so visitors do not mistake the Free plan for commercial licensing.
- Add fail-closed guards against Impact admin URLs and missing upstream hub state.

## Revenue-truth guard
Publication, clicks, free accounts, paid customers, commission, payout and revenue remain separate evidence stages. This PR does not claim any new conversion or earnings.

## Cost / safety
- $0 additional cost.
- No new Kittl account or affiliate application.
- No payment, self-referral, payout-setting change, or guessed tracking URL.