### PR TITLE
Revenue: rebuild ClickFunnels vs Reply.io buyer-intent page

### DIFF
--- a/projects/GlobalSaaSHub/public/compare/clickfunnels-vs-reply-io.html
+++ b/projects/GlobalSaaSHub/public/compare/clickfunnels-vs-reply-io.html
@@ -1,172 +1,118 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ClickFunnels vs Reply.io Comparison, Pricing & Winner (2026) | COSHUMA</title>
-    <meta name="description" content="In-depth side-by-side comparison of ClickFunnels vs Reply.io. Compare pricing, features, ratings (Not rated vs Not rated), and find out which AI tool is best for your workflow." />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ClickFunnels vs Reply.io 2026: Funnels vs Sales Outreach, Pricing & Trials | COSHUMA</title>
+  <meta name="description" content="Compare ClickFunnels vs Reply.io in 2026 by job-to-be-done, current pricing and trial entry. ClickFunnels is funnel-first; Reply.io is outbound-sales-first. See which workflow fits before paying." />
+  <link rel="canonical" href="https://coshuma.com/compare/clickfunnels-vs-reply-io.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://coshuma.com/compare/clickfunnels-vs-reply-io.html" />
+  <meta property="og:site_name" content="COSHUMA" />
+  <meta property="og:title" content="ClickFunnels vs Reply.io 2026: Funnels vs Sales Outreach" />
+  <meta property="og:description" content="A buyer-focused comparison of two sales tools that solve different parts of the revenue workflow." />
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"ClickFunnels vs Reply.io 2026","url":"https://coshuma.com/compare/clickfunnels-vs-reply-io.html","description":"Compare ClickFunnels and Reply.io by buyer workflow, pricing and trial entry.","isPartOf":{"@type":"WebSite","name":"COSHUMA","url":"https://coshuma.com/"},"about":[{"@type":"SoftwareApplication","name":"ClickFunnels","url":"https://coshuma.com/tool/clickfunnels.html"},{"@type":"SoftwareApplication","name":"Reply.io","url":"https://coshuma.com/tool/reply-io.html"}]}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Is ClickFunnels or Reply.io better for building a sales funnel?","acceptedAnswer":{"@type":"Answer","text":"ClickFunnels is the more direct fit when the job is building landing pages and sales funnels that move inbound visitors toward a purchase. Reply.io is primarily positioned around outbound sales outreach and prospect engagement."}},{"@type":"Question","name":"Is ClickFunnels or Reply.io better for cold outreach?","acceptedAnswer":{"@type":"Answer","text":"Reply.io is the more direct fit for outbound prospecting workflows because its current product and pricing pages center on email automation, multichannel sequences, LinkedIn automation, calls and SMS."}},{"@type":"Question","name":"Do both products offer a trial?","acceptedAnswer":{"@type":"Answer","text":"Both vendors currently advertise a 14-day trial. ClickFunnels states that a card on file is charged after 14 days unless the account is canceled or scheduled to cancel before the trial ends. Reply.io says its 14-day trial includes core outreach features; verify final signup terms with Reply.io."}}]}</script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="/affiliate-attribution.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>body{font-family:'Inter',sans-serif;background:#0b0c10;color:#f1f5f9}h1,h2,h3{font-family:'Outfit',sans-serif}</style>
+</head>
+<body class="min-h-screen bg-[#0b0c10]">
+<header class="sticky top-0 z-50 border-b border-[#222538] bg-[#07080c]/90 backdrop-blur-md">
+  <div class="mx-auto flex max-w-5xl items-center justify-between px-5 py-4">
+    <a href="/" class="font-black text-white">COSHUMA</a>
+    <a href="/best/verified-software-free-trials-deals.html" class="rounded-full border border-purple-500/30 bg-purple-500/10 px-4 py-2 text-xs font-bold text-purple-300">Verified offers →</a>
+  </div>
+</header>
+<main class="mx-auto max-w-5xl space-y-8 px-5 py-12">
+  <section class="space-y-5 text-center">
+    <div class="text-xs font-black tracking-[0.18em] text-purple-300">BUYER COMPARISON · OFFICIAL SOURCES CHECKED SEP 13, 2026</div>
+    <h1 class="text-4xl font-black md:text-5xl">ClickFunnels vs Reply.io</h1>
+    <p class="mx-auto max-w-3xl text-slate-300">These tools overlap around revenue generation, but they solve different jobs. ClickFunnels is built to turn inbound traffic into leads and purchases through funnels. Reply.io is built to help sales teams find and contact prospects through outbound sequences. Start with the workflow you actually need instead of comparing feature counts.</p>
+  </section>
 
-    <link rel="canonical" href="https://coshuma.com/compare/clickfunnels-vs-reply-io.html" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://coshuma.com/compare/clickfunnels-vs-reply-io.html" />
-    <meta property="og:title" content="ClickFunnels vs Reply.io Comparison (2026) | COSHUMA" />
-    <meta property="og:description" content="Compare ClickFunnels and Reply.io by pricing, features, and verified public information." />
+  <section class="grid gap-5 md:grid-cols-2">
+    <article class="space-y-4 rounded-3xl border border-purple-500/30 bg-[#131520] p-7">
+      <div class="text-xs font-black uppercase tracking-wider text-purple-300">ClickFunnels</div>
+      <h2 class="text-2xl font-black">Best fit: inbound funnel + conversion workflow</h2>
+      <p class="text-sm leading-6 text-slate-300">ClickFunnels' current pricing page lists Launch at $97/month, Scale at $197/month and Optimize at $297/month on monthly billing. The platform centers on funnels, pages, contacts, email, courses and related conversion infrastructure.</p>
+      <ul class="space-y-2 text-sm text-slate-300">
+        <li>✓ 14-day free trial currently advertised</li>
+        <li>✓ Launch: $97/month on monthly billing</li>
+        <li>✓ Scale: $197/month on monthly billing</li>
+        <li>✓ Optimize: $297/month on monthly billing</li>
+      </ul>
+      <a data-cta="affiliate" data-tool-id="clickfunnels" data-cta-source="compare-clickfunnels-reply-primary" href="https://www.clickfunnels.com/signup-flow?aff=b57f3056884d05b842f607e32347df542821875bbe3209a214141aa32a210532" target="_blank" rel="sponsored noopener noreferrer" class="block rounded-xl bg-purple-600 px-5 py-3.5 text-center font-extrabold text-white hover:bg-purple-500">Start ClickFunnels via verified COSHUMA route →</a>
+      <p class="text-[11px] leading-5 text-slate-500">COSHUMA recovered this exact customer-facing campaign URL from the existing ClickFunnels affiliate account. It is not a guessed pricing or dashboard URL. ClickFunnels states that the card on file is charged after the 14-day trial unless cancellation is completed or scheduled before the trial ends.</p>
+    </article>
 
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "ClickFunnels vs Reply.io Comparison",
-      "url": "https://coshuma.com/compare/clickfunnels-vs-reply-io.html",
-      "description": "Compare ClickFunnels and Reply.io by pricing, features, and verified public information.",
-      "isPartOf": {
-        "@type": "WebSite",
-        "name": "COSHUMA",
-        "url": "https://coshuma.com/"
-      },
-      "about": [
-        {"@type": "SoftwareApplication", "name": "ClickFunnels", "url": "https://coshuma.com/tool/clickfunnels.html"},
-        {"@type": "SoftwareApplication", "name": "Reply.io", "url": "https://coshuma.com/tool/reply-io.html"}
-      ]
-    }
-    </script>
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;800;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; background-color: #0b0c10; color: #f1f5f9; }
-      h1, h2, h3 { font-family: 'Outfit', sans-serif; }
-    </style>
-  </head>
-  <body class="min-h-screen flex flex-col justify-between">
-    <header class="border-b border-[#222538] bg-[#07080c]/80 backdrop-blur-md sticky top-0 z-50 py-4 px-6">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <a href="/" class="flex items-center gap-3">
-          <div class="h-8 w-8 rounded-lg bg-purple-600 flex items-center justify-center font-extrabold text-white text-lg">C</div>
-          <span class="font-extrabold text-lg tracking-tight text-white">COSHUMA</span>
-        </a>
-        <a href="/" class="text-xs font-bold px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 transition-all">
-          ← Back to All Tools
-        </a>
-      </div>
-    </header>
+    <article class="space-y-4 rounded-3xl border border-blue-500/30 bg-[#131520] p-7">
+      <div class="text-xs font-black uppercase tracking-wider text-blue-300">Reply.io</div>
+      <h2 class="text-2xl font-black">Best fit: outbound prospecting + sales engagement</h2>
+      <p class="text-sm leading-6 text-slate-300">Reply.io's current pricing page centers on sales outreach. It currently shows Email Volume starting from $59 and Multichannel starting from $99, with additional AI SDR and agency options whose final pricing should be checked live.</p>
+      <ul class="space-y-2 text-sm text-slate-300">
+        <li>✓ 14-day free trial currently advertised</li>
+        <li>✓ Email automation and follow-up sequences</li>
+        <li>✓ Multichannel options include LinkedIn, calls and SMS</li>
+        <li>✓ CRM integrations and sales reporting are part of the current product positioning</li>
+      </ul>
+      <a data-cta="official" data-tool-id="reply-io" data-cta-source="compare-clickfunnels-reply-official" href="https://reply.io/pricing/" target="_blank" rel="noopener noreferrer" class="block rounded-xl bg-blue-600 px-5 py-3.5 text-center font-extrabold text-white hover:bg-blue-500">Check Reply.io official pricing →</a>
+      <p class="text-[11px] leading-5 text-slate-500">Reply.io is intentionally linked to its official pricing page here. COSHUMA does not currently treat a Reply.io customer tracking URL as verified, so no affiliate parameter is invented.</p>
+    </article>
+  </section>
 
