### PR TITLE
Revenue: surface verified Catalister free-trial route

### DIFF
--- a/projects/GlobalSaaSHub/data/catalister-buyer-hub-evidence-2026-09-13.md
+++ b/projects/GlobalSaaSHub/data/catalister-buyer-hub-evidence-2026-09-13.md
@@ -1,0 +1,35 @@
+# Catalister buyer-hub evidence — 2026-09-13
+
+## Revenue route
+
+- Existing authenticated COSHUMA affiliate evidence records the exact customer-facing Catalister referral URL as `https://app.catalister.com/signup?via=coshuma`.
+- The authenticated Catalister dashboard issued that URL after onboarding and the customer signup destination retained `via=coshuma`.
+- Pre-validation dashboard evidence recorded 0 clicks, 0 paying referrals, 0 trialing referrals, EUR 0 total/unpaid commission and EUR 0 revenue. Link issuance and a validation visit are not customer conversions.
+- Source of the exact route: `data/approved-tracking-2026-09-08.json` and the existing `catalister` tool record.
+
+## Current buyer facts rechecked against Catalister first-party pages
+
+Rechecked on 2026-09-13:
+
+- Official site: `https://catalister.com/`
+- AI Shopify listing page: `https://catalister.com/ai-shopify-product-listing`
+
+The current first-party site states:
+
+- free 7-day trial,
+- no credit card required to start,
+- Starter €14.99/month,
+- Stacker €24.99/month,
+- Scaler €34.99/month,
+- Slayer €59.99/month,
+- Shopify-focused AI product listing/relisting and Google Ads analysis workflows.
+
+Final checkout pricing, taxes and offer terms remain vendor-controlled.
+
+## Safe production action
+
+Surface Catalister on COSHUMA's verified software free-trial/partner-offer hub using only the exact issued customer referral URL. Keep the official Catalister homepage available separately for independent pricing verification. Do not invent a pricing or checkout affiliate deep link.
+
+## Revenue truth guard
+
+This change proves only that an already-issued customer-facing referral route is being surfaced on another buyer-intent page. It does not prove a new click, trial, paid customer, commission, payout or revenue. Downstream stages remain evidence-dependent.

--- a/projects/GlobalSaaSHub/scripts/normalize_sponsorship_offer.py
+++ b/projects/GlobalSaaSHub/scripts/normalize_sponsorship_offer.py
@@ -138,6 +138,7 @@ def main() -> None:
         "surface_fireflies_verified_offer.py",
         "surface_make_verified_offer.py",
         "surface_voibe_verified_offer.py",
+        "surface_catalister_verified_offer.py",
     ):
         try:
             runpy.run_path(str(ROOT / "scripts" / script_name), run_name="__main__")

