### PR TITLE
Revenue: publish HighLevel vs HubSpot agency comparison

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/gohighlevel-vs-hubspot.html
+++ b/projects/GlobalSaaSHub/public/compare/gohighlevel-vs-hubspot.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>GoHighLevel vs HubSpot 2026: Pricing, Free Tier & Agency Fit | COSHUMA</title>
+  <meta name="description" content="Compare GoHighLevel vs HubSpot in 2026 for agencies and service businesses: current pricing, free/trial entry, client-account economics, CRM fit and which platform to shortlist." />
+  <link rel="canonical" href="https://coshuma.com/compare/gohighlevel-vs-hubspot.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/gohighlevel-vs-hubspot.html" />
+  <meta property="og:site_name" content="COSHUMA" />
+  <meta property="og:title" content="GoHighLevel vs HubSpot 2026: Pricing, Free Tier & Agency Fit" />
+  <meta property="og:description" content="Agency-first sub-account economics versus HubSpot's lower-risk free and Starter entry. Compare before you subscribe." />
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"GoHighLevel vs HubSpot 2026","url":"https://coshuma.com/compare/gohighlevel-vs-hubspot.html","isPartOf":{"@type":"WebSite","name":"COSHUMA","url":"https://coshuma.com/"},"about":[{"@type":"SoftwareApplication","name":"HighLevel","url":"https://coshuma.com/tool/gohighlevel.html"},{"@type":"SoftwareApplication","name":"HubSpot","url":"https://coshuma.com/tool/hubspot.html"}]}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Which is cheaper to start, GoHighLevel or HubSpot?","acceptedAnswer":{"@type":"Answer","text":"HubSpot currently offers a $0 free tier for up to 2 users with no credit card required. HighLevel currently advertises a 14-day free trial and its Starter plan at $97 per month."}},{"@type":"Question","name":"Which is better for an agency managing multiple client accounts?","acceptedAnswer":{"@type":"Answer","text":"HighLevel is designed around sub-accounts: Starter includes 3 and Unlimited includes unlimited sub-accounts. HubSpot can be a better fit when a team prioritizes its broader CRM ecosystem and wants to start from a free or low-cost seat-based entry."}},{"@type":"Question","name":"Does COSHUMA have a verified partner route for both products?","acceptedAnswer":{"@type":"Answer","text":"COSHUMA uses its verified account-specific HighLevel partner route. HubSpot is linked here to its official pricing page because COSHUMA is not treating a HubSpot affiliate route as verified on this comparison."}}]}</script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="/affiliate-attribution.js"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen bg-[#0b0c10]">
+<header class="sticky top-0 z-50 border-b border-[#222538] bg-[#07080c]/90"><div class="mx-auto flex max-w-5xl items-center justify-between px-5 py-4"><a href="/" class="text-lg font-black text-white">COSHUMA</a><a href="/best/crm-for-marketing-agencies.html" class="rounded-full border border-violet-500/30 bg-violet-500/10 px-4 py-2 text-xs font-bold text-violet-300">CRM buyer guide →</a></div></header>
+<main class="mx-auto max-w-5xl space-y-8 px-5 py-12">
+  <section class="space-y-5 text-center">
+    <div class="text-xs font-black tracking-[0.18em] text-violet-300">CRM & AGENCY PLATFORM COMPARISON · SOURCES CHECKED SEP 13, 2026</div>
+    <h1 class="text-4xl font-black md:text-5xl">GoHighLevel vs HubSpot</h1>
+    <p class="mx-auto max-w-3xl text-slate-300">These platforms can overlap in CRM, marketing and sales workflows, but they start from different economics. HighLevel is built around agency sub-accounts and an all-in-one operating stack; HubSpot gives buyers a much lower-risk free entry and a broad modular CRM ecosystem.</p>
+  </section>
+
+  <section class="grid grid-cols-1 gap-5 md:grid-cols-2">
+    <article class="space-y-4 rounded-3xl border border-violet-500/30 bg-[#131520] p-7">
+      <div class="text-xs font-black uppercase tracking-wider text-violet-300">HighLevel</div>
+      <h2 class="text-2xl font-black">Agency-first client-account economics</h2>
+      <p class="text-sm leading-6 text-slate-300">HighLevel's current official pricing lists Starter at $97/month with 3 sub-accounts, unlimited contacts and unlimited users. Unlimited is $297/month with unlimited sub-accounts. Agency Pro is $497/month and adds SaaS Mode and advanced agency resale controls.</p>
+      <ul class="space-y-2 text-sm text-slate-300"><li>✓ 14-day free trial currently advertised</li><li>✓ Starter: 3 sub-accounts</li><li>✓ Unlimited: unlimited sub-accounts</li><li>✓ Agency Pro: SaaS Mode and automated sub-account creation</li></ul>
+      <a data-cta="affiliate" data-tool-id="gohighlevel" data-cta-source="compare_highlevel_hubspot_highlevel" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="block rounded-xl bg-violet-600 px-5 py-3.5 text-center font-extrabold text-white hover:bg-violet-500">Start HighLevel's 14-day trial →</a>
+      <p class="text-[11px] leading-5 text-slate-500">This button uses COSHUMA's verified account-specific HighLevel partner route. HighLevel controls final trial eligibility, billing, taxes and usage charges.</p>
+    </article>
+
+    <article class="space-y-4 rounded-3xl border border-cyan-500/30 bg-[#131520] p-7">
+      <div class="text-xs font-black uppercase tracking-wider text-cyan-300">HubSpot</div>
+      <h2 class="text-2xl font-black">Lower-risk free entry + modular ecosystem</h2>
+      <p class="text-sm leading-6 text-slate-300">HubSpot's current Customer Platform pricing shows a $0 free tier for up to 2 users with no credit card required. Its current Starter offer starts at $7/month per seat on the pricing page, where $20/month per seat is also shown as the higher monthly reference price.</p>
+      <ul class="space-y-2 text-sm text-slate-300"><li>✓ Free: $0/month, up to 2 users</li><li>✓ No credit card required for the free tier</li><li>✓ Starter currently shown from $7/month/seat</li><li>✓ Marketing, sales, service, content and data tools can expand within the HubSpot ecosystem</li></ul>
+      <a data-cta="official" data-tool-id="hubspot" data-cta-source="compare_highlevel_hubspot_hubspot" href="https://www.hubspot.com/pricing/suite" target="_blank" rel="noopener noreferrer" class="block rounded-xl bg-cyan-600 px-5 py-3.5 text-center font-extrabold text-white hover:bg-cyan-500">Check HubSpot Customer Platform pricing →</a>
+      <p class="text-[11px] leading-5 text-slate-500">This is HubSpot's official pricing page, not a COSHUMA affiliate route. The $7 Starter price is a current promotional starting price for eligible new customers and can change.</p>
+    </article>
+  </section>
+
+  <section class="space-y-5 rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-9">
+    <h2 class="text-2xl font-black">Side-by-side decision table</h2>
+    <div class="overflow-x-auto"><table class="w-full min-w-[720px] text-left text-sm"><thead class="border-b border-[#2a2d42] text-slate-400"><tr><th class="py-3 pr-4">Decision factor</th><th class="py-3 pr-4">HighLevel</th><th class="py-3">HubSpot Customer Platform</th></tr></thead><tbody class="divide-y divide-[#202334] text-slate-300">
+      <tr><td class="py-4 pr-4 font-bold text-white">Lowest-risk start</td><td class="py-4 pr-4">14-day free trial currently advertised</td><td class="py-4">$0 free tier, up to 2 users, no card required</td></tr>
+      <tr><td class="py-4 pr-4 font-bold text-white">Entry paid pricing</td><td class="py-4 pr-4">Starter $97/month</td><td class="py-4">Starter currently shown from $7/month/seat; $20/month/seat reference also shown</td></tr>
+      <tr><td class="py-4 pr-4 font-bold text-white">Client-account model</td><td class="py-4 pr-4">3 sub-accounts on Starter; unlimited on Unlimited</td><td class="py-4">Seat-based platform entry rather than HighLevel-style agency sub-account packaging</td></tr>
+      <tr><td class="py-4 pr-4 font-bold text-white">Best fit</td><td class="py-4 pr-4">Agencies and service businesses consolidating CRM, funnels, calendars and automation around client accounts</td><td class="py-4">Teams wanting a free CRM entry and a broad modular sales, marketing, service, content and data ecosystem</td></tr>
+      <tr><td class="py-4 pr-4 font-bold text-white">Cost check before buying</td><td class="py-4 pr-4">Include phone, messaging, AI and other metered usage where relevant</td><td class="py-4">Check seats, hubs, contact tiers, credits and onboarding requirements for the products you actually need</td></tr>
+    </tbody></table></div>
+  </section>
+
+  <section class="space-y-4 rounded-3xl border border-emerald-500/25 bg-emerald-500/5 p-7">
+    <h2 class="text-2xl font-black">Which should you pick?</h2>
+    <p class="leading-7 text-slate-300"><strong class="text-white">Choose HighLevel</strong> when your economics depend on managing multiple client accounts and you want CRM, funnels, booking and automation under one agency-oriented subscription. <strong class="text-white">Choose HubSpot</strong> when the free/no-card entry is more important, or when your team prefers HubSpot's modular ecosystem and is comfortable evaluating seat and hub costs as it grows.</p>
+    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      <a data-cta="affiliate" data-tool-id="gohighlevel" data-cta-source="compare_highlevel_hubspot_highlevel_bottom" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-violet-600 px-5 py-3.5 text-center font-extrabold text-white hover:bg-violet-500">Try HighLevel via verified COSHUMA route →</a>
+      <a data-cta="official" data-tool-id="hubspot" data-cta-source="compare_highlevel_hubspot_hubspot_bottom" href="https://www.hubspot.com/pricing/suite" target="_blank" rel="noopener noreferrer" class="rounded-xl bg-cyan-600 px-5 py-3.5 text-center font-extrabold text-white hover:bg-cyan-500">Start with HubSpot's official pricing →</a>
+    </div>
+    <p class="text-[11px] leading-5 text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if an eligible HighLevel purchase later occurs through the verified HighLevel partner route, at no extra cost to you. HubSpot's button on this page is an official non-affiliate destination. No signup, paid conversion or revenue is inferred from a click.</p>
+  </section>
+
+  <section class="space-y-4 rounded-3xl border border-white/10 bg-[#131520] p-7">
+    <h2 class="text-2xl font-black">What to test before paying</h2>
+    <p class="text-slate-300">Run the same real workflow in each platform: capture one lead, move it through a pipeline, book an appointment, trigger follow-up and review reporting. If you run an agency, also model the number of client accounts, required staff seats and monthly messaging/phone volume. The cheapest headline price can become the wrong choice when your operating model is different.</p>
+    <div class="grid grid-cols-1 gap-3 sm:grid-cols-3 text-sm font-bold"><a href="/tool/gohighlevel.html" class="rounded-xl bg-white/[0.04] p-4 hover:bg-white/[0.07]">HighLevel buyer guide →</a><a href="/tool/hubspot.html" class="rounded-xl bg-white/[0.04] p-4 hover:bg-white/[0.07]">HubSpot buyer guide →</a><a href="/best/crm-for-marketing-agencies.html" class="rounded-xl bg-white/[0.04] p-4 hover:bg-white/[0.07]">Best CRM for agencies →</a></div>
+  </section>
+
+  <section class="space-y-3 rounded-3xl border border-white/10 bg-[#131520] p-7">
+    <h2 class="text-2xl font-black">Sources and verification boundary</h2>
+    <p class="text-sm leading-6 text-slate-400">Pricing and plan claims were rechecked against current official vendor pages on September 13, 2026. HighLevel's customer CTA is separately constrained to COSHUMA's already verified partner URL; COSHUMA does not append guessed affiliate parameters to pricing or trial pages.</p>
+    <ul class="space-y-2 text-sm"><li><a data-cta="source" href="https://www.gohighlevel.com/pricing" target="_blank" rel="noopener noreferrer" class="text-violet-300 underline">HighLevel official pricing</a></li><li><a data-cta="source" href="https://www.hubspot.com/pricing/suite" target="_blank" rel="noopener noreferrer" class="text-cyan-300 underline">HubSpot Customer Platform official pricing</a></li></ul>
+  </section>
+</main>
+<footer class="mt-12 border-t border-[#222538] py-8 text-center text-xs text-slate-500">© 2026 COSHUMA. Independent AI & SaaS buyer guides.</footer>
+</body>
+</html>