-    <main class="max-w-4xl mx-auto px-4 py-12 w-full space-y-8">
-      <div class="text-center space-y-3">
-        <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold bg-purple-500/10 border border-purple-500/20 text-purple-300">
-          ⚖️ Side-by-Side Head-to-Head Comparison
-        </div>
-        <h1 class="text-3xl md:text-5xl font-black text-white tracking-tight">ClickFunnels vs Reply.io</h1>
-        <p class="text-slate-400 text-sm max-w-2xl mx-auto">
-          Detailed breakdown of pricing, ratings, core capabilities, and decision recommendations to help you choose the best Sales & CRM tool.
-        </p>
-      </div>
+  <section class="space-y-5 rounded-3xl border border-[#222538] bg-[#131520] p-7 md:p-9">
+    <h2 class="text-2xl font-black">Decision table</h2>
+    <div class="overflow-x-auto">
+      <table class="w-full min-w-[720px] text-left text-sm">
+        <thead class="border-b border-[#2a2d42] text-slate-400"><tr><th class="py-3 pr-4">Decision factor</th><th class="py-3 pr-4">ClickFunnels</th><th class="py-3">Reply.io</th></tr></thead>
+        <tbody class="divide-y divide-[#202334] text-slate-300">
+          <tr><td class="py-4 pr-4 font-bold text-white">Primary job</td><td class="py-4 pr-4">Build pages and funnels that convert inbound traffic</td><td class="py-4">Run outbound prospecting and follow-up sequences</td></tr>
+          <tr><td class="py-4 pr-4 font-bold text-white">Current trial entry</td><td class="py-4 pr-4">14 days; card on file and auto-charge after trial unless canceled/scheduled to cancel</td><td class="py-4">14-day trial advertised; verify final signup and billing terms</td></tr>
+          <tr><td class="py-4 pr-4 font-bold text-white">Current starting paid price</td><td class="py-4 pr-4">Launch $97/month on monthly billing</td><td class="py-4">Email Volume currently shown from $59; Multichannel from $99</td></tr>
+          <tr><td class="py-4 pr-4 font-bold text-white">Choose it when</td><td class="py-4 pr-4">You already have or can acquire traffic and need a conversion path, checkout/funnel flow or related marketing stack</td><td class="py-4">You need to create pipeline by identifying prospects and contacting them across outbound channels</td></tr>
+          <tr><td class="py-4 pr-4 font-bold text-white">Do not choose only because</td><td class="py-4 pr-4">You need cold outreach; that is not the core job this comparison assigns to ClickFunnels</td><td class="py-4">You need a storefront-style funnel builder; outbound engagement is the more direct Reply.io use case</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
 
