### PR TITLE
Revenue: add Unbounce lead-handoff buyer guidance

### DIFF
--- a/projects/GlobalSaaSHub/data/unbounce-conversion-guidance-2026-09-13.md
+++ b/projects/GlobalSaaSHub/data/unbounce-conversion-guidance-2026-09-13.md
@@ -1,0 +1,42 @@
+# Unbounce conversion guidance — 2026-09-13
+
+## Why this evidence matters
+COSHUMA's older Search Console snapshot showed the query `unbounce` receiving 82 impressions and 0 clicks. Unbounce is now `approved_tracking`, so improving buyer-fit and conversion guidance on the existing Unbounce page is a zero-cost revenue task. The snapshot is historical traffic evidence only; it is not proof of current clicks or revenue.
+
+## Fresh first-party partner email
+- Company mailbox: `support@coshuma.com`
+- Gmail message ID: `1a09606cd37312f7`
+- Sender: Anastasia Kaploun / Unbounce
+- Received: 2026-09-12 14:30:21 UTC
+- Subject: `Unbounce partner tips: Making your referrals stick around`
+
+The Unbounce Affiliate Team reconfirmed COSHUMA's exact customer-facing referral URL:
+- `https://unbounce.partnerlinks.io/5ubjnt8lluqi`
+
+The same email advised affiliates to explain how captured leads can move into the buyer's existing marketing stack. It specifically referenced:
+- direct integrations such as Mailchimp, Marketo and Salesforce,
+- Zapier,
+- Webhooks,
+- Smart Traffic for automated visitor-to-variant routing.
+
+The email also stated that Smart Traffic is available on Optimize and higher. COSHUMA does not use the email's promotional lift claim as a guaranteed outcome.
+
+## Official public sources rechecked 2026-09-13
+- Pricing: `https://unbounce.com/pricing/`
+  - Starter $29/mo, Build $99/mo, Experiment $149/mo, Optimize $249/mo.
+  - 14-day free trial, no credit card required.
+  - Build lists 1000+ integrations.
+- Integrations: `https://unbounce.com/product/integrations/`
+  - Unbounce supports in-app integrations plus additional connections through Zapier and Webhooks.
+- Smart Traffic documentation: `https://documentation.unbounce.com/hc/en-us/articles/360036411591-What-is-Smart-Traffic`
+  - Smart Traffic learns which page variant is more likely to convert for different visitors and routes traffic accordingly after an initial learning phase.
+- Unbounce MCP page: `https://unbounce.com/product/mcp-server/`
+  - Smart Traffic is available on Optimize and higher.
+
+## Safe conversion-copy decision
+The existing Unbounce buyer page may explain integrations and Smart Traffic as reasons to test product fit, but must not claim that a visitor will personally achieve a conversion lift. The CTA must remain on the exact verified partner URL above; no pricing/trial deep link is invented.
+
+## Revenue-truth boundary
+- This email is partner guidance and referral-link confirmation.
+- It does not prove a new click, signup, trial, paid customer, commission or payout.
+- Any downstream revenue remains unverified until partner/dashboard evidence shows it.