--- a/projects/GlobalSaaSHub/scripts/surface_catalister_verified_offer.py
+++ b/projects/GlobalSaaSHub/scripts/surface_catalister_verified_offer.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGE = ROOT / "public" / "best" / "verified-software-free-trials-deals.html"
+MARKER = "<!-- COSHUMA_CATALISTER_VERIFIED_OFFER -->"
+TRACKING_URL = "https://app.catalister.com/signup?via=coshuma"
+GUIDE_URL = "/tool/catalister.html"
+OFFICIAL_URL = "https://catalister.com/"
+
+if not PAGE.exists():
+    raise SystemExit(f"Missing buyer hub: {PAGE}")
+
+html = PAGE.read_text(encoding="utf-8")
+
+# Evidence guard:
+# - authenticated Catalister dashboard evidence records this exact customer-facing
+#   referral URL and a signup destination retaining via=coshuma.
+# - Catalister first-party pages rechecked 2026-09-13 advertise a free 7-day trial
+#   with no credit card required and the plan prices used below.
+# - a link being issued or visited is not evidence of signup, sale or commission.
+if MARKER in html:
+    if TRACKING_URL not in html:
+        raise SystemExit("Catalister verified block exists but exact approved tracking URL is missing")
+    print("Catalister verified offer already surfaced")
+    raise SystemExit(0)
+
+old_meta = (
+    "Compare verified SaaS free trials and partner offers from Gamma, Time2book, "
+    "UpLead, Jotform, Unbounce, Pictory, Brand24, Bookyourdata, Tally, Typedesk, "
+    "Tagshop AI, RGE Studio, BoldSign, Teachable, Murf AI, Claap, Writesonic, Moosend, Kittl, HelpDesk, Krater, Fireflies.ai, Make.com and Voibe. COSHUMA separates customer-facing tracking links from product claims."
+)
+new_meta = (
+    "Compare verified SaaS free trials and partner offers from Gamma, Time2book, "
+    "UpLead, Jotform, Unbounce, Pictory, Brand24, Bookyourdata, Tally, Typedesk, "
+    "Tagshop AI, RGE Studio, BoldSign, Teachable, Murf AI, Claap, Writesonic, Moosend, Kittl, HelpDesk, Krater, Fireflies.ai, Make.com, Voibe and Catalister. COSHUMA separates customer-facing tracking links from product claims."
+)
+if old_meta not in html:
+    raise SystemExit("Buyer-hub meta description changed; refusing blind Catalister patch")
+html = html.replace(old_meta, new_meta, 1)
+
+item24 = (
+    '      {"@type":"ListItem","position":24,"name":"Voibe",'
+    '"url":"https://coshuma.com/tool/voibe.html"}\n'
+    "    ]"
+)
+item25 = (
+    '      {"@type":"ListItem","position":24,"name":"Voibe",'
+    '"url":"https://coshuma.com/tool/voibe.html"},\n'
+    '      {"@type":"ListItem","position":25,"name":"Catalister",'
+    '"url":"https://coshuma.com/tool/catalister.html"}\n'
+    "    ]"
+)
+if item24 not in html:
+    raise SystemExit("Voibe ItemList tail missing; Catalister patch requires the verified Voibe build step first")
+html = html.replace(item24, item25, 1)
+
+closing = '''    </section>\n\n    <section class="rounded-3xl border border-white/10 bg-[#11131a] p-7 md:p-9">\n      <h2 class="text-2xl font-black text-white">How this list is gated</h2>'''
+if closing not in html:
+    raise SystemExit("Buyer-hub final grid boundary changed; refusing blind Catalister patch")
+
+card = f'''      {MARKER}\n      <article class="rounded-3xl border border-purple-400/25 bg-[#11131a] p-7 space-y-5">\n        <div class="flex items-start justify-between gap-4"><div><div class="text-xs font-black uppercase tracking-wider text-purple-300">Shopify listing automation</div><h2 class="mt-1 text-3xl font-black text-white">Catalister</h2></div><span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">7-day free trial · no card</span></div>\n        <p class="text-sm leading-6 text-slate-300">Catalister's current first-party site advertises a <strong class="text-white">free 7-day trial with no credit card required</strong>. It is built around Shopify product research, AI-generated listings and relisting, plus product-level Google Ads analysis.</p>\n        <p class="text-sm leading-6 text-slate-300">At the time checked, monthly plans start at <strong class="text-white">€14.99</strong> for Starter, then €24.99 Stacker, €34.99 Scaler and €59.99 Slayer. Vendor checkout controls final pricing, taxes and terms.</p>\n        <p class="text-sm leading-6 text-slate-300">COSHUMA uses the exact customer signup referral URL previously issued inside the authenticated Catalister affiliate dashboard. COSHUMA does not move <code class="text-purple-200">via=coshuma</code> onto a guessed pricing or checkout URL.</p>\n        <div class="grid gap-3 sm:grid-cols-2"><a data-cta="affiliate" data-tool-id="catalister" data-cta-source="verified-deals-catalister-trial" data-cta-page="verified-software-free-trials-deals" href="{TRACKING_URL}" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl bg-purple-600 px-5 py-3.5 text-center text-sm font-black text-white hover:bg-purple-500">Start Catalister free trial →</a><a href="{GUIDE_URL}" class="rounded-xl border border-white/10 px-5 py-3.5 text-center text-sm font-bold text-slate-200 hover:bg-white/5">Compare Catalister plans</a></div>\n        <a href="{OFFICIAL_URL}" target="_blank" rel="noopener noreferrer" class="inline-block text-xs font-bold text-purple-200 hover:text-white">Verify Catalister pricing & trial →</a>\n        <p class="text-[11px] leading-5 text-slate-500">The first button preserves the exact account-issued customer-facing referral URL. Publication and link validation do not prove a click, trial, paid customer, commission, payout or revenue; those require separate partner-side evidence.</p>\n      </article>\n'''
+
+html = html.replace(closing, card + closing, 1)
+
+required = [
+    TRACKING_URL,
+    GUIDE_URL,
+    'data-cta-source="verified-deals-catalister-trial"',
+    "free 7-day trial with no credit card required",
+    "€14.99",
+    "via=coshuma",
+    "do not prove a click, trial, paid customer, commission, payout or revenue",
+]
+for token in required:
+    if token not in html:
+        raise SystemExit(f"Catalister buyer-hub patch lost required token: {token}")
+
+PAGE.write_text(html, encoding="utf-8")
+print("Surfaced verified Catalister free-trial route on buyer hub")


### PR DESCRIPTION
## Revenue goal
Surface one more already-approved customer-facing partner route on the high-intent verified offers hub without reapplying, guessing a deep link, or claiming downstream revenue.

## Evidence
- Existing authenticated Catalister affiliate evidence issued `https://app.catalister.com/signup?via=coshuma` and confirmed the customer signup destination preserves attribution.
- Catalister first-party pages rechecked 2026-09-13 advertise a 7-day free trial with no credit card required and current monthly entry pricing starting at €14.99.
- Existing downstream metrics remain separate; publication/link validation is not a signup, sale, commission or payout.

## Change
- Add a guarded/idempotent Catalister card to the verified software free-trials/partner-offers build pipeline.
- Extend the hub meta description and ItemList only after all prior verified-offer build steps have run.
- Preserve the exact issued signup referral URL; official pricing verification remains a separate non-affiliate link.
- Add evidence notes and fail closed if the preceding buyer-hub state changes unexpectedly.

No paid action, duplicate application, payout change, or inferred revenue.