-      <!-- Decision Summary & Verification Transparency Box -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-purple-500/30 space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧠 Decision Summary & Evidence</span>
-          </h2>
-          <span class="text-[10px] font-bold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-md">
-            ✓ Publicly Available Data (Last updated: August 31, 2026)
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/20 space-y-2">
-            <div class="font-bold text-purple-300">Choose ClickFunnels if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              Choose this option if its documented features match the workflow you need.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Documentation & Public Pricing Specs (August 31, 2026)
-            </div>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/20 space-y-2">
-            <div class="font-bold text-blue-300">Choose Reply.io if:</div>
-            <p class="text-slate-300 leading-relaxed">
-              Compare its current pricing and features with your requirements.
-            </p>
-            <div class="text-[10px] text-slate-400 font-mono pt-1 border-t border-[#222538]">
-              Source: Official Vendor Specifications & Benchmark Data (August 31, 2026)
-            </div>
-          </div>
-        </div>
-      </div>
+  <section class="space-y-4 rounded-3xl border border-emerald-500/25 bg-emerald-500/5 p-7">
+    <h2 class="text-2xl font-black">The shortest buying rule</h2>
+    <p class="leading-7 text-slate-300"><strong class="text-white">Choose ClickFunnels</strong> if your bottleneck starts after someone reaches your site: landing page, funnel, offer, checkout or follow-up. <strong class="text-white">Choose Reply.io</strong> if your bottleneck is before that point: finding prospects, initiating conversations and running structured outbound sequences.</p>
+    <p class="text-slate-300">Some businesses can eventually use both, but paying for both before proving each workflow creates unnecessary software cost. Test one measurable workflow first.</p>
+    <div class="grid gap-3 sm:grid-cols-2">
+      <a data-cta="affiliate" data-tool-id="clickfunnels" data-cta-source="compare-clickfunnels-reply-bottom" href="https://www.clickfunnels.com/signup-flow?aff=b57f3056884d05b842f607e32347df542821875bbe3209a214141aa32a210532" target="_blank" rel="sponsored noopener noreferrer" class="rounded-xl bg-purple-600 px-5 py-3.5 text-center font-extrabold text-white hover:bg-purple-500">Try ClickFunnels through verified route →</a>
+      <a data-cta="official" data-tool-id="reply-io" data-cta-source="compare-clickfunnels-reply-bottom-official" href="https://reply.io/pricing/" target="_blank" rel="noopener noreferrer" class="rounded-xl bg-blue-600 px-5 py-3.5 text-center font-extrabold text-white hover:bg-blue-500">Review Reply.io pricing →</a>
+    </div>
+    <p data-affiliate-disclosure="compare" class="text-[11px] leading-5 text-slate-500">Affiliate disclosure: COSHUMA may earn a commission if an eligible ClickFunnels purchase later occurs through the verified ClickFunnels partner route, at no extra cost to you. Reply.io links on this page are official non-affiliate destinations. A click is not treated as a signup, paid customer, commission or revenue.</p>
+  </section>
 
