### PR TITLE
SEO: surface high-intent revenue comparisons from homepage

### DIFF
--- a/projects/GlobalSaaSHub/index.html
+++ b/projects/GlobalSaaSHub/index.html
@@ -127,13 +127,13 @@
           <a href="/tool/databox.html">Databox pricing & review</a> ·
           <a href="/tool/brand24.html">Brand24 pricing & free trial</a> ·
           <a href="/best/shopify-pricing-free-trial.html">Shopify pricing & free trial</a><br />
-          <strong>Popular side-by-side comparisons:</strong><br />
+          <strong>High-intent side-by-side comparisons:</strong><br />
+          <a href="/compare/gohighlevel-vs-hubspot.html"><strong>GoHighLevel vs HubSpot: pricing, free tier & agency fit</strong></a> ·
+          <a href="/compare/uplead-vs-apollo.html"><strong>UpLead vs Apollo: pricing, credits & B2B data fit</strong></a> ·
+          <a href="/compare/gamma-vs-canva.html">Gamma vs Canva: AI presentations & pricing</a> ·
+          <a href="/compare/brand24-vs-mention.html">Brand24 vs Mention: monitoring, pricing & fit</a> ·
           <a href="/compare/vidiq-vs-tubebuddy.html">vidIQ vs TubeBuddy: pricing, features & best for</a> ·
-          <a href="/compare/descript-vs-tubebuddy.html">Descript vs TubeBuddy: pricing, features & best for</a> ·
-          <a href="/compare/castmagic-vs-tubebuddy.html">Castmagic vs TubeBuddy: pricing, features & best for</a> ·
-          <a href="/compare/systeme-io-vs-privy.html">Systeme.io vs Privy: pricing, features & best for</a> ·
-          <a href="/compare/activecampaign-vs-privy.html">ActiveCampaign vs Privy: pricing, features & best for</a> ·
-          <a href="/compare/agentworks-vs-relevance-ai.html">AgentWorks vs Relevance AI: pricing, features & best for</a>
+          <a href="/compare/systeme-io-vs-privy.html">Systeme.io vs Privy: pricing, features & best for</a>
         </nav>
       </div>
     </div>


### PR DESCRIPTION
### Why
The static homepage fallback currently links several generic/older comparisons, while newer purchase-intent pages with verified revenue paths are deeper in the site.

### Change
Surface four high-intent comparisons directly from the homepage fallback:
- GoHighLevel vs HubSpot
- UpLead vs Apollo
- Gamma vs Canva
- Brand24 vs Mention

Keep vidIQ vs TubeBuddy and Systeme.io vs Privy as additional comparison paths.

This is an internal-link/discovery change only: no affiliate URL is changed, no revenue is inferred, and no paid service is required.