### PR TITLE
Revenue: add Kittl vs Canva commercial-use buyer guide

### DIFF
--- a/projects/GlobalSaaSHub/data/kittl-vs-canva-commercial-use-evidence-2026-09-13.md
+++ b/projects/GlobalSaaSHub/data/kittl-vs-canva-commercial-use-evidence-2026-09-13.md
@@ -1,0 +1,46 @@
+# Kittl vs Canva commercial-use buyer evidence — 2026-09-13
+
+## Revenue objective
+Create a high-intent commercial-design comparison that can route qualified buyers to COSHUMA's already-verified Kittl customer tracking URL without inventing a Canva affiliate relationship or changing any existing partner state.
+
+## Existing COSHUMA Kittl tracking evidence
+- Affiliate state: `approved_tracking`.
+- Exact customer-facing Impact URL: `https://kittl.pxf.io/0GMrXY`.
+- Repository evidence already records that the authenticated Impact account issued this exact customer route and that the destination is Kittl's official customer site.
+- Do not manufacture a `/pricing` or other deep link from the Impact URL unless Impact/Kittl explicitly issues it.
+
+## Current first-party Kittl facts rechecked 2026-09-13
+Sources:
+- https://www.kittl.com/
+- https://www.kittl.com/pricing
+- https://help.kittl.com/subscription-billing/about-free-plan/
+- https://help.kittl.com/subscription-billing/about-pro-plan/
+- https://www.kittl.com/partners/affiliates
+
+Verified facts used on the buyer page:
+- Free is free forever and intended for personal use only.
+- Free currently includes 5 active projects, 500 MB upload storage, 200 AI tokens, and PNG/JPG exports up to 800px at 72dpi.
+- Paid Kittl plans add commercial licensing plus high-resolution/vector exports; Kittl's Pro help page currently states a commercial license for up to 500,000 copies and high-res/vector exports.
+- Kittl's public homepage currently lists Pro at $19/month and Expert at $49/month; checkout/localized pricing can vary, so the buyer page tells visitors to verify the live checkout price.
+- Kittl's public affiliate page currently states 20% of payments for 12 months and says up to $72 can be earned for a new Expert subscriber.
+
+## Current first-party Canva facts rechecked 2026-09-13
+Sources:
+- https://www.canva.com/pro/
+- https://www.canva.com/help/ai-access-variantb/
+- https://www.canva.com/licensing-explained/
+- https://www.canva.com/policies/content-license-agreement/
+
+Verified facts used on the buyer page:
+- Canva Free has a monthly AI allowance; the current help page lists up to 20 uses of Standard AI tools or Premium AI tools under the stated conditions, with no Ultra AI access on Free.
+- Canva Pro is positioned for individual creators, while Canva Business adds more advanced team/brand/AI capabilities.
+- Canva permits a wide range of personal and commercial uses for eligible content inside Canva designs, including marketing/social and merchandise, subject to the Content License Agreement.
+- Canva prohibits reselling/redistributing its content on a standalone basis and applies additional restrictions to certain content such as Popular Music; the comparison therefore tells buyers to review the exact asset license before selling a design.
+- No COSHUMA-specific Canva affiliate tracking URL is verified for this page. Canva destinations remain official non-affiliate links.
+
+## Revenue-truth guardrails
+- Page publication is not a click, signup, paid customer, commission, payout or revenue event.
+- A Kittl affiliate click is still only a click until Impact/vendor-side evidence proves a downstream conversion.
+- Do not infer Canva affiliate status.
+- Do not change payout settings, self-refer, purchase a plan, or create a duplicate Kittl application/account.
+- No paid resource is required for this change.