--- a/projects/GlobalSaaSHub/public/affiliate-attribution.js
+++ b/projects/GlobalSaaSHub/public/affiliate-attribution.js
@@ -102,17 +102,54 @@
   }
 
   function enhanceVerifiedPartnerOffers() {
-    if (!/\/tool\/make-com\.html$/.test(window.location.pathname)) return;
-    if (document.querySelector('[data-partner-offer="make-pro-welcome"]')) return;
+    if (/\/tool\/make-com\.html$/.test(window.location.pathname)) {
+      if (!document.querySelector('[data-partner-offer="make-pro-welcome"]')) {
+        const primaryCta = document.querySelector('a[data-cta="affiliate"][data-tool-id="make-com"]');
+        if (primaryCta && primaryCta.href.includes('pc=coshuma')) {
+          const offer = document.createElement('div');
+          offer.dataset.partnerOffer = 'make-pro-welcome';
+          offer.className = 'mt-3 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-xs leading-relaxed text-emerald-100';
+          offer.innerHTML = '<strong>Partner welcome offer:</strong> Make says new users who sign up through this verified partner link automatically receive their first month of Pro (10,000 operations) free. Confirm the offer is shown during signup before relying on it.';
+          primaryCta.insertAdjacentElement('afterend', offer);
+        }
+      }
+    }
 
-    const primaryCta = document.querySelector('a[data-cta="affiliate"][data-tool-id="make-com"]');
-    if (!primaryCta || !primaryCta.href.includes('pc=coshuma')) return;
+    if (/\/tool\/unbounce\.html$/.test(window.location.pathname)) {
+      if (!document.querySelector('[data-partner-offer="unbounce-conversion-fit"]')) {
+        const verifiedUrl = 'https://unbounce.partnerlinks.io/5ubjnt8lluqi';
+        const primaryCta = document.querySelector('a[data-cta="affiliate"][data-tool-id="unbounce"]');
+        const sections = Array.from(document.querySelectorAll('main > section'));
+        const attributionSection = sections.find(function (section) {
+          const heading = section.querySelector('h2');
+          return heading && /verified link before starting your trial/i.test(heading.textContent || '');
+        });
 
-    const offer = document.createElement('div');
-    offer.dataset.partnerOffer = 'make-pro-welcome';
-    offer.className = 'mt-3 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-xs leading-relaxed text-emerald-100';
-    offer.innerHTML = '<strong>Partner welcome offer:</strong> Make says new users who sign up through this verified partner link automatically receive their first month of Pro (10,000 operations) free. Confirm the offer is shown during signup before relying on it.';
-    primaryCta.insertAdjacentElement('afterend', offer);
+        if (primaryCta && primaryCta.href.startsWith(verifiedUrl) && attributionSection) {
+          const guide = document.createElement('section');
+          guide.dataset.partnerOffer = 'unbounce-conversion-fit';
+          guide.className = 'rounded-3xl border border-cyan-500/20 bg-cyan-500/5 p-6 md:p-8 space-y-5';
+          guide.innerHTML = [
+            '<div>',
+            '<div class="text-xs uppercase tracking-widest text-cyan-300 font-bold">Before you pay</div>',
+            '<h2 class="text-3xl font-black text-white mt-1">Test what happens after the form submit</h2>',
+            '<p class="text-sm text-slate-300 leading-relaxed mt-2">A fresh Unbounce Affiliate Team message to COSHUMA emphasized lead handoff as a retention use case. That makes integrations a practical buying test: confirm that captured leads can reach the CRM, email or automation stack you already use before choosing a paid plan.</p>',
+            '</div>',
+            '<div class="grid md:grid-cols-3 gap-3">',
+            '<div class="rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-5"><div class="text-xs uppercase tracking-wider text-cyan-300 font-bold">Direct handoff</div><div class="mt-2 text-sm text-slate-300 leading-relaxed">Unbounce lists native connections including Mailchimp, Marketo and Salesforce; its current Build plan also advertises 1000+ integrations.</div></div>',
+            '<div class="rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-5"><div class="text-xs uppercase tracking-wider text-cyan-300 font-bold">Automation bridge</div><div class="mt-2 text-sm text-slate-300 leading-relaxed">If your app is not a direct integration, Unbounce supports Zapier and Webhooks for moving captured lead data into other systems.</div></div>',
+            '<div class="rounded-2xl border border-[#2a2e42] bg-[#0d1018] p-5"><div class="text-xs uppercase tracking-wider text-cyan-300 font-bold">Optimization fit</div><div class="mt-2 text-sm text-slate-300 leading-relaxed">Smart Traffic routes visitors toward the page variant it predicts is more likely to convert. Unbounce currently positions Smart Traffic on Optimize and higher.</div></div>',
+            '</div>',
+            '<p class="text-xs text-slate-500 leading-relaxed">These are product-fit checks, not promised results. COSHUMA does not claim a conversion lift, signup or commission unless first-party reporting verifies it.</p>',
+            '<div class="flex flex-col sm:flex-row gap-3">',
+            '<a data-cta="affiliate" data-tool-id="unbounce" data-cta-source="unbounce-integration-fit" href="' + verifiedUrl + '" target="_blank" rel="sponsored noopener noreferrer" class="px-6 py-3.5 rounded-xl bg-cyan-600 hover:bg-cyan-500 text-white font-extrabold text-center">Test Unbounce through the verified partner route →</a>',
+            '<a href="https://unbounce.com/product/integrations/" target="_blank" rel="noopener noreferrer" class="px-6 py-3.5 rounded-xl border border-cyan-500/30 bg-cyan-500/5 text-cyan-100 font-bold text-center hover:bg-cyan-500/10">Check Unbounce integrations →</a>',
+            '</div>'
+          ].join('');
+          attributionSection.insertAdjacentElement('beforebegin', guide);
+        }
+      }
+    }
   }
 
   const attribution = sessionAttribution();


### PR DESCRIPTION
## Revenue objective
Improve the existing Unbounce buyer path using fresh first-party partner guidance, without changing the verified affiliate URL or inventing a deep link.

## Evidence
- Fresh Unbounce Affiliate Team email to `support@coshuma.com` (Gmail `1a09606cd37312f7`) reconfirmed the exact COSHUMA referral URL and advised partners to explain lead handoff through direct integrations, Zapier/Webhooks, and Smart Traffic.
- Current official Unbounce pricing was rechecked: Starter $29, Build $99, Experiment $149, Optimize $249, with a 14-day no-card trial.
- Official Unbounce integrations pages confirm native integrations plus Zapier/Webhooks.
- Official Smart Traffic documentation confirms visitor-to-variant routing behavior; current Unbounce material places Smart Traffic on Optimize and higher.

## Change
- Record the fresh vendor/public evidence in `data/unbounce-conversion-guidance-2026-09-13.md`.
- Add an idempotent buyer-fit section to `/tool/unbounce.html` through the already-loaded attribution script.
- New section asks buyers to test the post-form lead handoff, explains direct integrations / Zapier / Webhooks / Smart Traffic, and uses only the existing exact verified partner route `https://unbounce.partnerlinks.io/5ubjnt8lluqi`.
- New affiliate CTA receives `data-cta-source="unbounce-integration-fit"` so GA4 can measure this placement separately.

## Guardrails
- No pricing/trial affiliate deep link invented.
- No guaranteed conversion-lift claim.
- No signup, paid customer, commission, payout or revenue inferred from publication or clicks.
- No paid service or subscription.