--- a/projects/GlobalSaaSHub/scripts/normalize_sponsorship_offer.py
+++ b/projects/GlobalSaaSHub/scripts/normalize_sponsorship_offer.py
@@ -146,6 +146,7 @@ def main() -> None:
         "surface_novita_verified_offer.py",
         "surface_aiassistworks_verified_offer.py",
         "improve_verified_offer_discovery.py",
+        "surface_highlevel_hubspot_comparison.py",
     ):
         try:
             runpy.run_path(str(ROOT / "scripts" / script_name), run_name="__main__")

--- a/projects/GlobalSaaSHub/scripts/surface_highlevel_hubspot_comparison.py
+++ b/projects/GlobalSaaSHub/scripts/surface_highlevel_hubspot_comparison.py
@@ -1,4 +1,4 @@
-"""Keep the HighLevel vs HubSpot buyer-intent comparison safely indexed.
+"""Keep the HighLevel vs HubSpot buyer-intent comparison safely indexed and discoverable.
 
 The page is hand-authored from current official vendor pricing and uses only the
 already-verified COSHUMA HighLevel partner route. This guard refuses to publish if
@@ -8,10 +8,14 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 PAGE = ROOT / "public" / "compare" / "gohighlevel-vs-hubspot.html"
+CRM_HUB = ROOT / "public" / "best" / "crm-for-marketing-agencies.html"
 SITEMAP = ROOT / "public" / "sitemap.xml"
 CANONICAL = "https://coshuma.com/compare/gohighlevel-vs-hubspot.html"
 HIGHLEVEL = "https://www.gohighlevel.com/?fp_ref=sangkwon56"
 HUBSPOT = "https://www.hubspot.com/pricing/suite"