--- a/projects/GlobalSaaSHub/public/best/kittl-vs-canva-commercial-use.html
+++ b/projects/GlobalSaaSHub/public/best/kittl-vs-canva-commercial-use.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kittl vs Canva for Commercial Use, POD & Merch (2026) | COSHUMA</title>
+  <meta name="description" content="Kittl vs Canva for commercial design in 2026: compare free-plan limits, licensing, POD and merchandise fit, exports, AI allowances and which tool to test before paying." />
+  <link rel="canonical" href="https://coshuma.com/best/kittl-vs-canva-commercial-use.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="COSHUMA" />
+  <meta property="og:url" content="https://coshuma.com/best/kittl-vs-canva-commercial-use.html" />
+  <meta property="og:title" content="Kittl vs Canva for Commercial Use, POD & Merch (2026)" />
+  <meta property="og:description" content="A buyer-focused comparison for people choosing a design tool for client work, POD, merch and commercial content." />
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"Kittl vs Canva for Commercial Use, POD & Merch (2026)",
+    "dateModified":"2026-09-13",
+    "author":{"@type":"Organization","name":"COSHUMA"},
+    "publisher":{"@type":"Organization","name":"COSHUMA"},
+    "mainEntityOfPage":"https://coshuma.com/best/kittl-vs-canva-commercial-use.html"
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"Can I use Kittl Free for commercial work?","acceptedAnswer":{"@type":"Answer","text":"Kittl currently says its Free plan is for personal use only. Its paid plans add commercial licensing, so sellers and client-work users should verify the paid-plan license that matches their intended use before publishing or selling."}},
+      {"@type":"Question","name":"Can I use Canva designs commercially?","acceptedAnswer":{"@type":"Answer","text":"Canva allows a broad range of commercial uses for eligible Free and Pro content inside Canva designs, subject to its Content License Agreement. Standalone resale or redistribution of Canva content is restricted, and some content types have additional rules."}},
+      {"@type":"Question","name":"Which is better for print-on-demand: Kittl or Canva?","acceptedAnswer":{"@type":"Answer","text":"Kittl is the more focused first test if your workflow centers on typography, product graphics, mockups, high-resolution/vector exports and a clearly stated paid commercial license. Canva is broader when your commercial workflow also includes social, presentations, video and wider brand content."}},
+      {"@type":"Question","name":"What is the lowest-risk way to choose?","acceptedAnswer":{"@type":"Answer","text":"Build the same real product graphic in both tools, then compare editing time, export quality, asset licensing, mockup workflow and whether the paid features remove a real production bottleneck before upgrading."}}
+    ]
+  }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="/affiliate-attribution.js"></script>
+  <style>body{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}</style>
+</head>
+<body class="bg-[#08090d] text-slate-100 antialiased">
+  <header class="sticky top-0 z-50 border-b border-white/10 bg-[#0c0e14]/95 backdrop-blur">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-5 py-4">
+      <a href="/" class="text-xl font-black tracking-tight text-white">COSHUMA</a>
+      <a href="/best/" class="text-sm font-bold text-slate-400 hover:text-white">Buyer guides →</a>
+    </div>
+  </header>
+
+  <main class="mx-auto max-w-6xl px-5 py-12 sm:py-16">
+    <nav class="mb-7 text-sm text-slate-500"><a class="hover:text-white" href="/">Home</a><span class="px-2">/</span><a class="hover:text-white" href="/best/">Buyer guides</a><span class="px-2">/</span>Kittl vs Canva</nav>
+
+    <section class="grid gap-8 lg:grid-cols-[1.35fr_.65fr] lg:items-start">
+      <div>
+        <div class="mb-5 inline-flex rounded-full border border-fuchsia-400/20 bg-fuchsia-400/10 px-3 py-1 text-xs font-bold text-fuchsia-200">Official licensing and plan pages rechecked September 13, 2026</div>
+        <h1 class="text-4xl font-black tracking-[-0.04em] text-white sm:text-6xl">Kittl vs Canva for commercial use: choose by what you plan to sell</h1>
+        <p class="mt-5 max-w-3xl text-lg leading-8 text-slate-300"><strong class="text-white">Kittl is the more focused first test for product graphics, typography-heavy designs, mockups and paid commercial licensing.</strong> <strong class="text-white">Canva is broader when the same business also needs social posts, presentations, video and general brand content.</strong> The license is part of the buying decision, not a footnote.</p>
+        <div class="mt-7 flex flex-col gap-3 sm:flex-row">
+          <a data-cta="affiliate" data-tool-id="kittl" data-cta-source="kittl_canva_commercial_hero" href="https://kittl.pxf.io/0GMrXY" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl bg-fuchsia-600 px-6 py-4 text-center font-black text-white hover:bg-fuchsia-500">Start with Kittl Free →</a>
+          <a data-cta="official" href="https://www.canva.com/" target="_blank" rel="noopener noreferrer" class="rounded-xl border border-white/15 bg-white/[0.04] px-6 py-4 text-center font-bold text-slate-200 hover:bg-white/[0.08]">Open Canva official site →</a>
+        </div>
+        <p class="mt-3 text-xs leading-5 text-slate-500">Affiliate disclosure: the Kittl button uses COSHUMA's exact Impact-issued customer tracking route. Canva links on this page are official non-affiliate links. A click, account creation or trial is not treated as revenue unless partner-side evidence confirms a qualifying paid conversion.</p>
+      </div>
+
+      <aside class="rounded-3xl border border-fuchsia-400/20 bg-fuchsia-400/[0.06] p-6">
+        <div class="text-xs font-black uppercase tracking-widest text-fuchsia-300">Fast buyer decision</div>
+        <dl class="mt-5 space-y-4 text-sm">
+          <div><dt class="text-slate-500">Test Kittl first</dt><dd class="mt-1 font-bold text-white">POD, merch, product graphics, typography, mockups, high-res/vector output</dd></div>
+          <div><dt class="text-slate-500">Test Canva first</dt><dd class="mt-1 font-bold text-white">Broad brand content, social, presentations, video and team marketing workflows</dd></div>
+          <div><dt class="text-slate-500">Do not skip</dt><dd class="mt-1 font-bold text-white">Check the exact asset/license rules for what you plan to sell</dd></div>
+        </dl>
+      </aside>
+    </section>
+
+    <section class="mt-14 rounded-3xl border border-white/10 bg-[#11131a] p-6 sm:p-8">
+      <h2 class="text-3xl font-black text-white">The biggest difference starts on the free plans</h2>
+      <div class="mt-6 overflow-x-auto">
+        <table class="w-full min-w-[820px] text-left text-sm">
+          <thead class="text-slate-400"><tr class="border-b border-white/10"><th class="py-3 pr-4">Decision point</th><th class="py-3 pr-4">Kittl</th><th class="py-3 pr-4">Canva</th><th class="py-3">Buyer takeaway</th></tr></thead>
+          <tbody class="text-slate-300">
+            <tr class="border-b border-white/10"><td class="py-4 pr-4 font-bold text-white">Free access</td><td class="py-4 pr-4">Free forever; 5 active projects; 500 MB upload storage; 200 AI tokens</td><td class="py-4 pr-4">Free plan with a monthly AI allowance; Canva's current help page lists up to 20 uses under its stated Free-plan conditions</td><td class="py-4">Use Free to test workflow, not to assume commercial rights are identical.</td></tr>
+            <tr class="border-b border-white/10"><td class="py-4 pr-4 font-bold text-white">Commercial use</td><td class="py-4 pr-4">Kittl says Free is personal-use only; paid plans add commercial licensing</td><td class="py-4 pr-4">Eligible Canva content can be used in many commercial designs, subject to Canva's license and content-specific restrictions</td><td class="py-4">If you sell products, read the license before choosing the cheapest plan.</td></tr>
+            <tr class="border-b border-white/10"><td class="py-4 pr-4 font-bold text-white">Export direction</td><td class="py-4 pr-4">Free PNG/JPG up to 800px and 72dpi; paid plans add high-res and vector export</td><td class="py-4 pr-4">Broad design/export workflow across many content formats; exact premium features depend on plan</td><td class="py-4">For print/POD, test the exact file type and resolution your supplier needs.</td></tr>
+            <tr><td class="py-4 pr-4 font-bold text-white">Workflow breadth</td><td class="py-4 pr-4">Focused on design, product visuals, templates, mockups, vectors and AI-assisted creation</td><td class="py-4 pr-4">Broader visual-content workspace spanning social, presentations, video, documents and brand work</td><td class="py-4">Choose the tool that matches your repeatable weekly work, not the longest feature list.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="mt-14 grid gap-6 lg:grid-cols-2">
+      <article class="rounded-3xl border border-fuchsia-400/20 bg-fuchsia-400/[0.05] p-6 sm:p-8">
+        <div class="text-xs font-black uppercase tracking-widest text-fuchsia-300">Kittl is the better first test when…</div>
+        <h2 class="mt-2 text-2xl font-black text-white">Your revenue comes from products, merch or design deliverables</h2>
+        <ul class="mt-5 space-y-3 text-sm leading-6 text-slate-300">
+          <li>✓ Typography, product graphics and mockups are central to the workflow.</li>
+          <li>✓ You need high-resolution or vector exports for production.</li>
+          <li>✓ You want the paid plan's commercial-license terms spelled out before scaling.</li>
+          <li>✓ You are willing to upgrade only after a real product design proves the workflow fits.</li>
+        </ul>
+        <a data-cta="affiliate" data-tool-id="kittl" data-cta-source="kittl_canva_commercial_kittl_box" href="https://kittl.pxf.io/0GMrXY" target="_blank" rel="sponsored nofollow noopener noreferrer" class="mt-6 block rounded-xl bg-fuchsia-600 px-6 py-4 text-center font-black text-white hover:bg-fuchsia-500">Test Kittl through the verified route →</a>
+      </article>
+
+      <article class="rounded-3xl border border-cyan-400/20 bg-cyan-400/[0.05] p-6 sm:p-8">
+        <div class="text-xs font-black uppercase tracking-widest text-cyan-300">Canva is the better first test when…</div>
+        <h2 class="mt-2 text-2xl font-black text-white">Commercial design is only one part of a larger content system</h2>
+        <ul class="mt-5 space-y-3 text-sm leading-6 text-slate-300">
+          <li>• The same team also produces social posts, presentations, video and general marketing assets.</li>
+          <li>• A broad template/content ecosystem matters more than a product-design-first workflow.</li>
+          <li>• You want one workspace for multiple content formats and collaborators.</li>
+          <li>• You are comfortable checking Canva's asset-specific licensing restrictions before resale or merchandise use.</li>
+        </ul>
+        <a data-cta="official" href="https://www.canva.com/licensing-explained/" target="_blank" rel="noopener noreferrer" class="mt-6 block rounded-xl border border-cyan-400/30 bg-cyan-400/10 px-6 py-4 text-center font-black text-cyan-100 hover:bg-cyan-400/15">Check Canva licensing →</a>
+      </article>
+    </section>
+
+    <section class="mt-14 rounded-3xl border border-amber-400/20 bg-amber-400/[0.05] p-6 sm:p-8">
+      <div class="text-xs font-black uppercase tracking-widest text-amber-300">Commercial-use warning</div>
+      <h2 class="mt-2 text-2xl font-black text-white">A template that looks sellable is not automatically licensed for every resale model</h2>
+      <p class="mt-3 max-w-4xl text-sm leading-7 text-slate-300">Kittl explicitly separates personal-use Free access from paid commercial licensing. Canva allows a wide range of commercial uses for eligible content inside finished Canva designs, but it restricts standalone resale or redistribution of its content and applies additional rules to some assets, including music. For POD, digital products or client work, verify the exact asset and license before you publish at scale.</p>
+      <div class="mt-5 flex flex-col gap-3 sm:flex-row">
+        <a href="https://help.kittl.com/subscription-billing/about-free-plan/" target="_blank" rel="noopener noreferrer" class="rounded-xl border border-white/15 px-5 py-3 text-center text-sm font-bold text-slate-200 hover:bg-white/[0.05]">Kittl Free-plan terms →</a>
+        <a href="https://www.canva.com/policies/content-license-agreement/" target="_blank" rel="noopener noreferrer" class="rounded-xl border border-white/15 px-5 py-3 text-center text-sm font-bold text-slate-200 hover:bg-white/[0.05]">Canva Content License →</a>
+      </div>
+    </section>
+
+    <section class="mt-14 rounded-3xl border border-emerald-400/20 bg-emerald-400/[0.05] p-6 sm:p-8">
+      <div class="text-xs font-black uppercase tracking-widest text-emerald-300">Low-risk buying test</div>
+      <h2 class="mt-2 text-2xl font-black text-white">Build one real product graphic in both tools before upgrading</h2>
+      <p class="mt-3 max-w-4xl text-sm leading-7 text-slate-300">Use the same brief — for example a shirt graphic, product label or client promo asset — and compare editing time, typography control, mockups, export requirements and license fit. If Kittl wins on the product-design workflow, its paid commercial license becomes easier to justify. If the project quickly expands into social, presentation and video assets, Canva may be the broader workspace.</p>
+      <div class="mt-6 flex flex-col gap-3 sm:flex-row">
+        <a data-cta="affiliate" data-tool-id="kittl" data-cta-source="kittl_canva_commercial_bottom" href="https://kittl.pxf.io/0GMrXY" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl bg-emerald-600 px-6 py-4 text-center font-black text-white hover:bg-emerald-500">Start the Kittl free test →</a>
+        <a href="/best/kittl-commercial-use-license.html" class="rounded-xl border border-white/15 px-6 py-4 text-center font-bold text-slate-200 hover:bg-white/[0.05]">Read the Kittl commercial-license guide →</a>
+      </div>
+    </section>
+
+    <section class="mt-12 border-t border-white/10 pt-8 text-xs leading-6 text-slate-500">
+      <p><strong class="text-slate-300">Sources checked:</strong> Kittl official homepage, pricing, Free-plan and Pro-plan help pages; Canva official Pro page, AI-usage help, licensing explainer and Content License Agreement. Rechecked September 13, 2026. Features, prices and license terms can change; verify the live vendor terms before purchase or commercial publication.</p>
+      <p class="mt-2"><strong class="text-slate-300">Affiliate evidence:</strong> COSHUMA's existing authenticated Impact evidence records <code>https://kittl.pxf.io/0GMrXY</code> as the exact Kittl customer-facing tracking route. Canva remains non-affiliate on this page. This guide does not claim any new signup, paid customer, commission or payout.</p>
+    </section>
+  </main>
+
+  <footer class="border-t border-white/10 px-5 py-8 text-center text-xs text-slate-600">© 2026 COSHUMA · Independent AI & SaaS buyer guides</footer>
+</body>
+</html>


