### PR TITLE
Revenue UX: route HighLevel buyers to HubSpot comparison

### DIFF
--- a/projects/GlobalSaaSHub/public/tool/gohighlevel.html
+++ b/projects/GlobalSaaSHub/public/tool/gohighlevel.html
@@ -91,7 +91,7 @@
 
         <div class="flex flex-col sm:flex-row gap-3">
           <a data-cta="affiliate" data-tool-id="gohighlevel" data-cta-source="hero" href="https://www.gohighlevel.com/?fp_ref=sangkwon56" target="_blank" rel="sponsored noopener noreferrer" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-center shadow-lg shadow-purple-950/50 hover:brightness-110 transition-all">Start the 14-Day HighLevel Trial →</a>
-          <a href="/compare/text-vs-gohighlevel.html" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-[#181a29] border border-[#30344c] text-white text-center hover:border-purple-500/50 transition-all">Compare Text vs HighLevel →</a>
+          <a href="/compare/gohighlevel-vs-hubspot.html" class="flex-1 px-6 py-4 rounded-xl font-extrabold text-sm bg-[#181a29] border border-[#30344c] text-white text-center hover:border-purple-500/50 transition-all">Compare HighLevel vs HubSpot →</a>
         </div>
         <p class="text-[11px] leading-relaxed text-slate-500">Affiliate disclosure: the primary HighLevel button uses COSHUMA's verified partner URL. COSHUMA may earn a commission if you become a paying customer after using it, at no extra cost to you. Final trial eligibility, prices, taxes, add-ons and usage charges are controlled by HighLevel.</p>
       </section>


### PR DESCRIPTION
## Revenue goal
Reduce decision friction for HighLevel-intent visitors by sending the hero's comparison CTA to the newly deployed, source-backed HighLevel vs HubSpot buyer page.

## Change
- Keep the verified HighLevel affiliate CTA unchanged.
- Replace only the secondary hero comparison link from Text vs HighLevel to `gohighlevel-vs-hubspot.html`.
- Preserve the existing Text vs HighLevel comparison lower on the page, so support-platform discovery is not removed.

## Safety
- No affiliate URL changes.
- No new revenue/conversion claims.
- No paid action.
- Diff is exactly one line changed in one file.