+HUB_MARKER = 'data-revenue-link="highlevel-vs-hubspot"'
+
+HUB_BLOCK = '''\n    <section data-revenue-link="highlevel-vs-hubspot" class="mt-10 rounded-3xl border border-violet-400/25 bg-violet-500/[0.06] p-6 sm:p-8">\n      <div class="text-xs font-black uppercase tracking-[0.18em] text-violet-300">Direct agency comparison</div>\n      <h2 class="mt-2 text-2xl font-black text-white">Already down to HighLevel vs HubSpot?</h2>\n      <p class="mt-3 max-w-3xl text-sm leading-6 text-slate-300">Compare the current free/trial entry, seat economics and HighLevel sub-account model side by side before choosing a CRM stack.</p>\n      <a href="/compare/gohighlevel-vs-hubspot.html" class="mt-5 inline-flex min-h-11 items-center justify-center rounded-xl bg-violet-600 px-5 py-3 text-sm font-black text-white hover:bg-violet-500">Compare HighLevel vs HubSpot →</a>\n    </section>\n'''
 
 
 def main() -> None:
@@ -47,7 +51,16 @@ def main() -> None:
         sitemap = sitemap.replace("</urlset>", entry + "</urlset>", 1)
         SITEMAP.write_text(sitemap, encoding="utf-8")
 