### PR DESCRIPTION
## Revenue objective
Capture high-intent commercial-design traffic around Kittl vs Canva and route qualified product-design buyers to COSHUMA's already-verified Kittl Impact customer URL at $0 additional cost.

## Evidence
- Existing authenticated Impact evidence records the exact customer route `https://kittl.pxf.io/0GMrXY` as `approved_tracking`.
- Kittl first-party pages rechecked 2026-09-13: Free is free forever, 5 active projects, 500 MB upload storage, 200 AI tokens, low-res PNG/JPG exports and personal-use only; paid plans add commercial licensing and high-res/vector export.
- Kittl's current public affiliate page states 20% of payments for 12 months and up to $72 for a new Expert subscriber.
- Canva first-party licensing/help pages were rechecked for commercial-use boundaries and current Free-plan AI allowance. Canva remains official non-affiliate because no COSHUMA-specific tracking URL is verified.

## Change
- Add `/best/kittl-vs-canva-commercial-use.html` focused on POD, merch, client work, licensing and export fit.
- Use only the exact existing Kittl Impact route; no guessed pricing deep link.
- Keep Canva on official non-affiliate destinations.
- Record source/evidence and revenue-truth guardrails in repository data.
- Existing build steps already auto-link orphan `/best/` pages from the buyer-guide hub and add `/best/` pages to the sitemap.

## Guardrails
- No duplicate application/account.
- No payment, self-referral or payout change.
- No click/signup/customer/commission/revenue inference.
- No paid service or subscription.