### PR TITLE
Revenue: surface verified Omi buyer route

### DIFF
--- a/projects/GlobalSaaSHub/data/omi-buyer-hub-evidence-2026-09-13.md
+++ b/projects/GlobalSaaSHub/data/omi-buyer-hub-evidence-2026-09-13.md
@@ -1,0 +1,30 @@
+# Omi AI verified buyer-hub evidence — 2026-09-13
+
+## Revenue route
+
+- Existing authenticated affiliate-dashboard evidence already records the exact customer-facing COSHUMA referral URL as `https://www.omi.me/?ref=SANGKWONAN`.
+- Prior repository evidence: `projects/GlobalSaaSHub/data/omi-referral-evidence-2026-09-07.md`.
+- The referral key came from the authenticated Omi affiliate dashboard; it was not inferred from a generic homepage URL.
+- Do not use `https://affiliate.omi.me/overview`, login/dashboard URLs, email redirects, or guessed query parameters as customer CTAs.
+
+## Current buyer facts rechecked 2026-09-13
+
+First-party Omi product page:
+- https://www.omi.me/products/omi
+- Current device price shown: **$179 USD**.
+- Omi describes the device/app workflow as recording conversations and meetings and turning them into searchable transcripts, summaries, action items and memories.
+- The product page says buyers can start free or go unlimited.
+
+First-party Omi Help Center subscription guide:
+- https://help.omi.me/en/articles/12058411-understanding-omi-subscriptions
+- Basic: **free**, 300 listening minutes/month.
+- Plus: **$19/month** or $161.91/year; 1,500 listening minutes/month.
+- Unlimited: **$29/month** or $269.91/year; unlimited listening.
+
+## Publication rules
+
+- Surface only the exact dashboard-issued customer referral URL: `https://www.omi.me/?ref=SANGKWONAN`.
+- Keep official product/subscription links separate for independent buyer verification.
+- Do not claim a discount, free hardware, trial, order, sale, commission, payout, or revenue unless direct current evidence proves it.
+- The prior dashboard baseline recorded 0 clicks, 0 orders, $0 sales and $0 commissions as of 2026-09-07; that historical snapshot must not be reused as a current total.
+- A verification visit or production publication is not a click, signup, order, sale, commission or payout.

--- a/projects/GlobalSaaSHub/scripts/normalize_sponsorship_offer.py
+++ b/projects/GlobalSaaSHub/scripts/normalize_sponsorship_offer.py
@@ -147,6 +147,7 @@ def main() -> None:
         "surface_aiassistworks_verified_offer.py",
         "surface_taskip_verified_offer.py",
         "surface_clickfunnels_verified_offer.py",
+        "surface_omi_verified_offer.py",
         "improve_verified_offer_discovery.py",
     ):
         try:

--- a/projects/GlobalSaaSHub/scripts/surface_omi_verified_offer.py
+++ b/projects/GlobalSaaSHub/scripts/surface_omi_verified_offer.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGE = ROOT / "public" / "best" / "verified-software-free-trials-deals.html"
+MARKER = "<!-- COSHUMA_OMI_VERIFIED_OFFER -->"
+TRACKING_URL = "https://www.omi.me/?ref=SANGKWONAN"
+GUIDE_URL = "/tool/omi-ai.html"
+OFFICIAL_PRODUCT = "https://www.omi.me/products/omi"
+OFFICIAL_SUBSCRIPTIONS = "https://help.omi.me/en/articles/12058411-understanding-omi-subscriptions"
+BLOCKED_PUBLIC_TOKENS = (
+    "affiliate.omi.me",
+    "affiliate.omi.me/overview",
+)
+
+if not PAGE.exists():
+    raise SystemExit(f"Missing buyer hub: {PAGE}")
+
+html = PAGE.read_text(encoding="utf-8")
+
+# Evidence guard:
+# - authenticated Omi affiliate-dashboard evidence records TRACKING_URL as the exact
+#   COSHUMA customer-facing referral URL. The `ref=SANGKWONAN` key is dashboard-issued.
+# - Omi's first-party product page was rechecked 2026-09-13 and currently shows the
+#   device at $179 USD.
+# - Omi's first-party subscription guide was rechecked 2026-09-13 and currently lists
+#   Basic free with 300 listening minutes/month, Plus at $19/month and Unlimited at
+#   $29/month.
+# - no sale, commission, payout, discount or free-hardware claim is inferred.
+if MARKER in html:
+    if TRACKING_URL not in html:
+        raise SystemExit("Omi verified block exists but exact approved tracking URL is missing")
+    if any(token in html for token in BLOCKED_PUBLIC_TOKENS):
+        raise SystemExit("Omi affiliate admin URL leaked into the public buyer hub")
+    print("Omi verified offer already surfaced")
+    raise SystemExit(0)
+
+old_meta = (
+    "Compare verified SaaS free trials and partner offers from Gamma, Time2book, "
+    "UpLead, Jotform, Unbounce, Pictory, Brand24, Bookyourdata, Tally, Typedesk, "
+    "Tagshop AI, RGE Studio, BoldSign, Teachable, Murf AI, Claap, Writesonic, Moosend, Kittl, HelpDesk, Krater, Fireflies.ai, Make.com, Voibe, Catalister, Chatbase, Gojiberry, AWeber, Followr, Novita AI, AiAssistWorks, Taskip and ClickFunnels. COSHUMA separates customer-facing tracking links from product claims."
+)
+new_meta = (
+    "Compare verified SaaS free trials and partner offers from Gamma, Time2book, "
+    "UpLead, Jotform, Unbounce, Pictory, Brand24, Bookyourdata, Tally, Typedesk, "
+    "Tagshop AI, RGE Studio, BoldSign, Teachable, Murf AI, Claap, Writesonic, Moosend, Kittl, HelpDesk, Krater, Fireflies.ai, Make.com, Voibe, Catalister, Chatbase, Gojiberry, AWeber, Followr, Novita AI, AiAssistWorks, Taskip, ClickFunnels and Omi AI. COSHUMA separates customer-facing tracking links from product claims."
+)
+if old_meta not in html:
+    raise SystemExit("Buyer-hub meta description changed; refusing blind Omi patch")
+html = html.replace(old_meta, new_meta, 1)
+
+item33 = (
+    '      {"@type":"ListItem","position":33,"name":"ClickFunnels",'
+    '"url":"https://coshuma.com/best/clickfunnels-free-trial.html"}\n'
+    "    ]"
+)
+item34 = (
+    '      {"@type":"ListItem","position":33,"name":"ClickFunnels",'
+    '"url":"https://coshuma.com/best/clickfunnels-free-trial.html"},\n'
+    '      {"@type":"ListItem","position":34,"name":"Omi AI",'
+    '"url":"https://coshuma.com/tool/omi-ai.html"}\n'
+    "    ]"
+)
+if item33 not in html:
+    raise SystemExit("ClickFunnels ItemList tail missing; Omi patch requires the verified ClickFunnels build step first")
+html = html.replace(item33, item34, 1)
+
+closing = '''    </section>\n\n    <section class="rounded-3xl border border-white/10 bg-[#11131a] p-7 md:p-9">\n      <h2 class="text-2xl font-black text-white">How this list is gated</h2>'''
+if closing not in html:
+    raise SystemExit("Buyer-hub final grid boundary changed; refusing blind Omi patch")
+
+card = f'''      {MARKER}\n      <article class="rounded-3xl border border-sky-400/25 bg-[#11131a] p-7 space-y-5">\n        <div class="flex items-start justify-between gap-4"><div><div class="text-xs font-black uppercase tracking-wider text-sky-300">AI wearable + meeting memory</div><h2 class="mt-1 text-3xl font-black text-white">Omi AI</h2></div><span class="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">Free Basic plan</span></div>\n        <p class="text-sm leading-7 text-slate-300">Omi's current product page lists the wearable at $179. Its current help center lists a free Basic plan with 300 listening minutes per month, Plus at $19/month and Unlimited at $29/month. COSHUMA keeps the exact dashboard-issued referral route separate from those product claims.</p>\n        <ul class="space-y-2 text-sm text-slate-300">\n          <li>• Device: $179 USD on the current first-party product page.</li>\n          <li>• Basic: free, 300 listening minutes/month.</li>\n          <li>• Plus: $19/month; Unlimited: $29/month.</li>\n          <li>• Verified referral destination: exact Omi customer route issued to COSHUMA.</li>\n        </ul>\n        <div class="grid gap-3 sm:grid-cols-2">\n          <a data-cta="affiliate" data-tool-id="omi-ai" data-cta-source="verified-deals-omi" href="{TRACKING_URL}" target="_blank" rel="sponsored nofollow noopener noreferrer" class="rounded-xl bg-sky-600 px-5 py-3.5 text-center font-black text-white hover:bg-sky-500">Check Omi via verified referral →</a>\n          <a data-cta="official" href="{OFFICIAL_PRODUCT}" target="_blank" rel="noopener noreferrer" class="rounded-xl border border-white/15 px-5 py-3.5 text-center font-bold text-slate-200 hover:bg-white/[0.05]">Verify device price →</a>\n        </div>\n        <div class="flex flex-wrap gap-x-5 gap-y-2 text-xs font-bold">\n          <a href="{GUIDE_URL}" class="text-violet-300 hover:text-violet-200">Read COSHUMA Omi buyer guide →</a>\n          <a href="{OFFICIAL_SUBSCRIPTIONS}" target="_blank" rel="noopener noreferrer" class="text-slate-400 hover:text-white">Verify subscriptions →</a>\n        </div>\n        <p class="text-xs leading-5 text-slate-500">Affiliate disclosure: COSHUMA may earn a commission from an eligible purchase through the verified referral route, at no extra cost to the buyer. Publication, link checks or a visit do not prove an order, commission or payout.</p>\n      </article>\n'''
+
+html = html.replace(closing, card + "\n" + closing, 1)
+
+if html.count(TRACKING_URL) < 1:
+    raise SystemExit("Omi tracking URL missing after patch")
+if any(token in html for token in BLOCKED_PUBLIC_TOKENS):
+    raise SystemExit("Omi affiliate admin URL leaked after patch")
+
+PAGE.write_text(html, encoding="utf-8")
+print("Surfaced verified Omi buyer route")