-    print("highlevel-vs-hubspot-revenue-surface-v1")
+    if not CRM_HUB.exists():
+        raise SystemExit("CRM buyer hub missing; refusing orphan comparison publish")
+    hub = CRM_HUB.read_text(encoding="utf-8")
+    if HUB_MARKER not in hub:
+        if "</main>" not in hub:
+            raise SystemExit("CRM buyer hub main closing tag missing; refusing internal-link patch")
+        hub = hub.replace("</main>", HUB_BLOCK + "</main>", 1)
+        CRM_HUB.write_text(hub, encoding="utf-8")
+
+    print("highlevel-vs-hubspot-revenue-surface-v2")
 
 
 if __name__ == "__main__":

--- a/projects/GlobalSaaSHub/scripts/surface_highlevel_hubspot_comparison.py
+++ b/projects/GlobalSaaSHub/scripts/surface_highlevel_hubspot_comparison.py
@@ -1,0 +1,54 @@
+"""Keep the HighLevel vs HubSpot buyer-intent comparison safely indexed.
+
+The page is hand-authored from current official vendor pricing and uses only the
+already-verified COSHUMA HighLevel partner route. This guard refuses to publish if
+the tracked HighLevel route or official HubSpot pricing destination disappears.
+"""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGE = ROOT / "public" / "compare" / "gohighlevel-vs-hubspot.html"
+SITEMAP = ROOT / "public" / "sitemap.xml"
+CANONICAL = "https://coshuma.com/compare/gohighlevel-vs-hubspot.html"
+HIGHLEVEL = "https://www.gohighlevel.com/?fp_ref=sangkwon56"
+HUBSPOT = "https://www.hubspot.com/pricing/suite"
+
+
+def main() -> None:
+    if not PAGE.exists():
+        raise SystemExit("HighLevel vs HubSpot comparison missing; refusing revenue surface")
+
+    html = PAGE.read_text(encoding="utf-8")
+    required = (
+        CANONICAL,
+        HIGHLEVEL,
+        HUBSPOT,
+        'data-cta="affiliate" data-tool-id="gohighlevel"',
+        'data-cta="official" data-tool-id="hubspot"',
+        "No signup, paid conversion or revenue is inferred from a click.",
+    )
+    for token in required:
+        if token not in html:
+            raise SystemExit(f"HighLevel vs HubSpot safety check failed: {token}")
+
+    if not SITEMAP.exists():
+        raise SystemExit("Sitemap missing; refusing unindexed comparison publish")
+    sitemap = SITEMAP.read_text(encoding="utf-8")
+    if CANONICAL not in sitemap:
+        if "</urlset>" not in sitemap:
+            raise SystemExit("Sitemap closing tag missing; refusing comparison index patch")
+        entry = (
+            "  <url>\n"
+            f"    <loc>{CANONICAL}</loc>\n"
+            "    <changefreq>weekly</changefreq>\n"
+            "    <priority>0.82</priority>\n"
+            "  </url>\n"
+        )
+        sitemap = sitemap.replace("</urlset>", entry + "</urlset>", 1)
+        SITEMAP.write_text(sitemap, encoding="utf-8")
+
+    print("highlevel-vs-hubspot-revenue-surface-v1")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Revenue rationale
COSHUMA already has a verified HighLevel partner route and an agency-CRM buyer hub, but no dedicated HighLevel vs HubSpot comparison page. This adds a high-intent decision landing for buyers already choosing between those two platforms.

## What changes
- add `/compare/gohighlevel-vs-hubspot.html`
- use only COSHUMA's existing verified HighLevel route: `https://www.gohighlevel.com/?fp_ref=sangkwon56`
- keep HubSpot on its official non-affiliate Customer Platform pricing page
- ground pricing/trial copy in official vendor pages rechecked Sep 13, 2026
- add the comparison to the sitemap during the normal production pipeline
- add one internal discovery CTA from the existing CRM-for-agencies buyer hub

## Safety
- no guessed affiliate deep link or parameter
- no HubSpot affiliate status is inferred
- no click, signup, paid customer, commission, payout or revenue is inferred
- no paid service or payment change
- production build fails closed if the comparison loses either verified destination or disclosure boundary