+  <section class="space-y-4 rounded-3xl border border-white/10 bg-[#131520] p-7">
+    <h2 class="text-2xl font-black">What to test during the trial</h2>
+    <div class="grid gap-4 md:grid-cols-2">
+      <div class="rounded-2xl bg-white/[0.03] p-5"><h3 class="font-black text-white">ClickFunnels test</h3><p class="mt-2 text-sm leading-6 text-slate-300">Build one real offer: landing page → lead or order step → follow-up. Confirm publishing, analytics, integrations and the exact features your selected plan includes. Do not judge from templates alone.</p></div>
+      <div class="rounded-2xl bg-white/[0.03] p-5"><h3 class="font-black text-white">Reply.io test</h3><p class="mt-2 text-sm leading-6 text-slate-300">Run a small, compliant prospecting workflow with your own legitimate contacts. Test sequence setup, mailbox behavior, replies, CRM sync and reporting before importing a large list or adding paid channels.</p></div>
+    </div>
+    <div class="grid gap-3 sm:grid-cols-2 text-sm font-bold">
+      <a href="/tool/clickfunnels.html" class="rounded-xl bg-white/[0.04] p-4 hover:bg-white/[0.07]">ClickFunnels buyer guide →</a>
+      <a href="/tool/reply-io.html" class="rounded-xl bg-white/[0.04] p-4 hover:bg-white/[0.07]">Reply.io buyer guide →</a>
+    </div>
+  </section>
 