### PR DESCRIPTION
## Revenue goal
Surface an existing verified Omi customer referral route on COSHUMA's central buyer-offers hub without inventing a discount, deep link, sale, commission or payout.

## Evidence
- Existing authenticated affiliate-dashboard evidence already records the exact customer-facing route: `https://www.omi.me/?ref=SANGKWONAN`.
- Omi first-party product page rechecked 2026-09-13: device currently $179 USD.
- Omi first-party Help Center subscription guide rechecked 2026-09-13: Basic free with 300 listening minutes/month, Plus $19/month, Unlimited $29/month.
- Historical affiliate-dashboard baseline from 2026-09-07 was 0 clicks / 0 orders / $0 sales / $0 commissions and is not reused as a current total.

## Changes
- Adds evidence file `omi-buyer-hub-evidence-2026-09-13.md`.
- Adds fail-closed `surface_omi_verified_offer.py` build step.
- Adds Omi to the central Verified SaaS Free Trials & Partner Offers hub with a separate official product-price verification link.
- Chains the Omi surface step after ClickFunnels so ItemList ordering stays deterministic.

## Guardrails
- Exact dashboard-issued referral URL only.
- Affiliate/admin URLs are blocked from public output.
- No guessed query parameters or pricing deep links.
- No revenue inference from publication or verification visits.
- No paid action or subscription.