-
-      <!-- 2-Column Comparison Table -->
-      <div class="p-6 rounded-3xl bg-[#131520] border border-[#222538] space-y-6">
-        <h2 class="text-xl font-bold text-white">Side-by-Side Comparison</h2>
-        
-        <div class="grid grid-cols-2 gap-4 text-center">
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-purple-500/30 font-bold text-white text-base">
-            <a href="/tool/clickfunnels.html" class="hover:text-purple-300">ClickFunnels</a>
-          </div>
-          <div class="p-4 rounded-2xl bg-[#181a29] border border-blue-500/30 font-bold text-white text-base">
-            <a href="/tool/reply-io.html" class="hover:text-blue-300">Reply.io</a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">COSHUMA Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">COSHUMA Editorial Rating</div>
-            <div class="text-lg font-black text-amber-400">Not rated</div>
-          </div>
-        </div>
-
-
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538] text-center">
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">Pricing Plan</div>
-            <div class="text-base font-extrabold text-emerald-400">See official pricing</div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 p-4 rounded-2xl bg-[#181a29]/60 border border-[#222538]">
-          <div>
-            <div class="text-[10px] font-bold text-purple-300 uppercase tracking-wider mb-2 text-center">ClickFunnels Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Intuitive Drag-and-Drop Editor</div>
-<div>✓ Integrated Email Automation</div>
-<div>✓ Sales Funnel Templates</div>
-<div>✓ A/B Testing Capabilities</div>
-            </div>
-          </div>
-          <div>
-            <div class="text-[10px] font-bold text-blue-300 uppercase tracking-wider mb-2 text-center">Reply.io Features</div>
-            <div class="space-y-1.5 text-xs text-slate-300">
-              <div>✓ Multi-Channel Sales Sequences</div>
-<div>✓ AI Email Assistant</div>
-<div>✓ CRM Integrations</div>
-<div>✓ Performance Tracking & Reporting</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 pt-2">
-          <a href="https://www.clickfunnels.com/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-purple-600 hover:bg-purple-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get ClickFunnels →</a>
-          <a href="https://reply.io/" target="_blank" rel="noopener noreferrer" class="py-3.5 px-4 rounded-xl bg-blue-600 hover:bg-blue-500 font-extrabold text-xs text-white text-center shadow-lg transition-all">Get Reply.io →</a>
-        </div>
-      </div>
-    </main>
-
-    <footer class="border-t border-[#222538] bg-[#07080c] py-8 text-center text-xs text-slate-500">
-      <div class="max-w-6xl mx-auto px-4">
-        &copy; 2026 COSHUMA. Programmatic Compare Engine. All rights reserved.
-      </div>
-    </footer>
-  </body>
+  <section class="space-y-3 rounded-3xl border border-white/10 bg-[#131520] p-7">
+    <h2 class="text-2xl font-black">Sources and verification boundary</h2>
+    <p class="text-sm leading-6 text-slate-400">Pricing and trial claims were rechecked against vendor-owned pages on September 13, 2026. COSHUMA does not claim hands-on performance results, a conversion winner, or revenue from any click. Final plan prices, taxes, eligibility and billing terms are controlled by the vendors and can change.</p>
+    <ul class="space-y-2 text-sm">
+      <li><a data-cta="source" href="https://www.clickfunnels.com/pricing" target="_blank" rel="noopener noreferrer" class="text-purple-300 underline">ClickFunnels official pricing</a></li>
+      <li><a data-cta="source" href="https://support.clickfunnels.com/en/articles/12734363-will-i-be-billed-automatically-after-the-free-14-day-trial-period" target="_blank" rel="noopener noreferrer" class="text-purple-300 underline">ClickFunnels official 14-day trial billing guidance</a></li>
+      <li><a data-cta="source" href="https://reply.io/pricing/" target="_blank" rel="noopener noreferrer" class="text-blue-300 underline">Reply.io official pricing and trial information</a></li>
+    </ul>
+  </section>
+</main>
+<footer class="mt-12 border-t border-[#222538] py-8 text-center text-xs text-slate-500">© 2026 COSHUMA. Independent AI & SaaS buyer guides.</footer>
+</body>
 </html>


### PR DESCRIPTION
Replaces the generic ClickFunnels vs Reply.io comparison with a current buyer-decision page based on vendor-owned pricing/trial sources checked Sep 13, 2026.

Revenue safeguards:
- uses only the existing verified ClickFunnels customer campaign URL
- keeps Reply.io on its official pricing page because no verified customer tracking URL is established
- adds affiliate_click attribution sources and disclosure
- removes generic homepage CTA / generic AI-tool copy
- makes the funnel-vs-outbound decision explicit instead of inventing a performance winner

No signup, conversion, commission or revenue is inferred.